### PR TITLE
Move fork system tables to a reserved table-number range

### DIFF
--- a/crates/model/src/lib.rs
+++ b/crates/model/src/lib.rs
@@ -297,13 +297,28 @@ enum DefaultTableNumber {
     SchemaValidationProgress = 37,
     ScheduledJobArgs = 38,
     AuditLogConfig = 39,
-    AdminKeys = 40,
-    PeriodicBackupConfig = 41,
-    UsageLimits = 42,
-    DataSyncProgress = 43,
+    UsageLimits = 40,
+    DataSyncProgress = 41,
     // Keep this number and your user name up to date. The number makes it easy to know
     // what to use next. The username on the same line detects merge conflicts
-    // Next Number - 44 - mingu
+    // Next Number - 42 - nipunn
+
+    // ---- Fork-only system tables ----
+    // Deliberately in a reserved high range, far above upstream's sequence
+    // above, so upstream can keep appending table numbers indefinitely without
+    // colliding with ours (a collision is a hard build error: E0081). Keep
+    // upstream's numbering untouched — renumbering an upstream table makes this
+    // fork's on-disk layout diverge from every other Convex deployment.
+    //
+    // Changing a value here only affects tables created from now on;
+    // `Transaction::table_number_for_system_table` consults the default solely
+    // at creation time, so existing deployments keep the numbers they have.
+    //
+    // Must stay within [1, 9487]: TableNumber = 512 + this value, and system
+    // tables must land in [513, 10000).
+    // Next Fork Number - 1002 - mingu
+    AdminKeys = 1000,
+    PeriodicBackupConfig = 1001,
 }
 
 impl From<DefaultTableNumber> for TableNumber {


### PR DESCRIPTION
Found while auditing why upstream merges keep breaking. Independent of #3 — touches only `crates/model/src/lib.rs`, which that PR does not modify.

## The problem

The fork inserted its own tables into the middle of upstream's `DefaultTableNumber` sequence:

```rust
AdminKeys = 40,             // fork
PeriodicBackupConfig = 41,  // fork
UsageLimits = 42,           // upstream's 40, renumbered
DataSyncProgress = 43,      // upstream's 41, renumbered
```

Two consequences:

1. **Upstream's next system table is number 42**, which collides with the fork's `UsageLimits`. Duplicate enum discriminants are a hard compile error (`E0081`), so *every* future upstream system-table addition breaks the fork's build until someone renumbers by hand. This is a recurring, guaranteed breakage.
2. **Renumbering upstream's tables** makes this fork's on-disk layout diverge from every other Convex deployment, for no benefit.

Worth noting: this numbering was introduced by `3c3f95387 "Repair broken LLM merge resolutions from upstream syncs"` — the old LLM resolver's damage.

## The fix

Restore upstream's numbering verbatim and give the fork a reserved range starting at 1000, which upstream's sequence will never reach.

`TableNumber = 512 + DefaultTableNumber`, and system tables must land in `[513, 10000)`, so the fork range is valid with ~8500 slots.

## Data safety

**No existing data is affected.** `Transaction::table_number_for_system_table` consults the default *only when a table is first created*; existing tables are never renumbered.

One honest caveat: deployments created between `3c3f95387` and this commit keep `_admin_keys` at 552 rather than 1512. That's harmless — the real mapping is read from disk — but it does mean fork deployments aren't uniform on this number.

## Verification

`cargo check -p model` passes on the repo's pinned nightly. No test or fixture pins the affected numbers (checked).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated system table numbering to support `UsageLimits` and `DataSyncProgress`.
  * Reserved dedicated numbering ranges for fork-specific administrative and backup configuration tables.
  * Added documentation describing numbering ranges, collision avoidance, and persistence behavior.
  * These updates help maintain consistent table identification across installations and future updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->