### PR TITLE
Fix dashboard-orchestrator build broken by the upstream merge

### DIFF
--- a/.github/workflows/build_dashboard_orchestrator.yml
+++ b/.github/workflows/build_dashboard_orchestrator.yml
@@ -1,0 +1,64 @@
+# Fork-owned workflow. dashboard-orchestrator is a fork-only package, so no
+# upstream workflow builds it: `build_local_backend.yml` and `precompile.yml`
+# only build `dashboard-self-hosted...`. That gap let an upstream DeploymentInfo
+# change land on `enhanced` with the orchestrator uncompilable — the breakage
+# was only caught later by the sync script's own dashboard gate, which blocks
+# every subsequent sync until someone fixes it.
+#
+# Keeping this in its own file (rather than adding a filter to an upstream
+# workflow) means it carries no merge-conflict surface with upstream.
+
+name: Build Dashboard Orchestrator
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [enhanced]
+  pull_request:
+    branches: ["**"]
+
+jobs:
+  build:
+    name: Build dashboard-orchestrator
+    runs-on: "runs-on=${{ github.run_id }}/runner=xlarge-x64"
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Restore pnpm artifacts
+        uses: runs-on/cache/restore@bd330c5a5f6cbb837823ee25864f3c71a211c2e3 # v5.0.5
+        env:
+          AWS_REGION: ${{ vars.AWS_REGION }}
+          RUNS_ON_S3_BUCKET_CACHE: ${{ vars.RUNS_ON_S3_BUCKET_CACHE }}
+        with:
+          path: |
+            ~/.local/share/pnpm/store
+            npm-packages/.turbo/cache
+          key: pnpm-cache-${{ hashFiles('npm-packages/pnpm-lock.yaml') }}-3
+          restore-keys: pnpm-cache-
+
+      - name: Install mise tools
+        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
+        with:
+          cache: true
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: NPM install globals
+        run: npm ci --prefix scripts
+
+      - name: Build dashboard-orchestrator
+        run: |
+          just install-js
+          just turbo run build --filter=dashboard-orchestrator...

--- a/.github/workflows/scripts/sync-upstream-branch.sh
+++ b/.github/workflows/scripts/sync-upstream-branch.sh
@@ -165,7 +165,11 @@ validate_dashboard_build() {
     just turbo run build --force \
       --filter=dashboard-self-hosted... \
       --filter=dashboard-orchestrator...
-  ) 2>&1 | tail -40 | sed 's/^/  /'
+  ) 2>&1 | sed 's/^/  /'
+  # NB: no `tail` here. turbo interleaves task output and prints its own
+  # summary last, so truncating the tail reliably discards the actual
+  # compiler error and leaves only "Failed: <task>" — which is exactly
+  # useless when a sync fails on a dashboard type error.
 }
 
 # Full-workspace compile gate: `cargo check --workspace --all-targets` catches

--- a/npm-packages/dashboard-orchestrator/src/components/OrchestratorDeploymentShell.tsx
+++ b/npm-packages/dashboard-orchestrator/src/components/OrchestratorDeploymentShell.tsx
@@ -129,6 +129,9 @@ export function OrchestratorDeploymentShell({
       streamingExportEnabled: true,
     }),
     useTeamUsageState: () => "Default",
+    // The orchestrator control plane has no billing, so there is no plan to
+    // report. Matches dashboard-self-hosted.
+    useTeamPlanType: () => null,
     useCurrentUsageBanner: () => null,
     useCurrentProject: () => ({
       id: project.id,
@@ -212,7 +215,16 @@ export function OrchestratorDeploymentShell({
     // links and break the chrome).
     deploymentBackendOwnsAdminKeys: true,
     workosIntegrationEnabled: false,
-    logStreamTopicFiltersEnabled: true,
+    // `logStreamTopicFiltersEnabled` used to be set here. Upstream removed it
+    // from DeploymentInfo in bb97ce4f8 ("remove launched LaunchDarkly flags")
+    // once the feature shipped, so the behaviour is now unconditional and the
+    // flag no longer exists to set.
+    //
+    // Both gated off until the features ship; the orchestrator has no
+    // LaunchDarkly, so flip these to true at launch. Matches
+    // dashboard-self-hosted.
+    usageLimitsEnabled: false,
+    copyEnvVarNameAndValueEnabled: false,
     connectionStateCheckIntervalMs: 2500,
   };
 


### PR DESCRIPTION
**The hourly sync is still failing** after #3 and #4 — now on `validate_dashboard_build`, because `dashboard-orchestrator` doesn't compile against upstream's current `DeploymentInfo`.

## The breakage

```
./src/components/OrchestratorDeploymentShell.tsx:215:5
Type error: 'logStreamTopicFiltersEnabled' does not exist in type '{ ok: true; ... }'
...missing the following properties: useTeamPlanType, usageLimitsEnabled, copyEnvVarNameAndValueEnabled
```

- `logStreamTopicFiltersEnabled` was removed upstream in `bb97ce4f8` *("remove launched LaunchDarkly flags")* once the feature shipped — the behaviour is now unconditional and the property no longer exists to set.
- The other three became required. Set to the same values `dashboard-self-hosted` uses: the orchestrator control plane has no billing (`useTeamPlanType: () => null`) and no LaunchDarkly, so both feature flags stay gated off until those features ship.

This is precisely the failure the dashboard gate exists to catch: **an upstream API change breaking fork-only code the merge never touched**, in a file that produced no conflict. The gate worked — it just fired after the merge had landed rather than before.

## Two follow-ups so it's caught earlier and diagnosed faster

**1. New fork-owned `Build Dashboard Orchestrator` workflow.** No upstream workflow builds this package — `build_local_backend.yml` and `precompile.yml` both filter on `dashboard-self-hosted...` only. That gap is why #3's CI went fully green while shipping an uncompilable orchestrator. It's a separate file rather than a filter added to an upstream workflow, so it carries **no merge-conflict surface**.

**2. Removed the `tail -40` from `validate_dashboard_build`** — which I added in #3, and which turned out to hide exactly the error we needed. turbo interleaves task output and prints its summary last, so tailing discarded the compiler error and left only `Failed: dashboard-orchestrator#build`. The real cause had to be reproduced locally to be seen at all.

## Verification

`next build` now passes type checking for `dashboard-orchestrator`. The remaining local failure is a Windows SWC DLL-load issue that doesn't occur on Linux CI — the new workflow in this PR will confirm on Linux.

## Still outstanding (needs you, not code)

The sync's PR hand-off is **still** failing, now for a different reason:

```
pull request create failed: GraphQL: Resource not accessible by personal access token (createPullRequest)
PR hand-off failed; escalating to a GitHub issue.
GraphQL: Resource not accessible by personal access token (createIssue)
```

Switching `GH_TOKEN` to the PAT in #3 was necessary but not sufficient — **`UPSTREAM_SYNC_PAT` itself lacks `pull_requests: write` and `issues: write`**. Until those scopes are added, a failing sync still can't announce itself. The escalation chain is working correctly; it just has no permission to act.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for deploying orchestrator environments without requiring a plan type.
  - Added configuration controls for usage limits and environment-variable copying, currently disabled by default.

- **Bug Fixes**
  - Improved build validation output so complete diagnostic details are preserved.

- **Chores**
  - Added automated dashboard-orchestrator builds for supported branch updates, pull requests, and manual runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->