### PR TITLE
Sync: regenerate pnpm-lock.yaml with --no-frozen-lockfile

### DIFF
--- a/.github/workflows/scripts/sync-upstream-branch.sh
+++ b/.github/workflows/scripts/sync-upstream-branch.sh
@@ -54,7 +54,29 @@ reconcile_pnpm_lock() {
     echo "just not on PATH; skipping pnpm lockfile reconciliation" >&2
     return 0
   fi
-  just update-js 2>&1 | tail -20 | sed 's/^/  /'
+  # NOT `just update-js`. That runs a bare `pnpm install`, and pnpm defaults
+  # --frozen-lockfile to TRUE whenever CI=true — so in Actions it refuses to
+  # update the lockfile and errors out, which is the exact opposite of this
+  # function's job. --no-frozen-lockfile is required for the regeneration to
+  # happen at all. (`rush update`, which this replaced, had no such default.)
+  (
+    cd npm-packages
+    just pnpm install --no-frozen-lockfile
+  ) 2>&1 | tail -20 | sed 's/^/  /'
+
+  # The whole reason this function exists: `pnpm-lock.yaml` is `merge=theirs`,
+  # so every sync takes upstream's lockfile verbatim and upstream's lockfile
+  # has no importer for fork-only workspace packages. If regeneration silently
+  # failed to re-add them, `pnpm install --frozen-lockfile` in the build gates
+  # (and in every downstream CI job) breaks. Fail loudly here instead.
+  local pkg
+  for pkg in dashboard-orchestrator; do
+    if ! grep -qE "^  ${pkg}:" npm-packages/pnpm-lock.yaml; then
+      echo "pnpm-lock.yaml has no '${pkg}' importer after regeneration" >&2
+      return 1
+    fi
+  done
+
   if ! git diff --quiet -- npm-packages/pnpm-lock.yaml; then
     git add npm-packages/pnpm-lock.yaml
     git commit --amend --no-edit


### PR DESCRIPTION
`sync_enhanced` started failing again — **not** a token problem. A real bug in the Rush→pnpm migration from #3, which stayed dormant until upstream touched the lockfile.

## Cause

`reconcile_pnpm_lock()` called `just update-js`, which runs a bare `pnpm install`. **pnpm defaults `--frozen-lockfile` to `true` whenever `CI=true`**, so in Actions that command *refuses* to update the lockfile and exits 1 — the exact opposite of the function's purpose. `rush update`, which it replaced, had no such default.

Why it only surfaced now: `pnpm-lock.yaml` is `merge=theirs`, so each sync takes upstream's lockfile verbatim — and upstream's lockfile has no importer for the fork-only `dashboard-orchestrator`. Regeneration is what puts it back. Once upstream landed lockfile changes (`5ba4e3c1a` and others), every sync hit:

```
ERR_PNPM_OUTDATED_LOCKFILE  Cannot install with "frozen-lockfile" because
pnpm-lock.yaml is not up to date with <ROOT>/dashboard-orchestrator/package.json
```

## Fix

- Pass `--no-frozen-lockfile` explicitly so regeneration actually happens.
- Add a guard that fails loudly if the fork-only importer is missing *after* regeneration. That absence breaks `pnpm install --frozen-lockfile` in the build gates and in every downstream CI job, and it's silent until something else trips over it.

## Verification

Reproduced both sides locally with a deliberately stale lockfile:

| Command (`CI=true`) | Result |
|---|---|
| `pnpm install` | exit 1 — `ERR_PNPM_OUTDATED_LOCKFILE` |
| `pnpm install --no-frozen-lockfile` | exit 0 — importer intact |

Working tree restored afterwards; no test residue in the diff.

## Note on the token

Unrelated to this, but resolved: the secret held a *different* token from the one being edited, which is why permission changes never took effect. The secret now holds a token with `Pull requests: write` (probe returns `422` validation, not `403`). Both tokens pasted during debugging still need rotating.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated dependency synchronization in CI.
  * Added validation to ensure required dashboard components are represented in the lockfile.
  * This helps identify incomplete dependency updates earlier and supports more reliable builds and releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->