### PR TITLE
Allow the docs theme's git dependency to run its build script

### DIFF
--- a/npm-packages/pnpm-workspace.yaml
+++ b/npm-packages/pnpm-workspace.yaml
@@ -152,6 +152,27 @@ packages:
 
 autoInstallPeers: true
 publishBranch: release
+
+# Fork-only. pnpm 10 refuses to run a dependency's build scripts unless the
+# package is allowlisted here, and `npm-packages/docs` pulls this theme from a
+# git tarball that needs a build step to be usable:
+#
+#   ERR_PNPM_GIT_DEP_PREPARE_NOT_ALLOWED  Failed to prepare git-hosted package
+#   ... needs to execute build scripts but is not in the "onlyBuiltDependencies"
+#   allowlist.
+#
+# Upstream does not need this entry because its CI *writes* a pnpm store cache,
+# so the package arrives already prepared and no build script runs. This fork's
+# workflows use `runs-on/cache/restore` (restore-only) and never populate that
+# cache, so every time the lockfile hash changes the fork cold-installs and
+# trips the block. Without this, `just install-js` fails and takes the backend
+# build, the dashboard builds and the sync gates down with it.
+#
+# The entry is pinned to the dependency's current commit, which is how pnpm
+# identifies it. If upstream bumps that pin this will need updating -- the
+# error message names the exact replacement string.
+onlyBuiltDependencies:
+  - "root@https://codeload.github.com/nipunn1313/docusaurus-openapi-docs/tar.gz/33ca8ab0ecbe76adc157c6c7ade3e53e5c990428"
 minimumReleaseAge: 10080
 # The next security overrides below force a brand-new next version; next pins
 # its @next/swc platform binaries to that exact (equally new) version, which


### PR DESCRIPTION
**All fork CI is currently red**, including `enhanced` itself — and no fork change caused it.

## What's failing

Every workflow that starts with `just install-js` — `Build Convex Backend`, `Build Dashboard Orchestrator`, and the sync's own validation gates:

```
ERR_PNPM_GIT_DEP_PREPARE_NOT_ALLOWED  Failed to prepare git-hosted package
fetched from ".../nipunn1313/docusaurus-openapi-docs/...": The git-hosted
package "root@" needs to execute build scripts but is not in the
"onlyBuiltDependencies" allowlist.
```

`Build Convex Backend` on `enhanced` was green at 01:50 and red from 02:41 — the 02:08 sync is what changed, and it only merged upstream commits.

## Why upstream is green and we aren't

Upstream's CI **writes** a pnpm store cache, so the package arrives already prepared and no build script runs at install time. This fork's workflows use `runs-on/cache/restore` — **restore-only**, never populating the cache. So whenever the lockfile hash changes, the fork cold-installs and pnpm 10 blocks the build script.

The lockfile hash changed because the sync merged upstream's lockfile updates. That's the whole trigger: a latent difference in cache behaviour, exposed by a routine sync.

## Fix

Allowlist the package exactly as pnpm's error prescribes. Pinned to the dependency's current commit because that's how pnpm identifies it — if upstream bumps the pin, the error names the exact replacement.

## Verification — and its limit

I could **not** reproduce this locally, and I'd rather say so than imply otherwise. It needs a cold full-monorepo install with `--frozen-lockfile`; an isolated probe of that dependency alone installs cleanly, because it generates its own lockfile and so never prepares the *pathless* tarball entry the monorepo lockfile carries.

CI is cold on every run and settles it in ~4 minutes. `Build Dashboard Orchestrator` on this PR is the test.

## Note on #10

#10 (release catch-up) is failing for exactly this reason — its tree is identical to `enhanced`, which is currently broken. It should go green once this lands and it's rebuilt; no change to #10 itself is needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package installation settings to support the documentation build dependency with pnpm 10.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->