### PR TITLE
Fix orchestrator sign-in needing a page refresh first

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5237,6 +5237,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "instant-acme"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37221e690dcc5d0ea7c1f70decda6ae3495e72e8af06bca15e982193ffdf4fc4"
+dependencies = [
+ "async-trait",
+ "aws-lc-rs",
+ "base64 0.22.1",
+ "bytes",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.59",
+]
+
+[[package]]
 name = "interval_map"
 version = "0.1.0"
 dependencies = [
@@ -6951,11 +6973,14 @@ dependencies = [
  "httparse",
  "hyper",
  "hyper-util",
+ "instant-acme",
  "keybroker",
  "orchestrator_api_types",
  "parking_lot",
  "pretty_assertions",
  "rand 0.9.4",
+ "rcgen",
+ "reqwest",
  "rustls",
  "rustls-native-certs 0.8.1",
  "serde",
@@ -6963,6 +6988,7 @@ dependencies = [
  "serde_with",
  "sha2 0.10.8",
  "slugify",
+ "sodium_secretbox",
  "strum 0.28.0",
  "syn 2.0.118",
  "sysinfo 0.33.1",
@@ -7202,6 +7228,16 @@ name = "pb_extras"
 version = "0.1.0"
 dependencies = [
  "tonic",
+]
+
+[[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64 0.22.1",
+ "serde_core",
 ]
 
 [[package]]
@@ -8132,6 +8168,19 @@ dependencies = [
  "tracing",
  "winnow 0.5.40",
  "zstd 0.13.1",
+]
+
+[[package]]
+name = "rcgen"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75e669e5202259b5314d1ea5397316ad400819437857b90861765f24c4cf80a2"
+dependencies = [
+ "pem",
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "yasna",
 ]
 
 [[package]]
@@ -9354,7 +9403,7 @@ dependencies = [
 [[package]]
 name = "shuttle"
 version = "0.9.1"
-source = "git+https://github.com/awslabs/shuttle#0c32849b084a3cf3b6b2a7c10b173473d83faf72"
+source = "git+https://github.com/awslabs/shuttle#1d48fea107777cb75eac9d1b931022c5b01deeec"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -9375,7 +9424,7 @@ dependencies = [
 [[package]]
 name = "shuttle-core"
 version = "0.1.0"
-source = "git+https://github.com/awslabs/shuttle#0c32849b084a3cf3b6b2a7c10b173473d83faf72"
+source = "git+https://github.com/awslabs/shuttle#1d48fea107777cb75eac9d1b931022c5b01deeec"
 dependencies = [
  "assoc",
  "bitvec",
@@ -9414,7 +9463,7 @@ dependencies = [
 [[package]]
 name = "shuttle-parking_lot"
 version = "0.12.5"
-source = "git+https://github.com/awslabs/shuttle#0c32849b084a3cf3b6b2a7c10b173473d83faf72"
+source = "git+https://github.com/awslabs/shuttle#1d48fea107777cb75eac9d1b931022c5b01deeec"
 dependencies = [
  "cfg-if",
  "parking_lot",
@@ -9423,8 +9472,8 @@ dependencies = [
 
 [[package]]
 name = "shuttle-parking_lot-impl"
-version = "0.1.0"
-source = "git+https://github.com/awslabs/shuttle#0c32849b084a3cf3b6b2a7c10b173473d83faf72"
+version = "0.1.1"
+source = "git+https://github.com/awslabs/shuttle#1d48fea107777cb75eac9d1b931022c5b01deeec"
 dependencies = [
  "lock_api",
  "shuttle",
@@ -9434,7 +9483,7 @@ dependencies = [
 [[package]]
 name = "shuttle-schedulers"
 version = "0.1.0"
-source = "git+https://github.com/awslabs/shuttle#0c32849b084a3cf3b6b2a7c10b173473d83faf72"
+source = "git+https://github.com/awslabs/shuttle#1d48fea107777cb75eac9d1b931022c5b01deeec"
 dependencies = [
  "rand 0.8.6",
  "rand_pcg",
@@ -9446,7 +9495,7 @@ dependencies = [
 [[package]]
 name = "shuttle-std"
 version = "0.1.0"
-source = "git+https://github.com/awslabs/shuttle#0c32849b084a3cf3b6b2a7c10b173473d83faf72"
+source = "git+https://github.com/awslabs/shuttle#1d48fea107777cb75eac9d1b931022c5b01deeec"
 dependencies = [
  "assoc",
  "owo-colors",
@@ -12492,6 +12541,15 @@ name = "yansi"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
+
+[[package]]
+name = "yasna"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
+dependencies = [
+ "time",
+]
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,6 +123,7 @@ jsonschema = "0.33"
 keybroker = { path = "crates/keybroker" }
 levenshtein_automata = "0.2.1"
 libc = "0.2"
+instant-acme = { version = "0.7", default-features = false, features = [ "hyper-rustls", "aws-lc-rs" ] }
 libsodium-sys-stable = { version = "1.22.2", features = [ "minimal" ] }
 log_interleaver = { path = "crates/log_interleaver" }
 log_streaming = { path = "crates/log_streaming" }
@@ -182,6 +183,7 @@ rc-zip = { version = "5", features = [ "deflate", "deflate64", "zstd" ] }
 ref-cast = "1.0.20"
 regex = "1"
 reqwest = { version = "0.12.7", features = [ "json", "stream", "gzip", "native-tls-alpn", "native-tls-vendored" ] }
+rcgen = { version = "0.13", features = [ "pem" ] }
 reqwest-middleware = "0.4.1"
 roles = { path = "crates/roles" }
 rsa = "0.9.6"

--- a/crates/orchestrator/Cargo.toml
+++ b/crates/orchestrator/Cargo.toml
@@ -31,9 +31,12 @@ http-body-util = { workspace = true }
 httparse = "1.10"
 hyper = { workspace = true }
 hyper-util = { workspace = true, features = ["server", "http1", "client", "client-legacy"] }
+instant-acme = { workspace = true }
 keybroker = { workspace = true }
 parking_lot = { workspace = true }
 rand = { workspace = true }
+rcgen = { workspace = true }
+reqwest = { workspace = true }
 rustls = { workspace = true }
 rustls-native-certs = { workspace = true }
 serde = { workspace = true }
@@ -41,6 +44,7 @@ serde_json = { workspace = true }
 serde_with = { workspace = true }
 sha2 = { workspace = true }
 slugify = { workspace = true }
+sodium_secretbox = { workspace = true }
 strum = { workspace = true }
 sysinfo = "0.33"
 thiserror = { workspace = true }

--- a/crates/orchestrator/openapi.json
+++ b/crates/orchestrator/openapi.json
@@ -2654,6 +2654,306 @@
         }
       }
     },
+    "/api/dashboard/deployments/{deployment_id}/custom_domains/list": {
+      "get": {
+        "tags": ["dashboard"],
+        "operationId": "list_custom_domains",
+        "parameters": [
+          {
+            "name": "deployment_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListCustomDomains"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/dashboard/deployments/{deployment_id}/custom_domains/create": {
+      "post": {
+        "tags": ["dashboard"],
+        "operationId": "create_custom_domain",
+        "parameters": [
+          {
+            "name": "deployment_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateCustomDomainArgs"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomDomain"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/api/dashboard/deployments/{deployment_id}/custom_domains/delete": {
+      "post": {
+        "tags": ["dashboard"],
+        "operationId": "delete_custom_domain",
+        "parameters": [
+          {
+            "name": "deployment_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CustomDomainArgs"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/api/dashboard/deployments/{deployment_id}/custom_domains/verify": {
+      "post": {
+        "tags": ["dashboard"],
+        "operationId": "verify_custom_domain",
+        "parameters": [
+          {
+            "name": "deployment_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CustomDomainArgs"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VerifyCustomDomainResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/dashboard/deployments/{deployment_id}/custom_domains/retry": {
+      "post": {
+        "tags": ["dashboard"],
+        "operationId": "retry_custom_domain",
+        "parameters": [
+          {
+            "name": "deployment_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CustomDomainArgs"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/api/dashboard/teams/{team_id}/dns_credentials/list": {
+      "get": {
+        "tags": ["dashboard"],
+        "operationId": "list_dns_creds",
+        "parameters": [
+          {
+            "name": "team_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListDnsCredentials"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/dashboard/teams/{team_id}/dns_credentials/create": {
+      "post": {
+        "tags": ["dashboard"],
+        "operationId": "create_dns_cred",
+        "parameters": [
+          {
+            "name": "team_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateDnsCredentialArgs"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DnsCredential"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/api/dashboard/teams/{team_id}/dns_credentials/{credential_id}/delete": {
+      "post": {
+        "tags": ["dashboard"],
+        "operationId": "delete_dns_cred",
+        "parameters": [
+          {
+            "name": "team_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "credential_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/.well-known/acme-challenge/{token}": {
+      "get": {
+        "tags": ["acme"],
+        "operationId": "serve_challenge",
+        "parameters": [
+          {
+            "name": "token",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Key authorization for an in-flight challenge"
+          },
+          "404": {
+            "description": ""
+          }
+        }
+      }
+    },
     "/api/dashboard/teams/{team_id}/get_audit_log_events": {
       "get": {
         "tags": ["dashboard"],
@@ -3300,20 +3600,20 @@
         "type": "object",
         "required": ["id", "kind", "name", "creationTime", "keySuffix"],
         "properties": {
-          "creationTime": {
-            "type": "number",
-            "format": "double"
-          },
           "id": {
-            "type": "string"
-          },
-          "keySuffix": {
             "type": "string"
           },
           "kind": {
             "type": "string"
           },
           "name": {
+            "type": "string"
+          },
+          "creationTime": {
+            "type": "number",
+            "format": "double"
+          },
+          "keySuffix": {
             "type": "string"
           }
         }
@@ -3322,14 +3622,12 @@
         "type": "object",
         "required": ["id", "teamId", "action", "metadata", "creationTime"],
         "properties": {
-          "action": {
-            "type": "string"
-          },
-          "creationTime": {
-            "type": "number",
-            "format": "double"
-          },
           "id": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0
+          },
+          "teamId": {
             "type": "integer",
             "format": "int64",
             "minimum": 0
@@ -3339,11 +3637,13 @@
             "format": "int64",
             "minimum": 0
           },
+          "action": {
+            "type": "string"
+          },
           "metadata": {},
-          "teamId": {
-            "type": "integer",
-            "format": "int64",
-            "minimum": 0
+          "creationTime": {
+            "type": "number",
+            "format": "double"
           }
         }
       },
@@ -3351,14 +3651,14 @@
         "type": "object",
         "required": ["events"],
         "properties": {
-          "cursor": {
-            "type": ["string", "null"]
-          },
           "events": {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/AuditLogEvent"
             }
+          },
+          "cursor": {
+            "type": ["string", "null"]
           }
         }
       },
@@ -3367,11 +3667,11 @@
         "description": "Body of `POST /api/claim_preview_deployment`.",
         "required": ["projectSelection", "identifier"],
         "properties": {
-          "identifier": {
-            "type": "string"
-          },
           "projectSelection": {
             "$ref": "#/components/schemas/ProjectSelectionArgs"
+          },
+          "identifier": {
+            "type": "string"
           }
         }
       },
@@ -3380,17 +3680,56 @@
         "description": "Response shape for `POST /api/claim_preview_deployment`.",
         "required": ["deploymentName", "adminKey", "url", "deploymentType"],
         "properties": {
-          "adminKey": {
-            "type": "string"
-          },
           "deploymentName": {
             "type": "string"
           },
-          "deploymentType": {
+          "adminKey": {
             "type": "string"
           },
           "url": {
             "type": "string"
+          },
+          "deploymentType": {
+            "type": "string"
+          }
+        }
+      },
+      "CreateCustomDomainArgs": {
+        "type": "object",
+        "required": ["domain"],
+        "properties": {
+          "domain": {
+            "type": "string"
+          },
+          "challengeType": {
+            "type": ["string", "null"],
+            "description": "Defaults to `http-01`, which needs no credentials."
+          },
+          "dnsCredentialId": {
+            "type": ["integer", "null"],
+            "format": "int64"
+          }
+        }
+      },
+      "CreateDnsCredentialArgs": {
+        "type": "object",
+        "required": ["name", "provider", "secrets"],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "provider": {
+            "type": "string"
+          },
+          "secrets": {
+            "type": "object",
+            "description": "Provider secrets keyed by the field `key`s advertised in\n[`DnsProviderInfo`]. Sealed before storage and never returned.",
+            "additionalProperties": {
+              "type": "string"
+            },
+            "propertyNames": {
+              "type": "string"
+            }
           }
         }
       },
@@ -3410,12 +3749,12 @@
         "type": "object",
         "required": ["name"],
         "properties": {
+          "name": {
+            "type": "string"
+          },
           "expiresAt": {
             "type": ["number", "null"],
             "format": "double"
-          },
-          "name": {
-            "type": "string"
           }
         }
       },
@@ -3426,15 +3765,15 @@
           "accessToken": {
             "type": "string"
           },
-          "creationTime": {
-            "type": "number",
-            "format": "double"
-          },
           "id": {
             "type": "string"
           },
           "name": {
             "type": "string"
+          },
+          "creationTime": {
+            "type": "number",
+            "format": "double"
           }
         }
       },
@@ -3443,7 +3782,22 @@
         "description": "Body of `POST /api/create_project` (CLI).",
         "required": ["team", "projectName"],
         "properties": {
+          "team": {
+            "type": "string"
+          },
+          "projectName": {
+            "type": "string"
+          },
           "deploymentType": {
+            "type": ["string", "null"]
+          },
+          "region": {
+            "type": ["string", "null"]
+          },
+          "tier": {
+            "type": ["string", "null"]
+          },
+          "provisioningMode": {
             "type": ["string", "null"]
           },
           "knobOverrides": {
@@ -3454,21 +3808,6 @@
             "propertyNames": {
               "type": "string"
             }
-          },
-          "projectName": {
-            "type": "string"
-          },
-          "provisioningMode": {
-            "type": ["string", "null"]
-          },
-          "region": {
-            "type": ["string", "null"]
-          },
-          "team": {
-            "type": "string"
-          },
-          "tier": {
-            "type": ["string", "null"]
           }
         }
       },
@@ -3477,12 +3816,6 @@
         "description": "Response shape for `POST /api/create_project` (CLI).",
         "required": ["projectId", "projectSlug", "teamSlug"],
         "properties": {
-          "adminKey": {
-            "type": ["string", "null"]
-          },
-          "deploymentName": {
-            "type": ["string", "null"]
-          },
           "projectId": {
             "type": "integer",
             "format": "int64",
@@ -3494,7 +3827,13 @@
           "teamSlug": {
             "type": "string"
           },
+          "deploymentName": {
+            "type": ["string", "null"]
+          },
           "url": {
+            "type": ["string", "null"]
+          },
+          "adminKey": {
             "type": ["string", "null"]
           }
         }
@@ -3517,6 +3856,59 @@
           },
           "slug": {
             "type": ["string", "null"]
+          }
+        }
+      },
+      "CustomDomain": {
+        "type": "object",
+        "required": [
+          "id",
+          "deploymentId",
+          "domain",
+          "certState",
+          "createdAt",
+          "challengeType"
+        ],
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "deploymentId": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "domain": {
+            "type": "string"
+          },
+          "certState": {
+            "type": "string",
+            "description": "`pending` -> `issuing` -> `active`, or `failed`. Only ever set from an\nobserved outcome: `active` means an HTTPS request to the domain\nactually succeeded, not that issuance was requested."
+          },
+          "createdAt": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "challengeType": {
+            "type": "string",
+            "description": "`http-01` (no credentials needed) or `dns-01` (needs a DNS provider\ncredential, and is the only option for wildcards)."
+          },
+          "dnsCredentialId": {
+            "type": ["integer", "null"],
+            "format": "int64"
+          },
+          "lastError": {
+            "type": ["string", "null"],
+            "description": "Verbatim reason the last issuance failed, if it did."
+          }
+        }
+      },
+      "CustomDomainArgs": {
+        "type": "object",
+        "required": ["domain"],
+        "properties": {
+          "domain": {
+            "type": "string"
           }
         }
       },
@@ -3548,25 +3940,25 @@
           "isDefault"
         ],
         "properties": {
+          "deploymentName": {
+            "type": "string"
+          },
           "adminKey": {
             "$ref": "#/components/schemas/AccessToken"
           },
-          "deploymentName": {
+          "url": {
             "type": "string"
           },
           "deploymentType": {
             "$ref": "#/components/schemas/DeploymentType"
           },
-          "isDefault": {
-            "type": "boolean",
-            "description": "Whether this is the default deployment for its project (dev: per\nmember; prod: per project). Preview/custom/local are always `false`."
-          },
           "reference": {
             "type": ["string", "null"],
             "description": "The user-facing reference for this deployment (e.g. `preview/pr-42`),\nusable as the `<ref>` in `team:project:<ref>` selectors. `None` for\nlocal deployments, which don't have a Big Brain reference."
           },
-          "url": {
-            "type": "string"
+          "isDefault": {
+            "type": "boolean",
+            "description": "Whether this is the default deployment for its project (dev: per\nmember; prod: per project). Preview/custom/local are always `false`."
           }
         }
       },
@@ -3588,10 +3980,10 @@
         "type": "object",
         "required": ["name", "description"],
         "properties": {
-          "description": {
+          "name": {
             "type": "string"
           },
-          "name": {
+          "description": {
             "type": "string"
           }
         }
@@ -3605,10 +3997,10 @@
         "type": "object",
         "required": ["name", "description"],
         "properties": {
-          "description": {
+          "name": {
             "type": "string"
           },
-          "name": {
+          "description": {
             "type": "string"
           }
         }
@@ -3627,17 +4019,12 @@
           "creationTime"
         ],
         "properties": {
-          "creationTime": {
-            "type": "number",
-            "format": "double"
-          },
-          "deploymentClass": {
-            "type": "string"
-          },
-          "deploymentType": {
-            "type": "string"
-          },
           "id": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0
+          },
+          "projectId": {
             "type": "integer",
             "format": "int64",
             "minimum": 0
@@ -3645,16 +4032,14 @@
           "name": {
             "type": "string"
           },
-          "previewIdentifier": {
-            "type": ["string", "null"]
+          "deploymentType": {
+            "type": "string"
           },
-          "projectId": {
-            "type": "integer",
-            "format": "int64",
-            "minimum": 0
+          "deploymentClass": {
+            "type": "string"
           },
-          "region": {
-            "type": ["string", "null"]
+          "url": {
+            "type": "string"
           },
           "siteUrl": {
             "type": "string"
@@ -3662,8 +4047,15 @@
           "state": {
             "type": "string"
           },
-          "url": {
-            "type": "string"
+          "creationTime": {
+            "type": "number",
+            "format": "double"
+          },
+          "region": {
+            "type": ["string", "null"]
+          },
+          "previewIdentifier": {
+            "type": ["string", "null"]
           }
         }
       },
@@ -3676,6 +4068,14 @@
           "runningOverrides"
         ],
         "properties": {
+          "effectiveTier": {
+            "type": "string",
+            "description": "Effective tier for the next spawn: `desired_tier` if set, else the\nproject's tier."
+          },
+          "desiredTier": {
+            "type": ["string", "null"],
+            "description": "`Some` when this deployment overrides the project tier; `None` when\nit inherits."
+          },
           "desiredOverrides": {
             "type": "object",
             "description": "Deployment-level overrides only (not merged with project's).",
@@ -3686,13 +4086,9 @@
               "type": "string"
             }
           },
-          "desiredTier": {
-            "type": ["string", "null"],
-            "description": "`Some` when this deployment overrides the project tier; `None` when\nit inherits."
-          },
-          "effectiveTier": {
+          "runningTier": {
             "type": "string",
-            "description": "Effective tier for the next spawn: `desired_tier` if set, else the\nproject's tier."
+            "description": "Tier the currently-running container was spawned with."
           },
           "runningOverrides": {
             "type": "object",
@@ -3703,10 +4099,6 @@
             "propertyNames": {
               "type": "string"
             }
-          },
-          "runningTier": {
-            "type": "string",
-            "description": "Tier the currently-running container was spawned with."
           }
         }
       },
@@ -3718,9 +4110,6 @@
         "type": "object",
         "required": ["deviceName"],
         "properties": {
-          "bootstrapToken": {
-            "type": ["string", "null"]
-          },
           "deviceName": {
             "type": "string"
           },
@@ -3728,6 +4117,9 @@
             "type": ["string", "null"]
           },
           "password": {
+            "type": ["string", "null"]
+          },
+          "bootstrapToken": {
             "type": ["string", "null"]
           }
         }
@@ -3746,21 +4138,72 @@
           }
         }
       },
+      "DnsCredential": {
+        "type": "object",
+        "required": ["id", "name", "provider", "createdAt"],
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "name": {
+            "type": "string"
+          },
+          "provider": {
+            "type": "string"
+          },
+          "createdAt": {
+            "type": "integer",
+            "format": "int64"
+          }
+        }
+      },
+      "DnsProviderField": {
+        "type": "object",
+        "required": ["key", "label", "help"],
+        "properties": {
+          "key": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          },
+          "help": {
+            "type": "string"
+          }
+        }
+      },
+      "DnsProviderInfo": {
+        "type": "object",
+        "description": "A DNS provider the orchestrator can drive, plus the secret fields its\ncredential form needs. Sent to the dashboard so adding a provider doesn't\nrequire a matching dashboard change.",
+        "required": ["provider", "fields"],
+        "properties": {
+          "provider": {
+            "type": "string"
+          },
+          "fields": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DnsProviderField"
+            }
+          }
+        }
+      },
       "EnvironmentVariable": {
         "type": "object",
         "required": ["name", "value", "deploymentTypes"],
         "properties": {
-          "deploymentTypes": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
           "name": {
             "type": "string"
           },
           "value": {
             "type": "string"
+          },
+          "deploymentTypes": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           }
         }
       },
@@ -3775,12 +4218,12 @@
           "email": {
             "type": "string"
           },
+          "name": {
+            "type": ["string", "null"]
+          },
           "inviteCode": {
             "type": ["string", "null"],
             "description": "Optional team invitation code. Required for a non-allowlisted user to\nmint the temporary session token needed to accept an invite."
-          },
-          "name": {
-            "type": ["string", "null"]
           }
         }
       },
@@ -3796,10 +4239,10 @@
             "format": "int64",
             "minimum": 0
           },
-          "role": {
+          "teamSlug": {
             "type": "string"
           },
-          "teamSlug": {
+          "role": {
             "type": "string"
           }
         }
@@ -3848,18 +4291,9 @@
           "deploymentCount"
         ],
         "properties": {
-          "allocatedCpus": {
-            "type": "number",
-            "format": "float"
-          },
-          "allocatedMemoryMb": {
+          "totalMemoryMb": {
             "type": "integer",
             "format": "int64",
-            "minimum": 0
-          },
-          "deploymentCount": {
-            "type": "integer",
-            "format": "int32",
             "minimum": 0
           },
           "totalCpus": {
@@ -3867,9 +4301,18 @@
             "format": "int32",
             "minimum": 0
           },
-          "totalMemoryMb": {
+          "allocatedMemoryMb": {
             "type": "integer",
             "format": "int64",
+            "minimum": 0
+          },
+          "allocatedCpus": {
+            "type": "number",
+            "format": "float"
+          },
+          "deploymentCount": {
+            "type": "integer",
+            "format": "int32",
             "minimum": 0
           }
         }
@@ -3890,23 +4333,23 @@
         "type": "object",
         "required": ["id", "email", "role", "code", "createdAt"],
         "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0
+          },
+          "email": {
+            "type": "string"
+          },
+          "role": {
+            "type": "string"
+          },
           "code": {
             "type": "string"
           },
           "createdAt": {
             "type": "number",
             "format": "double"
-          },
-          "email": {
-            "type": "string"
-          },
-          "id": {
-            "type": "integer",
-            "format": "int64",
-            "minimum": 0
-          },
-          "role": {
-            "type": "string"
           }
         }
       },
@@ -3914,23 +4357,23 @@
         "type": "object",
         "required": ["envVar", "description", "category", "exposure"],
         "properties": {
+          "envVar": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
           "category": {
             "type": "string"
           },
-          "defaultValue": {
-            "type": ["string", "null"]
-          },
-          "description": {
+          "exposure": {
             "type": "string"
           },
           "displayName": {
             "type": ["string", "null"]
           },
-          "envVar": {
-            "type": "string"
-          },
-          "exposure": {
-            "type": "string"
+          "defaultValue": {
+            "type": ["string", "null"]
           }
         }
       },
@@ -3943,6 +4386,33 @@
             "items": {
               "$ref": "#/components/schemas/KnobEntry"
             }
+          }
+        }
+      },
+      "ListCustomDomains": {
+        "type": "object",
+        "required": ["domains", "providers", "targetHost", "routingEnabled"],
+        "properties": {
+          "domains": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CustomDomain"
+            }
+          },
+          "providers": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DnsProviderInfo"
+            },
+            "description": "Providers available for dns-01, with their credential form fields."
+          },
+          "targetHost": {
+            "type": "string",
+            "description": "Hostname the operator should CNAME/A-record the custom domain at.\nEmpty when the orchestrator has no public router host configured."
+          },
+          "routingEnabled": {
+            "type": "boolean",
+            "description": "False when the orchestrator has no Traefik dynamic directory wired up,\nin which case adding a domain would record a row that never routes."
           }
         }
       },
@@ -3966,6 +4436,24 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/DeploymentRegion"
+            }
+          }
+        }
+      },
+      "ListDnsCredentials": {
+        "type": "object",
+        "required": ["credentials", "providers"],
+        "properties": {
+          "credentials": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DnsCredential"
+            }
+          },
+          "providers": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DnsProviderInfo"
             }
           }
         }
@@ -4013,13 +4501,13 @@
         "type": "object",
         "required": ["id", "email"],
         "properties": {
-          "email": {
-            "type": "string"
-          },
           "id": {
             "type": "integer",
             "format": "int64",
             "minimum": 0
+          },
+          "email": {
+            "type": "string"
           },
           "name": {
             "type": ["string", "null"]
@@ -4039,14 +4527,14 @@
         "type": "object",
         "required": ["variables"],
         "properties": {
-          "cursor": {
-            "type": ["string", "null"]
-          },
           "variables": {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/PlatformDefaultEnvVar"
             }
+          },
+          "cursor": {
+            "type": ["string", "null"]
           }
         }
       },
@@ -4054,14 +4542,14 @@
         "type": "object",
         "required": ["deployments"],
         "properties": {
-          "cursor": {
-            "type": ["string", "null"]
-          },
           "deployments": {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/PlatformDeploymentResponse"
             }
+          },
+          "cursor": {
+            "type": ["string", "null"]
           }
         }
       },
@@ -4069,14 +4557,14 @@
         "type": "object",
         "required": ["tokens"],
         "properties": {
-          "cursor": {
-            "type": ["string", "null"]
-          },
           "tokens": {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/PlatformDeployKeyResponse"
             }
+          },
+          "cursor": {
+            "type": ["string", "null"]
           }
         }
       },
@@ -4084,15 +4572,25 @@
         "type": "object",
         "required": ["kind"],
         "properties": {
+          "kind": {
+            "type": "string"
+          },
           "deploymentClass": {
             "type": ["string", "null"]
           },
-          "force": {
-            "type": ["boolean", "null"],
-            "description": "Legacy client hint. Host allocation can be overprovisioned, so the\norchestrator no longer requires this to exceed current host capacity."
+          "region": {
+            "type": ["string", "null"]
           },
-          "kind": {
-            "type": "string"
+          "previewIdentifier": {
+            "type": ["string", "null"]
+          },
+          "tier": {
+            "type": ["string", "null"],
+            "description": "Overrides the project's default tier for this deployment only."
+          },
+          "provisioningMode": {
+            "type": ["string", "null"],
+            "description": "Override the project's default infrastructure strategy for this\ndeployment only (`default`, `volume-sqlite`, or `sidecar`)."
           },
           "knobOverrides": {
             "type": ["object", "null"],
@@ -4104,19 +4602,9 @@
               "type": "string"
             }
           },
-          "previewIdentifier": {
-            "type": ["string", "null"]
-          },
-          "provisioningMode": {
-            "type": ["string", "null"],
-            "description": "Override the project's default infrastructure strategy for this\ndeployment only (`default`, `volume-sqlite`, or `sidecar`)."
-          },
-          "region": {
-            "type": ["string", "null"]
-          },
-          "tier": {
-            "type": ["string", "null"],
-            "description": "Overrides the project's default tier for this deployment only."
+          "force": {
+            "type": ["boolean", "null"],
+            "description": "Legacy client hint. Host allocation can be overprovisioned, so the\norchestrator no longer requires this to exceed current host capacity."
           }
         }
       },
@@ -4124,16 +4612,16 @@
         "type": "object",
         "required": ["projectName"],
         "properties": {
-          "deploymentType": {
-            "type": ["string", "null"]
-          },
           "projectName": {
             "type": "string"
           },
-          "region": {
+          "slug": {
             "type": ["string", "null"]
           },
-          "slug": {
+          "deploymentType": {
+            "type": ["string", "null"]
+          },
+          "region": {
             "type": ["string", "null"]
           }
         }
@@ -4142,12 +4630,6 @@
         "type": "object",
         "required": ["projectId", "projectSlug", "teamSlug"],
         "properties": {
-          "adminKey": {
-            "type": ["string", "null"]
-          },
-          "deploymentName": {
-            "type": ["string", "null"]
-          },
           "projectId": {
             "type": "integer",
             "format": "int64",
@@ -4159,7 +4641,13 @@
           "teamSlug": {
             "type": "string"
           },
+          "deploymentName": {
+            "type": ["string", "null"]
+          },
           "url": {
+            "type": ["string", "null"]
+          },
+          "adminKey": {
             "type": ["string", "null"]
           }
         }
@@ -4180,17 +4668,17 @@
         "type": "object",
         "required": ["name", "value", "deploymentTypes"],
         "properties": {
-          "deploymentTypes": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
           "name": {
             "type": "string"
           },
           "value": {
             "type": "string"
+          },
+          "deploymentTypes": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           }
         }
       },
@@ -4198,23 +4686,23 @@
         "type": "object",
         "required": ["id", "name", "creationTime", "keySuffix"],
         "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
           "creationTime": {
             "type": "number",
             "format": "double"
+          },
+          "keySuffix": {
+            "type": "string"
           },
           "expiresAt": {
             "type": ["number", "null"],
             "format": "double",
             "description": "Milliseconds since epoch; `None` for keys that never expire."
-          },
-          "id": {
-            "type": "string"
-          },
-          "keySuffix": {
-            "type": "string"
-          },
-          "name": {
-            "type": "string"
           }
         }
       },
@@ -4232,34 +4720,27 @@
           "creationTime"
         ],
         "properties": {
-          "creationTime": {
-            "type": "number",
-            "format": "double"
-          },
-          "deploymentClass": {
-            "type": "string"
-          },
           "id": {
             "type": "integer",
             "format": "int64",
             "minimum": 0
-          },
-          "kind": {
-            "type": "string"
-          },
-          "name": {
-            "type": "string"
-          },
-          "previewIdentifier": {
-            "type": ["string", "null"]
           },
           "projectId": {
             "type": "integer",
             "format": "int64",
             "minimum": 0
           },
-          "region": {
-            "type": ["string", "null"]
+          "name": {
+            "type": "string"
+          },
+          "kind": {
+            "type": "string"
+          },
+          "deploymentClass": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
           },
           "siteUrl": {
             "type": "string"
@@ -4267,12 +4748,19 @@
           "state": {
             "type": "string"
           },
+          "creationTime": {
+            "type": "number",
+            "format": "double"
+          },
+          "region": {
+            "type": ["string", "null"]
+          },
+          "previewIdentifier": {
+            "type": ["string", "null"]
+          },
           "tier": {
             "type": "string",
             "description": "Resource tier (S4/S8/S16/S32/S64/S128/S256 or custom:<memoryMb>:<cpus>)\nsnapshotted on the\ndeployment row at provision time. Surfaced so the dashboard can\ndisplay the tier badge without an extra request to settings."
-          },
-          "url": {
-            "type": "string"
           }
         }
       },
@@ -4292,17 +4780,15 @@
         "type": "object",
         "required": ["id", "teamId", "name", "slug", "isDemo", "creationTime"],
         "properties": {
-          "creationTime": {
-            "type": "number",
-            "format": "double"
-          },
           "id": {
             "type": "integer",
             "format": "int64",
             "minimum": 0
           },
-          "isDemo": {
-            "type": "boolean"
+          "teamId": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0
           },
           "name": {
             "type": "string"
@@ -4310,10 +4796,12 @@
           "slug": {
             "type": "string"
           },
-          "teamId": {
-            "type": "integer",
-            "format": "int64",
-            "minimum": 0
+          "isDemo": {
+            "type": "boolean"
+          },
+          "creationTime": {
+            "type": "number",
+            "format": "double"
           }
         }
       },
@@ -4321,13 +4809,13 @@
         "type": "object",
         "required": ["id", "email", "role"],
         "properties": {
-          "email": {
-            "type": "string"
-          },
           "id": {
             "type": "integer",
             "format": "int64",
             "minimum": 0
+          },
+          "email": {
+            "type": "string"
           },
           "role": {
             "type": "string"
@@ -4355,13 +4843,10 @@
         "type": "object",
         "required": ["kind"],
         "properties": {
-          "deploymentName": {
-            "type": ["string", "null"]
-          },
           "kind": {
             "type": "string"
           },
-          "memberId": {
+          "teamId": {
             "type": ["integer", "null"],
             "format": "int64",
             "minimum": 0
@@ -4371,7 +4856,10 @@
             "format": "int64",
             "minimum": 0
           },
-          "teamId": {
+          "deploymentName": {
+            "type": ["string", "null"]
+          },
+          "memberId": {
             "type": ["integer", "null"],
             "format": "int64",
             "minimum": 0
@@ -4402,18 +4890,18 @@
         "type": "object",
         "required": ["id", "email", "isVerified", "isPrimary"],
         "properties": {
-          "email": {
-            "type": "string"
-          },
           "id": {
             "type": "integer",
             "format": "int64",
             "minimum": 0
           },
-          "isPrimary": {
-            "type": "boolean"
+          "email": {
+            "type": "string"
           },
           "isVerified": {
+            "type": "boolean"
+          },
+          "isPrimary": {
             "type": "boolean"
           }
         }
@@ -4427,17 +4915,15 @@
         "type": "object",
         "required": ["id", "teamId", "name", "slug", "isDemo", "creationTime"],
         "properties": {
-          "creationTime": {
-            "type": "number",
-            "format": "double"
-          },
           "id": {
             "type": "integer",
             "format": "int64",
             "minimum": 0
           },
-          "isDemo": {
-            "type": "boolean"
+          "teamId": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0
           },
           "name": {
             "type": "string"
@@ -4445,10 +4931,12 @@
           "slug": {
             "type": "string"
           },
-          "teamId": {
-            "type": "integer",
-            "format": "int64",
-            "minimum": 0
+          "isDemo": {
+            "type": "boolean"
+          },
+          "creationTime": {
+            "type": "number",
+            "format": "double"
           }
         }
       },
@@ -4456,11 +4944,11 @@
         "type": "object",
         "required": ["projectId", "memberId"],
         "properties": {
-          "memberId": {
+          "projectId": {
             "type": "integer",
             "format": "int64"
           },
-          "projectId": {
+          "memberId": {
             "type": "integer",
             "format": "int64"
           }
@@ -4497,15 +4985,15 @@
             "description": "If there is no CONVEX_DEPLOYMENT, select a project with team and\nproject.",
             "required": ["teamSlug", "projectSlug", "kind"],
             "properties": {
-              "kind": {
-                "type": "string",
-                "enum": ["teamAndProjectSlugs"]
+              "teamSlug": {
+                "type": "string"
               },
               "projectSlug": {
                 "type": "string"
               },
-              "teamSlug": {
-                "type": "string"
+              "kind": {
+                "type": "string",
+                "enum": ["teamAndProjectSlugs"]
               }
             }
           }
@@ -4515,6 +5003,9 @@
         "type": "object",
         "required": ["tier", "knobOverrides"],
         "properties": {
+          "tier": {
+            "type": "string"
+          },
           "knobOverrides": {
             "type": "object",
             "description": "Flat map from env var name to canonical string value. Empty when no\noverrides have been set (the deployment will use tier defaults).",
@@ -4524,9 +5015,6 @@
             "propertyNames": {
               "type": "string"
             }
-          },
-          "tier": {
-            "type": "string"
           }
         }
       },
@@ -4538,14 +5026,14 @@
         "description": "Body of `POST /api/deployment/provision_and_authorize`.",
         "required": ["deploymentType"],
         "properties": {
-          "deploymentType": {
-            "type": "string"
+          "teamSlug": {
+            "type": ["string", "null"]
           },
           "projectSlug": {
             "type": ["string", "null"]
           },
-          "teamSlug": {
-            "type": ["string", "null"]
+          "deploymentType": {
+            "type": "string"
           }
         }
       },
@@ -4561,34 +5049,34 @@
           "adminKey"
         ],
         "properties": {
-          "adminKey": {
-            "type": "string",
-            "description": "Full admin key the operator generated when starting their backend.\nStored hashed; only the last few characters are retained in the clear\n(as `keySuffix`) for UI display."
-          },
           "deploymentName": {
             "type": "string"
-          },
-          "deploymentType": {
-            "type": "string",
-            "description": "`prod`, `dev`, or `preview`."
-          },
-          "previewIdentifier": {
-            "type": ["string", "null"],
-            "description": "Required for `preview` deployments — matches the preview branch / id."
           },
           "projectId": {
             "type": "integer",
             "format": "int64",
             "minimum": 0
           },
-          "region": {
-            "type": ["string", "null"]
+          "deploymentType": {
+            "type": "string",
+            "description": "`prod`, `dev`, or `preview`."
+          },
+          "url": {
+            "type": "string"
           },
           "siteUrl": {
             "type": "string"
           },
-          "url": {
-            "type": "string"
+          "adminKey": {
+            "type": "string",
+            "description": "Full admin key the operator generated when starting their backend.\nStored hashed; only the last few characters are retained in the clear\n(as `keySuffix`) for UI display."
+          },
+          "region": {
+            "type": ["string", "null"]
+          },
+          "previewIdentifier": {
+            "type": ["string", "null"],
+            "description": "Required for `preview` deployments — matches the preview branch / id."
           }
         }
       },
@@ -4636,19 +5124,19 @@
           "cancelAtPeriodEnd"
         ],
         "properties": {
-          "cancelAtPeriodEnd": {
-            "type": "boolean"
-          },
-          "currentPeriodEnd": {
-            "type": "number",
-            "format": "double"
+          "plan": {
+            "$ref": "#/components/schemas/StubBillingPlan"
           },
           "currentPeriodStart": {
             "type": "number",
             "format": "double"
           },
-          "plan": {
-            "$ref": "#/components/schemas/StubBillingPlan"
+          "currentPeriodEnd": {
+            "type": "number",
+            "format": "double"
+          },
+          "cancelAtPeriodEnd": {
+            "type": "boolean"
           }
         }
       },
@@ -4659,12 +5147,12 @@
           "code": {
             "type": "string"
           },
-          "maxReferrals": {
+          "referredCount": {
             "type": "integer",
             "format": "int64",
             "minimum": 0
           },
-          "referredCount": {
+          "maxReferrals": {
             "type": "integer",
             "format": "int64",
             "minimum": 0
@@ -4675,11 +5163,6 @@
         "type": "object",
         "required": ["currentSpendCents"],
         "properties": {
-          "currentSpendCents": {
-            "type": "integer",
-            "format": "int64",
-            "minimum": 0
-          },
           "disableThresholdCents": {
             "type": ["integer", "null"],
             "format": "int64",
@@ -4687,6 +5170,11 @@
           },
           "warningThresholdCents": {
             "type": ["integer", "null"],
+            "format": "int64",
+            "minimum": 0
+          },
+          "currentSpendCents": {
+            "type": "integer",
             "format": "int64",
             "minimum": 0
           }
@@ -4708,34 +5196,12 @@
           "plan"
         ],
         "properties": {
-          "allowAuditLog": {
-            "type": "boolean"
-          },
-          "allowCustomDomains": {
-            "type": "boolean"
-          },
-          "allowPeriodicBackups": {
-            "type": "boolean"
-          },
-          "allowStreamingExport": {
-            "type": "boolean"
-          },
-          "maxDeployments": {
-            "type": "integer",
-            "format": "int64",
-            "minimum": 0
-          },
-          "maxFunctionCallsPerMonth": {
-            "type": "integer",
-            "format": "int64",
-            "minimum": 0
-          },
           "maxProjects": {
             "type": "integer",
             "format": "int64",
             "minimum": 0
           },
-          "maxStorageBytes": {
+          "maxTeams": {
             "type": "integer",
             "format": "int64",
             "minimum": 0
@@ -4745,10 +5211,32 @@
             "format": "int64",
             "minimum": 0
           },
-          "maxTeams": {
+          "maxDeployments": {
             "type": "integer",
             "format": "int64",
             "minimum": 0
+          },
+          "maxStorageBytes": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0
+          },
+          "maxFunctionCallsPerMonth": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0
+          },
+          "allowPeriodicBackups": {
+            "type": "boolean"
+          },
+          "allowAuditLog": {
+            "type": "boolean"
+          },
+          "allowCustomDomains": {
+            "type": "boolean"
+          },
+          "allowStreamingExport": {
+            "type": "boolean"
           },
           "plan": {
             "type": "string"
@@ -4785,11 +5273,11 @@
         "type": "object",
         "required": ["valid"],
         "properties": {
-          "teamName": {
-            "type": ["string", "null"]
-          },
           "valid": {
             "type": "boolean"
+          },
+          "teamName": {
+            "type": ["string", "null"]
           }
         }
       },
@@ -4797,6 +5285,18 @@
         "type": "object",
         "required": ["team", "project", "teamId", "projectId", "isDefault"],
         "properties": {
+          "team": {
+            "$ref": "#/components/schemas/TeamSlug"
+          },
+          "project": {
+            "$ref": "#/components/schemas/ProjectSlug"
+          },
+          "teamId": {
+            "$ref": "#/components/schemas/TeamId"
+          },
+          "projectId": {
+            "$ref": "#/components/schemas/ProjectId"
+          },
           "deploymentId": {
             "oneOf": [
               {
@@ -4807,25 +5307,13 @@
               }
             ]
           },
-          "isDefault": {
-            "type": "boolean",
-            "description": "Whether this is the default deployment for its project (dev: per\nmember; prod: per project). Always `false` for local deployments."
-          },
-          "project": {
-            "$ref": "#/components/schemas/ProjectSlug"
-          },
-          "projectId": {
-            "$ref": "#/components/schemas/ProjectId"
-          },
           "reference": {
             "type": ["string", "null"],
             "description": "The user-facing reference for this deployment (e.g. `preview/pr-42`),\nusable as the `<ref>` in `team:project:<ref>` selectors. `None` for\nlocal deployments."
           },
-          "team": {
-            "$ref": "#/components/schemas/TeamSlug"
-          },
-          "teamId": {
-            "$ref": "#/components/schemas/TeamId"
+          "isDefault": {
+            "type": "boolean",
+            "description": "Whether this is the default deployment for its project (dev: per\nmember; prod: per project). Always `false` for local deployments."
           }
         }
       },
@@ -4838,13 +5326,13 @@
         "type": "object",
         "required": ["id", "email", "role"],
         "properties": {
-          "email": {
-            "type": "string"
-          },
           "id": {
             "type": "integer",
             "format": "int64",
             "minimum": 0
+          },
+          "email": {
+            "type": "string"
           },
           "name": {
             "type": ["string", "null"]
@@ -4858,11 +5346,6 @@
         "type": "object",
         "required": ["id", "name", "slug"],
         "properties": {
-          "creator": {
-            "type": ["integer", "null"],
-            "format": "int64",
-            "minimum": 0
-          },
           "id": {
             "type": "integer",
             "format": "int64",
@@ -4873,6 +5356,11 @@
           },
           "slug": {
             "type": "string"
+          },
+          "creator": {
+            "type": ["integer", "null"],
+            "format": "int64",
+            "minimum": 0
           }
         }
       },
@@ -4924,6 +5412,10 @@
       "UpdateDeploymentSettingsArgs": {
         "type": "object",
         "properties": {
+          "desiredTier": {
+            "type": ["string", "null"],
+            "description": "Set to a tier name to override the project tier. Set to `null` to\nclear the override and fall back to the project tier. Omit to leave\nunchanged."
+          },
           "desiredOverrides": {
             "type": ["object", "null"],
             "description": "Partial knob-override patch: `Some(value)` sets a key, `None` for a\nkey clears it. Omit the whole field to leave unchanged.",
@@ -4933,10 +5425,6 @@
             "propertyNames": {
               "type": "string"
             }
-          },
-          "desiredTier": {
-            "type": ["string", "null"],
-            "description": "Set to a tier name to override the project tier. Set to `null` to\nclear the override and fall back to the project tier. Omit to leave\nunchanged."
           }
         }
       },
@@ -4978,6 +5466,10 @@
         "type": "object",
         "required": ["projectId", "adminMemberIds"],
         "properties": {
+          "projectId": {
+            "type": "integer",
+            "format": "int64"
+          },
           "adminMemberIds": {
             "type": "array",
             "items": {
@@ -4985,16 +5477,16 @@
               "format": "int64"
             },
             "description": "Replaces the full admin set for the project."
-          },
-          "projectId": {
-            "type": "integer",
-            "format": "int64"
           }
         }
       },
       "UpdateProjectSettingsArgs": {
         "type": "object",
         "properties": {
+          "tier": {
+            "type": ["string", "null"],
+            "description": "Set to switch tier. Omit to leave unchanged."
+          },
           "knobOverrides": {
             "type": ["object", "null"],
             "description": "Replace the override map entirely. Omit to leave unchanged. A value\nof `null` for any individual knob clears that override (so the\neffective value falls back to tier default).",
@@ -5004,10 +5496,6 @@
             "propertyNames": {
               "type": "string"
             }
-          },
-          "tier": {
-            "type": ["string", "null"],
-            "description": "Set to switch tier. Omit to leave unchanged."
           }
         }
       },
@@ -5019,6 +5507,22 @@
           },
           "slug": {
             "type": ["string", "null"]
+          }
+        }
+      },
+      "VerifyCustomDomainResponse": {
+        "type": "object",
+        "required": ["domain", "certState"],
+        "properties": {
+          "domain": {
+            "type": "string"
+          },
+          "certState": {
+            "type": "string"
+          },
+          "error": {
+            "type": ["string", "null"],
+            "description": "Why the probe failed, when it did. Surfaced verbatim in the dashboard\nbecause the causes (DNS not pointed here, ACME rate limit) are things\nonly the operator can fix."
           }
         }
       }

--- a/crates/orchestrator/src/acme/dns_providers.rs
+++ b/crates/orchestrator/src/acme/dns_providers.rs
@@ -1,0 +1,493 @@
+//! DNS providers for the ACME DNS-01 challenge.
+//!
+//! The orchestrator performs the challenge itself rather than delegating to
+//! Traefik, because Traefik reads DNS credentials from static configuration
+//! and would need a restart whenever they change. Doing it here means an
+//! operator can paste an API token into the dashboard and have the next
+//! certificate use it immediately.
+//!
+//! Each provider only has to create and delete a TXT record. Adding one is a
+//! new `Provider` match arm plus a `DnsProvider` impl.
+
+use std::{
+    collections::BTreeMap,
+    fmt,
+};
+
+use anyhow::Context;
+use async_trait::async_trait;
+use serde::{
+    Deserialize,
+    Serialize,
+};
+
+/// Providers the orchestrator can drive. The string form is what's stored in
+/// `dns_provider_credentials.provider` and sent over the API.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum Provider {
+    Cloudflare,
+    DigitalOcean,
+    Hetzner,
+}
+
+impl Provider {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Provider::Cloudflare => "cloudflare",
+            Provider::DigitalOcean => "digitalocean",
+            Provider::Hetzner => "hetzner",
+        }
+    }
+
+    pub fn parse(s: &str) -> anyhow::Result<Self> {
+        match s {
+            "cloudflare" => Ok(Provider::Cloudflare),
+            "digitalocean" => Ok(Provider::DigitalOcean),
+            "hetzner" => Ok(Provider::Hetzner),
+            other => anyhow::bail!("unknown DNS provider {other:?}"),
+        }
+    }
+
+    /// Secret fields this provider needs, in the order the dashboard should
+    /// render them. Driving the form from here means adding a provider
+    /// doesn't require a matching dashboard change.
+    pub fn required_fields(self) -> &'static [ProviderField] {
+        match self {
+            Provider::Cloudflare => &[ProviderField {
+                key: "apiToken",
+                label: "API token",
+                help: "Cloudflare token with Zone:DNS:Edit and Zone:Zone:Read on the target zone.",
+            }],
+            Provider::DigitalOcean => &[ProviderField {
+                key: "apiToken",
+                label: "API token",
+                help: "DigitalOcean personal access token with write scope.",
+            }],
+            Provider::Hetzner => &[ProviderField {
+                key: "apiToken",
+                label: "API token",
+                help: "Hetzner DNS Console API token.",
+            }],
+        }
+    }
+
+    pub fn all() -> &'static [Provider] {
+        &[
+            Provider::Cloudflare,
+            Provider::DigitalOcean,
+            Provider::Hetzner,
+        ]
+    }
+}
+
+impl fmt::Display for Provider {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct ProviderField {
+    pub key: &'static str,
+    pub label: &'static str,
+    pub help: &'static str,
+}
+
+/// Decrypted provider secrets. Held only for the duration of a challenge —
+/// at rest these live sealed in `dns_provider_credentials.secrets`.
+pub type Secrets = BTreeMap<String, String>;
+
+/// A TXT record the orchestrator created and must clean up afterwards.
+pub struct TxtRecord {
+    pub provider_id: String,
+    pub zone_id: String,
+}
+
+#[async_trait]
+pub trait DnsProvider: Send + Sync {
+    /// Creates `_acme-challenge.<domain>` TXT = `value`.
+    async fn create_txt(&self, domain: &str, value: &str) -> anyhow::Result<TxtRecord>;
+
+    /// Best-effort cleanup. Failure here is logged, never fatal: a stale
+    /// challenge record is untidy but harmless, whereas failing the whole
+    /// issuance over cleanup would be worse.
+    async fn delete_txt(&self, record: &TxtRecord) -> anyhow::Result<()>;
+}
+
+pub fn build(provider: Provider, secrets: &Secrets) -> anyhow::Result<Box<dyn DnsProvider>> {
+    let token = secrets
+        .get("apiToken")
+        .filter(|t| !t.trim().is_empty())
+        .context("credential is missing `apiToken`")?
+        .clone();
+
+    Ok(match provider {
+        Provider::Cloudflare => Box::new(Cloudflare::new(token)),
+        Provider::DigitalOcean => Box::new(DigitalOcean::new(token)),
+        Provider::Hetzner => Box::new(Hetzner::new(token)),
+    })
+}
+
+/// The record name ACME looks for.
+pub fn challenge_record_name(domain: &str) -> String {
+    format!("_acme-challenge.{}", domain.trim_start_matches("*."))
+}
+
+/// Walks `a.b.example.com` -> `b.example.com` -> `example.com` -> `com`.
+/// Providers key their APIs by registrable zone, but a custom domain can be
+/// any depth of subdomain, so the zone has to be discovered by trying each
+/// suffix rather than assuming the last two labels (which breaks on
+/// `example.co.uk`).
+fn zone_candidates(domain: &str) -> Vec<String> {
+    let base = domain.trim_start_matches("*.");
+    let labels: Vec<&str> = base.split('.').collect();
+    (0..labels.len().saturating_sub(1))
+        .map(|i| labels[i..].join("."))
+        .collect()
+}
+
+fn http() -> anyhow::Result<reqwest::Client> {
+    reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(30))
+        .build()
+        .context("building DNS provider HTTP client")
+}
+
+// ---------- Cloudflare ----------
+
+struct Cloudflare {
+    token: String,
+}
+
+impl Cloudflare {
+    fn new(token: String) -> Self {
+        Self { token }
+    }
+
+    async fn zone_id(&self, domain: &str) -> anyhow::Result<String> {
+        let client = http()?;
+        for candidate in zone_candidates(domain) {
+            let res: serde_json::Value = client
+                .get("https://api.cloudflare.com/client/v4/zones")
+                .bearer_auth(&self.token)
+                .query(&[("name", candidate.as_str())])
+                .send()
+                .await
+                .context("querying Cloudflare zones")?
+                .json()
+                .await
+                .context("parsing Cloudflare zone response")?;
+
+            // A bad token fails identically for every candidate, so surface
+            // Cloudflare's own message instead of the generic "no zone" below.
+            if res.get("success").and_then(|v| v.as_bool()) == Some(false) {
+                anyhow::bail!("Cloudflare rejected the token: {}", errors_of(&res));
+            }
+            if let Some(id) = res
+                .get("result")
+                .and_then(|r| r.as_array())
+                .and_then(|a| a.first())
+                .and_then(|z| z.get("id"))
+                .and_then(|v| v.as_str())
+            {
+                return Ok(id.to_string());
+            }
+        }
+        anyhow::bail!("no Cloudflare zone found for {domain} — is the token scoped to this zone?")
+    }
+}
+
+fn errors_of(res: &serde_json::Value) -> String {
+    res.get("errors")
+        .and_then(|e| e.as_array())
+        .map(|errs| {
+            errs.iter()
+                .filter_map(|e| e.get("message").and_then(|m| m.as_str()))
+                .collect::<Vec<_>>()
+                .join("; ")
+        })
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "unknown error".to_string())
+}
+
+#[async_trait]
+impl DnsProvider for Cloudflare {
+    async fn create_txt(&self, domain: &str, value: &str) -> anyhow::Result<TxtRecord> {
+        let zone_id = self.zone_id(domain).await?;
+        let res: serde_json::Value = http()?
+            .post(format!(
+                "https://api.cloudflare.com/client/v4/zones/{zone_id}/dns_records"
+            ))
+            .bearer_auth(&self.token)
+            .json(&serde_json::json!({
+                "type": "TXT",
+                "name": challenge_record_name(domain),
+                "content": value,
+                "ttl": 60,
+            }))
+            .send()
+            .await
+            .context("creating Cloudflare TXT record")?
+            .json()
+            .await
+            .context("parsing Cloudflare create response")?;
+
+        if res.get("success").and_then(|v| v.as_bool()) != Some(true) {
+            anyhow::bail!("Cloudflare rejected the TXT record: {}", errors_of(&res));
+        }
+
+        let id = res
+            .get("result")
+            .and_then(|r| r.get("id"))
+            .and_then(|v| v.as_str())
+            .context("Cloudflare create response had no record id")?
+            .to_string();
+
+        Ok(TxtRecord {
+            provider_id: id,
+            zone_id,
+        })
+    }
+
+    async fn delete_txt(&self, record: &TxtRecord) -> anyhow::Result<()> {
+        http()?
+            .delete(format!(
+                "https://api.cloudflare.com/client/v4/zones/{}/dns_records/{}",
+                record.zone_id, record.provider_id
+            ))
+            .bearer_auth(&self.token)
+            .send()
+            .await
+            .context("deleting Cloudflare TXT record")?;
+        Ok(())
+    }
+}
+
+// ---------- DigitalOcean ----------
+
+struct DigitalOcean {
+    token: String,
+}
+
+impl DigitalOcean {
+    fn new(token: String) -> Self {
+        Self { token }
+    }
+
+    async fn zone(&self, domain: &str) -> anyhow::Result<String> {
+        let client = http()?;
+        for candidate in zone_candidates(domain) {
+            let res = client
+                .get(format!(
+                    "https://api.digitalocean.com/v2/domains/{candidate}"
+                ))
+                .bearer_auth(&self.token)
+                .send()
+                .await
+                .context("querying DigitalOcean domains")?;
+            if res.status().is_success() {
+                return Ok(candidate);
+            }
+            if res.status() == reqwest::StatusCode::UNAUTHORIZED {
+                anyhow::bail!("DigitalOcean rejected the token");
+            }
+        }
+        anyhow::bail!("no DigitalOcean domain found for {domain}")
+    }
+}
+
+#[async_trait]
+impl DnsProvider for DigitalOcean {
+    async fn create_txt(&self, domain: &str, value: &str) -> anyhow::Result<TxtRecord> {
+        let zone = self.zone(domain).await?;
+        // DigitalOcean wants the record name relative to the zone.
+        let full = challenge_record_name(domain);
+        let name = full
+            .strip_suffix(&format!(".{zone}"))
+            .unwrap_or(&full)
+            .to_string();
+
+        let res: serde_json::Value = http()?
+            .post(format!(
+                "https://api.digitalocean.com/v2/domains/{zone}/records"
+            ))
+            .bearer_auth(&self.token)
+            .json(&serde_json::json!({
+                "type": "TXT",
+                "name": name,
+                "data": value,
+                "ttl": 60,
+            }))
+            .send()
+            .await
+            .context("creating DigitalOcean TXT record")?
+            .json()
+            .await
+            .context("parsing DigitalOcean create response")?;
+
+        let id = res
+            .get("domain_record")
+            .and_then(|r| r.get("id"))
+            .and_then(|v| v.as_i64())
+            .context("DigitalOcean create response had no record id")?;
+
+        Ok(TxtRecord {
+            provider_id: id.to_string(),
+            zone_id: zone,
+        })
+    }
+
+    async fn delete_txt(&self, record: &TxtRecord) -> anyhow::Result<()> {
+        http()?
+            .delete(format!(
+                "https://api.digitalocean.com/v2/domains/{}/records/{}",
+                record.zone_id, record.provider_id
+            ))
+            .bearer_auth(&self.token)
+            .send()
+            .await
+            .context("deleting DigitalOcean TXT record")?;
+        Ok(())
+    }
+}
+
+// ---------- Hetzner ----------
+
+struct Hetzner {
+    token: String,
+}
+
+impl Hetzner {
+    fn new(token: String) -> Self {
+        Self { token }
+    }
+
+    async fn zone_id(&self, domain: &str) -> anyhow::Result<String> {
+        let res: serde_json::Value = http()?
+            .get("https://dns.hetzner.com/api/v1/zones")
+            .header("Auth-API-Token", &self.token)
+            .send()
+            .await
+            .context("querying Hetzner zones")?
+            .json()
+            .await
+            .context("parsing Hetzner zone response")?;
+
+        let zones = res
+            .get("zones")
+            .and_then(|z| z.as_array())
+            .context("Hetzner returned no zone list — is the token valid?")?;
+
+        // Prefer the longest matching zone so a delegated subdomain zone wins
+        // over its parent.
+        for candidate in zone_candidates(domain) {
+            if let Some(id) = zones
+                .iter()
+                .find(|z| z.get("name").and_then(|n| n.as_str()) == Some(candidate.as_str()))
+                .and_then(|z| z.get("id"))
+                .and_then(|v| v.as_str())
+            {
+                return Ok(id.to_string());
+            }
+        }
+        anyhow::bail!("no Hetzner zone found for {domain}")
+    }
+}
+
+#[async_trait]
+impl DnsProvider for Hetzner {
+    async fn create_txt(&self, domain: &str, value: &str) -> anyhow::Result<TxtRecord> {
+        let zone_id = self.zone_id(domain).await?;
+        let res: serde_json::Value = http()?
+            .post("https://dns.hetzner.com/api/v1/records")
+            .header("Auth-API-Token", &self.token)
+            .json(&serde_json::json!({
+                "zone_id": zone_id,
+                "type": "TXT",
+                "name": challenge_record_name(domain),
+                "value": value,
+                "ttl": 60,
+            }))
+            .send()
+            .await
+            .context("creating Hetzner TXT record")?
+            .json()
+            .await
+            .context("parsing Hetzner create response")?;
+
+        let id = res
+            .get("record")
+            .and_then(|r| r.get("id"))
+            .and_then(|v| v.as_str())
+            .context("Hetzner create response had no record id")?
+            .to_string();
+
+        Ok(TxtRecord {
+            provider_id: id,
+            zone_id,
+        })
+    }
+
+    async fn delete_txt(&self, record: &TxtRecord) -> anyhow::Result<()> {
+        http()?
+            .delete(format!(
+                "https://dns.hetzner.com/api/v1/records/{}",
+                record.provider_id
+            ))
+            .header("Auth-API-Token", &self.token)
+            .send()
+            .await
+            .context("deleting Hetzner TXT record")?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn zone_candidates_walk_up_from_most_specific() {
+        assert_eq!(
+            zone_candidates("a.b.example.com"),
+            vec!["a.b.example.com", "b.example.com", "example.com"]
+        );
+    }
+
+    #[test]
+    fn zone_candidates_cover_multi_part_tlds() {
+        // `example.co.uk` is the registrable zone here; assuming the last two
+        // labels would look for `co.uk` and never find it.
+        assert!(zone_candidates("api.example.co.uk").contains(&"example.co.uk".to_string()));
+    }
+
+    #[test]
+    fn challenge_record_is_prefixed_and_unwildcarded() {
+        assert_eq!(
+            challenge_record_name("api.example.com"),
+            "_acme-challenge.api.example.com"
+        );
+        assert_eq!(
+            challenge_record_name("*.example.com"),
+            "_acme-challenge.example.com"
+        );
+    }
+
+    #[test]
+    fn providers_round_trip_through_their_string_form() {
+        for p in Provider::all() {
+            assert_eq!(Provider::parse(p.as_str()).unwrap(), *p);
+            assert!(!p.required_fields().is_empty());
+        }
+        assert!(Provider::parse("route53").is_err());
+    }
+
+    #[test]
+    fn build_rejects_blank_tokens() {
+        let mut secrets = Secrets::new();
+        secrets.insert("apiToken".into(), "   ".into());
+        assert!(build(Provider::Cloudflare, &secrets).is_err());
+        assert!(build(Provider::Cloudflare, &Secrets::new()).is_err());
+    }
+}

--- a/crates/orchestrator/src/acme/mod.rs
+++ b/crates/orchestrator/src/acme/mod.rs
@@ -1,0 +1,409 @@
+//! ACME certificate issuance for custom domains.
+//!
+//! # Why the orchestrator does this instead of Traefik
+//!
+//! Traefik can absolutely run ACME itself — but `certificatesResolvers` is
+//! *static* configuration. Adding a provider or rotating a DNS API token
+//! means editing the compose file and restarting Traefik. That rules it out
+//! for a dashboard-driven workflow.
+//!
+//! Traefik's *dynamic* (file) provider, by contrast, hot-reloads routers and
+//! `tls.certificates`. So the orchestrator owns the ACME conversation and
+//! hands Traefik finished certificates. Consequences:
+//!
+//! - DNS credentials live in Postgres (sealed), entered in the dashboard, and
+//!   take effect on the next issuance — no restart, no SSH.
+//! - Adding a DNS provider is a code change here, not an operator-facing
+//!   configuration change.
+//! - Custom domains need *zero* static Traefik configuration beyond pointing
+//!   the file provider at a directory.
+//!
+//! # Challenges
+//!
+//! - `http-01` needs no credentials at all. Traefik routes
+//!   `/.well-known/acme-challenge/` for the domain to the orchestrator (via a
+//!   dynamic router it writes itself), which serves the token from
+//!   [`ChallengeStore`].
+//! - `dns-01` works when port 80 isn't reachable, and is the only way to get
+//!   a wildcard. It needs a provider token — see [`dns_providers`].
+
+pub mod dns_providers;
+pub mod renewal;
+
+use std::{
+    collections::HashMap,
+    sync::Arc,
+    time::Duration,
+};
+
+use anyhow::Context;
+use instant_acme::{
+    Account,
+    AccountCredentials,
+    AuthorizationStatus,
+    ChallengeType,
+    Identifier,
+    LetsEncrypt,
+    NewAccount,
+    NewOrder,
+    OrderStatus,
+};
+use parking_lot::Mutex;
+
+use crate::{
+    acme::dns_providers::{
+        DnsProvider,
+        Provider,
+        Secrets,
+    },
+    state::OrchestratorState,
+    time::now_unix_ms,
+};
+
+/// Certificates are renewed well before the 90-day Let's Encrypt lifetime so
+/// a few failed attempts don't turn into an outage.
+const RENEW_AFTER_MS: i64 = 60 * 24 * 60 * 60 * 1000;
+
+/// How long to wait for the ACME server to validate a challenge before
+/// giving up. DNS propagation is the slow part.
+const VALIDATION_TIMEOUT: Duration = Duration::from_secs(180);
+const POLL_INTERVAL: Duration = Duration::from_secs(3);
+
+/// Gap between publishing a TXT record and telling the ACME server to check
+/// it. Without this the server frequently reads a stale negative answer from
+/// its resolver cache and fails the authorization outright.
+const DNS_PROPAGATION_DELAY: Duration = Duration::from_secs(15);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ChallengeKind {
+    Http01,
+    Dns01,
+}
+
+impl ChallengeKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            ChallengeKind::Http01 => "http-01",
+            ChallengeKind::Dns01 => "dns-01",
+        }
+    }
+
+    pub fn parse(s: &str) -> anyhow::Result<Self> {
+        match s {
+            "http-01" => Ok(ChallengeKind::Http01),
+            "dns-01" => Ok(ChallengeKind::Dns01),
+            other => anyhow::bail!("unknown challenge type {other:?}"),
+        }
+    }
+}
+
+/// In-flight HTTP-01 tokens, keyed by challenge token. Populated for the
+/// duration of an issuance and served by the orchestrator's
+/// `/.well-known/acme-challenge/{token}` route.
+#[derive(Clone, Default)]
+pub struct ChallengeStore(Arc<Mutex<HashMap<String, String>>>);
+
+impl ChallengeStore {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn insert(&self, token: String, key_authorization: String) {
+        self.0.lock().insert(token, key_authorization);
+    }
+
+    pub fn get(&self, token: &str) -> Option<String> {
+        self.0.lock().get(token).cloned()
+    }
+
+    pub fn remove(&self, token: &str) {
+        self.0.lock().remove(token);
+    }
+}
+
+pub struct IssuedCertificate {
+    pub cert_pem: String,
+    pub key_pem: String,
+    pub issued_at: i64,
+    pub renew_after: i64,
+}
+
+/// Loads the stored ACME account, creating and persisting one on first use.
+///
+/// The account key is what proves to Let's Encrypt that we're the same
+/// client across renewals, so it's sealed with the same secretbox the DNS
+/// credentials use.
+async fn account(state: &OrchestratorState) -> anyhow::Result<Account> {
+    let directory = directory_url(state);
+
+    if let Some(record) = state
+        .storage
+        .get_acme_account(&directory)
+        .await
+        .context("loading ACME account")?
+    {
+        let plaintext = state
+            .secrets
+            .open(&record.credentials)
+            .context("decrypting ACME account credentials")?;
+        let credentials: AccountCredentials = serde_json::from_slice(&plaintext)
+            .context("parsing stored ACME account credentials")?;
+        return Account::from_credentials(credentials)
+            .await
+            .context("restoring ACME account");
+    }
+
+    let contact = state
+        .config
+        .acme_contact_email
+        .as_ref()
+        .map(|e| format!("mailto:{e}"));
+    let contacts: Vec<&str> = contact.iter().map(|s| s.as_str()).collect();
+
+    let (acct, credentials) = Account::create(
+        &NewAccount {
+            contact: &contacts,
+            terms_of_service_agreed: true,
+            only_return_existing: false,
+        },
+        &directory,
+        None,
+    )
+    .await
+    .context("creating ACME account")?;
+
+    let sealed = state
+        .secrets
+        .seal(&serde_json::to_vec(&credentials).context("serializing ACME credentials")?);
+    state
+        .storage
+        .upsert_acme_account(&directory, acct.id(), &sealed)
+        .await
+        .context("storing ACME account")?;
+
+    Ok(acct)
+}
+
+fn directory_url(state: &OrchestratorState) -> String {
+    state
+        .config
+        .acme_directory_url
+        .clone()
+        .unwrap_or_else(|| LetsEncrypt::Production.url().to_string())
+}
+
+/// Runs a full ACME order for `domain` and returns the issued certificate.
+///
+/// `dns` must be supplied for [`ChallengeKind::Dns01`]; it's ignored for
+/// HTTP-01, which needs no credentials.
+pub async fn issue(
+    state: &OrchestratorState,
+    domain: &str,
+    challenge_kind: ChallengeKind,
+    dns: Option<(Provider, Secrets)>,
+) -> anyhow::Result<IssuedCertificate> {
+    let account = account(state).await?;
+
+    let identifiers = [Identifier::Dns(domain.to_string())];
+    let mut order = account
+        .new_order(&NewOrder {
+            identifiers: &identifiers,
+        })
+        .await
+        .context("creating ACME order")?;
+
+    let authorizations = order
+        .authorizations()
+        .await
+        .context("fetching ACME authorizations")?;
+
+    // Tracks what we published so cleanup runs even on the error paths.
+    let mut http_tokens: Vec<String> = Vec::new();
+    let mut dns_records: Vec<(Box<dyn DnsProvider>, dns_providers::TxtRecord)> = Vec::new();
+
+    let result = async {
+        let mut needs_dns_delay = false;
+
+        for authz in &authorizations {
+            if authz.status == AuthorizationStatus::Valid {
+                // Already validated from a previous order — nothing to do.
+                continue;
+            }
+
+            let wanted = match challenge_kind {
+                ChallengeKind::Http01 => ChallengeType::Http01,
+                ChallengeKind::Dns01 => ChallengeType::Dns01,
+            };
+            let challenge = authz
+                .challenges
+                .iter()
+                .find(|c| c.r#type == wanted)
+                .with_context(|| {
+                    format!(
+                        "the ACME server offered no {} challenge for this domain",
+                        challenge_kind.as_str()
+                    )
+                })?;
+
+            let key_auth = order.key_authorization(challenge);
+            let Identifier::Dns(authz_domain) = &authz.identifier;
+
+            match challenge_kind {
+                ChallengeKind::Http01 => {
+                    state
+                        .challenges
+                        .insert(challenge.token.clone(), key_auth.as_str().to_string());
+                    http_tokens.push(challenge.token.clone());
+                },
+                ChallengeKind::Dns01 => {
+                    let (provider, secrets) = dns.as_ref().context(
+                        "the dns-01 challenge needs DNS provider credentials, but none were \
+                         selected",
+                    )?;
+                    let client = dns_providers::build(*provider, secrets)?;
+                    let record = client
+                        .create_txt(authz_domain, &key_auth.dns_value())
+                        .await
+                        .with_context(|| format!("publishing the DNS-01 record for {authz_domain}"))?;
+                    dns_records.push((client, record));
+                    needs_dns_delay = true;
+                },
+            }
+        }
+
+        // Give recursive resolvers a chance to see the new TXT record before
+        // the ACME server queries them.
+        if needs_dns_delay {
+            tokio::time::sleep(DNS_PROPAGATION_DELAY).await;
+        }
+
+        for authz in &authorizations {
+            if authz.status == AuthorizationStatus::Valid {
+                continue;
+            }
+            let wanted = match challenge_kind {
+                ChallengeKind::Http01 => ChallengeType::Http01,
+                ChallengeKind::Dns01 => ChallengeType::Dns01,
+            };
+            if let Some(challenge) = authz.challenges.iter().find(|c| c.r#type == wanted) {
+                let url = challenge.url.clone();
+                order
+                    .set_challenge_ready(&url)
+                    .await
+                    .context("telling the ACME server the challenge is ready")?;
+            }
+        }
+
+        wait_until_ready(&mut order).await?;
+
+        // Order is authorized; generate a fresh keypair and CSR for it.
+        let params = rcgen::CertificateParams::new(vec![domain.to_string()])
+            .context("building certificate params")?;
+        let keypair = rcgen::KeyPair::generate().context("generating certificate key")?;
+        let csr = params
+            .serialize_request(&keypair)
+            .context("building certificate signing request")?;
+
+        order
+            .finalize(csr.der())
+            .await
+            .context("finalizing the ACME order")?;
+
+        let cert_pem = wait_for_certificate(&mut order).await?;
+        let issued_at = now_unix_ms();
+
+        Ok::<_, anyhow::Error>(IssuedCertificate {
+            cert_pem,
+            key_pem: keypair.serialize_pem(),
+            issued_at,
+            renew_after: issued_at + RENEW_AFTER_MS,
+        })
+    }
+    .await;
+
+    // Cleanup regardless of outcome. Neither failure is worth surfacing over
+    // the actual issuance result: a leftover TXT record or in-memory token is
+    // untidy, not broken.
+    for token in http_tokens {
+        state.challenges.remove(&token);
+    }
+    for (client, record) in dns_records {
+        if let Err(e) = client.delete_txt(&record).await {
+            tracing::warn!(error = %e, "failed to clean up DNS-01 challenge record");
+        }
+    }
+
+    result
+}
+
+async fn wait_until_ready(order: &mut instant_acme::Order) -> anyhow::Result<()> {
+    let deadline = tokio::time::Instant::now() + VALIDATION_TIMEOUT;
+    loop {
+        let state = order.refresh().await.context("polling ACME order")?;
+        match state.status {
+            OrderStatus::Ready | OrderStatus::Valid => return Ok(()),
+            OrderStatus::Invalid => {
+                anyhow::bail!(
+                    "the ACME server could not validate this domain{}",
+                    state
+                        .error
+                        .as_ref()
+                        .map(|e| format!(": {}", e.detail.as_deref().unwrap_or("no detail")))
+                        .unwrap_or_default()
+                )
+            },
+            OrderStatus::Pending | OrderStatus::Processing => {
+                anyhow::ensure!(
+                    tokio::time::Instant::now() < deadline,
+                    "timed out waiting for the ACME server to validate this domain — check that \
+                     DNS points here (http-01) or that the provider token can edit this zone \
+                     (dns-01)"
+                );
+                tokio::time::sleep(POLL_INTERVAL).await;
+            },
+        }
+    }
+}
+
+async fn wait_for_certificate(order: &mut instant_acme::Order) -> anyhow::Result<String> {
+    let deadline = tokio::time::Instant::now() + VALIDATION_TIMEOUT;
+    loop {
+        if let Some(pem) = order.certificate().await.context("downloading certificate")? {
+            return Ok(pem);
+        }
+        anyhow::ensure!(
+            tokio::time::Instant::now() < deadline,
+            "timed out waiting for the ACME server to sign the certificate"
+        );
+        tokio::time::sleep(POLL_INTERVAL).await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn challenge_kinds_round_trip() {
+        for kind in [ChallengeKind::Http01, ChallengeKind::Dns01] {
+            assert_eq!(ChallengeKind::parse(kind.as_str()).unwrap(), kind);
+        }
+        assert!(ChallengeKind::parse("tls-alpn-01").is_err());
+    }
+
+    #[test]
+    fn challenge_store_serves_then_forgets_tokens() {
+        let store = ChallengeStore::new();
+        store.insert("tok".into(), "tok.thumbprint".into());
+        assert_eq!(store.get("tok").as_deref(), Some("tok.thumbprint"));
+        store.remove("tok");
+        assert_eq!(store.get("tok"), None);
+    }
+
+    #[test]
+    fn renewal_is_well_inside_the_certificate_lifetime() {
+        // Let's Encrypt issues for 90 days; renewing at 60 leaves a month of
+        // failed attempts before anything actually breaks.
+        assert!(RENEW_AFTER_MS < 90 * 24 * 60 * 60 * 1000);
+    }
+}

--- a/crates/orchestrator/src/acme/renewal.rs
+++ b/crates/orchestrator/src/acme/renewal.rs
@@ -1,0 +1,63 @@
+//! Background certificate renewal.
+//!
+//! Also picks up domains that have *no* certificate — a first issuance that
+//! failed because DNS wasn't pointed here yet, or because the ACME server was
+//! unreachable. That makes the common "I added the domain before the CNAME
+//! propagated" case self-healing instead of requiring the operator to notice
+//! and hit retry.
+
+use std::time::Duration;
+
+use crate::{
+    routes::dashboard::custom_domains::spawn_issuance,
+    state::OrchestratorState,
+    time::now_unix_ms,
+};
+
+/// How often to look for work. Certificates last 90 days and are renewed at
+/// 60, so this only has to be frequent enough to retry transient failures at
+/// a sensible pace — not to hit a deadline.
+const SWEEP_INTERVAL: Duration = Duration::from_secs(60 * 60);
+
+/// Delay before the first sweep, so a restart loop can't hammer the ACME
+/// server's rate limits.
+const STARTUP_DELAY: Duration = Duration::from_secs(60);
+
+pub fn spawn(state: OrchestratorState) {
+    if state.config.traefik_dynamic_dir.is_none() {
+        tracing::info!("custom domains disabled; not starting the renewal sweeper");
+        return;
+    }
+
+    tokio::spawn(async move {
+        tokio::time::sleep(STARTUP_DELAY).await;
+        loop {
+            if let Err(e) = sweep(&state).await {
+                tracing::warn!(error = %format!("{e:#}"), "certificate renewal sweep failed");
+            }
+            tokio::time::sleep(SWEEP_INTERVAL).await;
+        }
+    });
+}
+
+async fn sweep(state: &OrchestratorState) -> anyhow::Result<()> {
+    let due = state
+        .storage
+        .domains_needing_certificates(now_unix_ms())
+        .await?;
+
+    if due.is_empty() {
+        return Ok(());
+    }
+
+    tracing::info!(count = due.len(), "issuing/renewing certificates");
+    for domain in due {
+        // Skip domains currently mid-issuance so a slow order isn't started
+        // twice by an overlapping sweep.
+        if domain.cert_state == "issuing" {
+            continue;
+        }
+        spawn_issuance(state.clone(), domain.domain);
+    }
+    Ok(())
+}

--- a/crates/orchestrator/src/config.rs
+++ b/crates/orchestrator/src/config.rs
@@ -55,6 +55,24 @@ pub struct OrchestratorConfig {
     pub postgres_image: String,
     /// Docker image for the MinIO sidecar (used when `enable_sidecars`).
     pub minio_image: String,
+    /// Directory watched by Traefik's file provider. When set, the
+    /// orchestrator renders one router/service pair per custom domain into
+    /// `<dir>/custom-domains.yml` so domains added after a backend container
+    /// was created still route (docker labels are fixed at create time).
+    /// `None` disables custom domains entirely.
+    pub traefik_dynamic_dir: Option<PathBuf>,
+    /// Host:port Traefik uses to reach the orchestrator when forwarding ACME
+    /// HTTP-01 challenge requests, e.g. `orchestrator:8050`.
+    pub orchestrator_upstream: String,
+    /// Path the certificate directory is mounted at *inside the Traefik
+    /// container*. May differ from `traefik_dynamic_dir`, which is this
+    /// process's view of the same volume.
+    pub traefik_cert_dir: String,
+    /// Contact address registered with the ACME server (renewal warnings).
+    pub acme_contact_email: Option<String>,
+    /// ACME directory to use. Defaults to Let's Encrypt production; point at
+    /// the staging directory to exercise the flow without burning rate limit.
+    pub acme_directory_url: Option<String>,
 }
 
 impl OrchestratorConfig {
@@ -164,6 +182,11 @@ mod tests {
             enable_sidecars,
             postgres_image: "postgres:16-alpine".into(),
             minio_image: "quay.io/minio/minio:latest".into(),
+            traefik_dynamic_dir: None,
+            orchestrator_upstream: "orchestrator:8050".into(),
+            traefik_cert_dir: "/dynamic".into(),
+            acme_contact_email: None,
+            acme_directory_url: None,
         }
     }
 

--- a/crates/orchestrator/src/custom_domains.rs
+++ b/crates/orchestrator/src/custom_domains.rs
@@ -1,0 +1,453 @@
+//! Custom domain routing and certificate delivery.
+//!
+//! Spawned backends get their Traefik routers from docker labels
+//! (`provisioner::docker`), but labels are fixed when the container is
+//! created — a domain added later would never reach it. So custom domains go
+//! through Traefik's *file* provider instead: the orchestrator renders every
+//! domain into one YAML file that Traefik watches and hot-reloads.
+//!
+//! Certificates are issued by the orchestrator (see [`crate::acme`]) rather
+//! than by Traefik, because Traefik's `certificatesResolvers` are static
+//! configuration and could never be driven from the dashboard. We write the
+//! PEMs next to the config and reference them under `tls.certificates`,
+//! which the file provider *does* hot-reload. The upshot is that custom
+//! domains need no static Traefik configuration at all beyond pointing the
+//! file provider at this directory — no restarts, no editing compose over
+//! SSH.
+//!
+//! The file is always rewritten in full from the database rather than
+//! patched, so a crash mid-update can't leave a half-applied routing table:
+//! whatever is in Postgres is the truth, and the next write reconciles.
+
+use std::{
+    collections::BTreeSet,
+    path::{
+        Path,
+        PathBuf,
+    },
+};
+
+use anyhow::Context;
+
+use crate::{
+    state::OrchestratorState,
+    storage::{
+        CustomDomainRoute,
+        StoredCertificate,
+    },
+};
+
+/// Filename written into the Traefik dynamic directory. Stable so each
+/// rewrite replaces the previous routing table wholesale.
+const CONFIG_FILENAME: &str = "custom-domains.yml";
+/// Config lives in its own subdirectory, and Traefik's file provider watches
+/// *that* rather than the volume root. The provider parses every file in the
+/// directory it's pointed at, so keeping PEMs out of it is what stops Traefik
+/// from trying to read a certificate as dynamic configuration.
+const CONFIG_DIRNAME: &str = "conf";
+/// Sibling subdirectory holding the PEMs referenced by the config above.
+const CERT_DIRNAME: &str = "certs";
+
+/// Ports the backend serves the Convex API and HTTP actions on. Same values
+/// the docker-label routers use.
+const BACKEND_API_PORT: u16 = 3210;
+const BACKEND_SITE_PORT: u16 = 3211;
+
+/// Rejects anything that isn't a plausible public hostname before it reaches
+/// the routing table. A domain flows into a Traefik `Host()` rule, so a value
+/// containing backticks or newlines could otherwise break out of the rule and
+/// rewrite unrelated routing.
+pub fn validate_domain(domain: &str) -> anyhow::Result<String> {
+    let normalized = domain.trim().trim_end_matches('.').to_ascii_lowercase();
+
+    anyhow::ensure!(!normalized.is_empty(), "domain must not be empty");
+    anyhow::ensure!(
+        normalized.len() <= 253,
+        "domain must be 253 characters or fewer"
+    );
+    anyhow::ensure!(
+        normalized.contains('.'),
+        "domain must be fully qualified (e.g. api.example.com)"
+    );
+    anyhow::ensure!(
+        !normalized.starts_with('-') && !normalized.starts_with('.'),
+        "domain must not start with '-' or '.'"
+    );
+    // A wildcard needs a DNS-01 challenge, which needs provider credentials.
+    // Allowed, but only the leading label may be `*`.
+    let body = normalized.strip_prefix("*.").unwrap_or(&normalized);
+    anyhow::ensure!(
+        !body.contains('*'),
+        "'*' is only allowed as the leading label (e.g. *.example.com)"
+    );
+
+    for label in body.split('.') {
+        anyhow::ensure!(!label.is_empty(), "domain must not contain empty labels");
+        anyhow::ensure!(
+            label.len() <= 63,
+            "each domain label must be 63 characters or fewer"
+        );
+        anyhow::ensure!(
+            label.chars().all(|c| c.is_ascii_alphanumeric() || c == '-'),
+            "domain labels may only contain letters, digits, and '-'"
+        );
+        anyhow::ensure!(
+            !label.starts_with('-') && !label.ends_with('-'),
+            "domain labels must not start or end with '-'"
+        );
+    }
+
+    Ok(normalized)
+}
+
+/// Traefik router/service names must be unique and stable per domain. Dots
+/// and other separators are collapsed so the name stays a single YAML key.
+fn router_key(domain: &str) -> String {
+    let slug: String = domain
+        .chars()
+        .map(|c| if c.is_ascii_alphanumeric() { c } else { '-' })
+        .collect();
+    format!("convex-custom-{slug}")
+}
+
+/// Filename (not path) of the PEM pair for a domain.
+fn cert_stem(domain: &str) -> String {
+    domain
+        .chars()
+        .map(|c| if c.is_ascii_alphanumeric() { c } else { '-' })
+        .collect()
+}
+
+/// Where the orchestrator serves ACME HTTP-01 challenge responses. Traefik
+/// routes this path for every custom domain, on the plain `web` entrypoint,
+/// so a domain can be validated *before* it has a certificate.
+const ACME_CHALLENGE_PATH: &str = "/.well-known/acme-challenge/";
+
+pub struct RenderInput<'a> {
+    pub routes: &'a [CustomDomainRoute],
+    pub certificates: &'a [StoredCertificate],
+    pub container_prefix: &'a str,
+    /// Host:port Traefik uses to reach the orchestrator for challenge
+    /// responses, e.g. `orchestrator:8050`.
+    pub orchestrator_upstream: &'a str,
+    /// Directory the PEMs live in, as Traefik sees it.
+    pub cert_dir: &'a str,
+}
+
+/// Renders the dynamic config. Kept pure (no I/O) so the exact YAML Traefik
+/// will consume can be asserted in tests.
+pub fn render_config(input: RenderInput<'_>) -> String {
+    let mut routers = String::new();
+    let mut services = String::new();
+    let mut certificates = String::new();
+
+    // `domain` is UNIQUE in the schema, but guard anyway: a duplicate key
+    // would silently drop a router when Traefik parses the YAML.
+    let mut seen = BTreeSet::new();
+
+    // One challenge router shared by all custom domains. It matches the ACME
+    // path on *any* host on the plain HTTP entrypoint; the ACME server only
+    // ever requests it for domains we asked it to validate.
+    if !input.routes.is_empty() {
+        // Listens on *both* entrypoints on purpose. The `web` entrypoint has
+        // a global http->https redirection whose internal router outranks
+        // anything we can declare here, so a challenge request gets bounced
+        // to `websecure` — where the domain has no valid certificate yet.
+        // That's fine: Let's Encrypt follows redirects during HTTP-01 and
+        // deliberately does not validate the certificate on the target. But
+        // it only works if the challenge path is also routed on websecure,
+        // otherwise the redirected request lands on the backend and 404s.
+        routers.push_str(&format!(
+            "    convex-acme-challenge:\n      rule: \"PathPrefix(`{ACME_CHALLENGE_PATH}`)\"\n     \
+             \x20priority: 9000\n      entryPoints:\n        - web\n        - websecure\n      \
+             service: convex-acme-challenge\n      tls: {{}}\n"
+        ));
+        services.push_str(&format!(
+            "    convex-acme-challenge:\n      loadBalancer:\n        servers:\n          - url: \
+             \"http://{}\"\n",
+            input.orchestrator_upstream
+        ));
+    }
+
+    for route in input.routes {
+        if !seen.insert(route.domain.as_str()) {
+            continue;
+        }
+        let key = router_key(&route.domain);
+        let upstream = format!("{}{}", input.container_prefix, route.deployment_name);
+
+        routers.push_str(&format!(
+            "    {key}:\n      rule: \"Host(`{domain}`)\"\n      priority: 100\n      \
+             entryPoints:\n        - websecure\n      service: {key}\n      tls: {{}}\n",
+            key = key,
+            domain = route.domain,
+        ));
+        services.push_str(&format!(
+            "    {key}:\n      loadBalancer:\n        servers:\n          - url: \
+             \"http://{upstream}:{port}\"\n",
+            key = key,
+            upstream = upstream,
+            port = BACKEND_API_PORT,
+        ));
+    }
+
+    // Only reference PEMs that actually exist on disk. A domain without a
+    // certificate still gets a router — Traefik serves its default cert and
+    // the browser warns — which is strictly better than dropping the route
+    // and is visible in the dashboard as `pending`.
+    for cert in input.certificates {
+        let stem = cert_stem(&cert.domain);
+        certificates.push_str(&format!(
+            "    - certFile: \"{dir}/{stem}.crt\"\n      keyFile: \"{dir}/{stem}.key\"\n",
+            dir = input.cert_dir,
+            stem = stem,
+        ));
+    }
+
+    let mut out = String::from("# Managed by convex-orchestrator. Do not edit by hand.\n");
+
+    if routers.is_empty() {
+        // Traefik treats an empty `http:` mapping as malformed, so emit
+        // explicit empty maps when nothing is configured.
+        out.push_str("http:\n  routers: {}\n  services: {}\n");
+    } else {
+        out.push_str("http:\n  routers:\n");
+        out.push_str(&routers);
+        out.push_str("  services:\n");
+        out.push_str(&services);
+    }
+
+    if !certificates.is_empty() {
+        out.push_str("tls:\n  certificates:\n");
+        out.push_str(&certificates);
+    }
+
+    out
+}
+
+/// Port the HTTP-actions ("site") origin would use. Exposed so the dashboard
+/// copy and any future second-hostname support stay in sync with the router.
+pub const fn site_port() -> u16 {
+    BACKEND_SITE_PORT
+}
+
+fn config_path(dir: &Path) -> PathBuf {
+    dir.join(CONFIG_DIRNAME).join(CONFIG_FILENAME)
+}
+
+/// Re-renders the whole custom-domain routing table from the database and
+/// writes it, plus every stored certificate, into the Traefik dynamic
+/// directory. No-op when the feature is disabled (no directory configured).
+///
+/// Writes go to a temp file and are then renamed, because Traefik watches the
+/// directory and would otherwise happily load a truncated file.
+pub async fn sync_traefik_config(state: &OrchestratorState) -> anyhow::Result<()> {
+    let Some(dir) = state.config.traefik_dynamic_dir.clone() else {
+        return Ok(());
+    };
+
+    let routes = state
+        .storage
+        .list_all_custom_domain_routes()
+        .await
+        .context("listing custom domains for Traefik config")?;
+    let certificates = state
+        .storage
+        .list_certificates()
+        .await
+        .context("listing certificates for Traefik config")?;
+
+    let conf_dir = dir.join(CONFIG_DIRNAME);
+    std::fs::create_dir_all(&conf_dir)
+        .with_context(|| format!("creating Traefik config dir {conf_dir:?}"))?;
+    let cert_dir = dir.join(CERT_DIRNAME);
+    std::fs::create_dir_all(&cert_dir)
+        .with_context(|| format!("creating certificate dir {cert_dir:?}"))?;
+
+    // Write PEMs before the config that references them, so Traefik never
+    // reloads a config pointing at a file that isn't there yet.
+    for cert in &certificates {
+        let stem = cert_stem(&cert.domain);
+        write_atomic(&cert_dir.join(format!("{stem}.crt")), &cert.cert_pem)?;
+        write_atomic(&cert_dir.join(format!("{stem}.key")), &cert.key_pem)?;
+    }
+
+    let body = render_config(RenderInput {
+        routes: &routes,
+        certificates: &certificates,
+        container_prefix: &state.config.backend_container_prefix,
+        orchestrator_upstream: &state.config.orchestrator_upstream,
+        // Traefik sees the same volume; the path is whatever it's mounted at
+        // on its side.
+        cert_dir: &format!("{}/{CERT_DIRNAME}", state.config.traefik_cert_dir),
+    });
+
+    write_atomic(&config_path(&dir), &body)?;
+
+    tracing::info!(
+        domains = routes.len(),
+        certificates = certificates.len(),
+        path = ?config_path(&dir),
+        "wrote Traefik custom-domain config"
+    );
+    Ok(())
+}
+
+fn write_atomic(path: &Path, body: &str) -> anyhow::Result<()> {
+    let tmp = path.with_extension("tmp");
+    std::fs::write(&tmp, body).with_context(|| format!("writing {tmp:?}"))?;
+    std::fs::rename(&tmp, path).with_context(|| format!("renaming {tmp:?} -> {path:?}"))?;
+    Ok(())
+}
+
+/// Probes the domain over HTTPS to confirm Traefik is serving it with a
+/// certificate the platform's own TLS stack accepts. Issuance succeeding
+/// doesn't prove the routing works, so the dashboard's "active" state is
+/// driven from this rather than from the ACME result.
+pub async fn probe_domain(domain: &str) -> (String, Option<String>) {
+    let url = format!("https://{domain}/instance_name");
+    let client = match reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(10))
+        .build()
+    {
+        Ok(c) => c,
+        Err(e) => return ("pending".to_string(), Some(e.to_string())),
+    };
+
+    match client.get(&url).send().await {
+        // Any HTTP response at all means TLS completed against a cert the
+        // client trusts. The status code reflects the backend, not the domain.
+        Ok(_) => ("active".to_string(), None),
+        Err(e) => ("pending".to_string(), Some(e.to_string())),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn route(domain: &str, deployment: &str) -> CustomDomainRoute {
+        CustomDomainRoute {
+            domain: domain.to_string(),
+            deployment_name: deployment.to_string(),
+        }
+    }
+
+    fn cert(domain: &str) -> StoredCertificate {
+        StoredCertificate {
+            domain: domain.to_string(),
+            cert_pem: "cert".into(),
+            key_pem: "key".into(),
+            issued_at: 0,
+            renew_after: 0,
+        }
+    }
+
+    fn render(routes: &[CustomDomainRoute], certs: &[StoredCertificate]) -> String {
+        render_config(RenderInput {
+            routes,
+            certificates: certs,
+            container_prefix: "orchestrator-",
+            orchestrator_upstream: "orchestrator:8050",
+            cert_dir: "/dynamic/certs",
+        })
+    }
+
+    #[test]
+    fn normalizes_domains() {
+        assert_eq!(
+            validate_domain(" API.Example.COM. ").unwrap(),
+            "api.example.com"
+        );
+    }
+
+    #[test]
+    fn rejects_domains_that_could_break_out_of_the_traefik_rule() {
+        for bad in [
+            "",
+            "example",
+            "ex`ample.com",
+            "example.com`)||Host(`evil.com",
+            "-lead.example.com",
+            "trail-.example.com",
+            "double..dot.com",
+            "sub.*.example.com",
+        ] {
+            assert!(
+                validate_domain(bad).is_err(),
+                "expected {bad:?} to be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn accepts_a_leading_wildcard() {
+        // Wildcards are legitimate now that dns-01 is supported.
+        assert_eq!(validate_domain("*.example.com").unwrap(), "*.example.com");
+    }
+
+    #[test]
+    fn renders_a_router_and_service_per_domain() {
+        let config = render(&[route("api.example.com", "happy-otter-123")], &[]);
+        assert!(config.contains("convex-custom-api-example-com:"));
+        assert!(config.contains("rule: \"Host(`api.example.com`)\""));
+        assert!(config.contains("url: \"http://orchestrator-happy-otter-123:3210\""));
+    }
+
+    #[test]
+    fn never_references_a_traefik_cert_resolver() {
+        // Cert resolvers are static Traefik config; relying on one would put
+        // this feature back behind a restart. Certificates must come from
+        // `tls.certificates` instead.
+        let config = render(
+            &[route("api.example.com", "one")],
+            &[cert("api.example.com")],
+        );
+        assert!(!config.contains("certResolver"));
+        assert!(config.contains("tls:\n  certificates:"));
+        assert!(config.contains("certFile: \"/dynamic/certs/api-example-com.crt\""));
+        assert!(config.contains("keyFile: \"/dynamic/certs/api-example-com.key\""));
+    }
+
+    #[test]
+    fn routes_the_acme_challenge_path_on_both_entrypoints() {
+        // HTTP-01 has to work before any certificate exists. The global
+        // http->https redirect outranks anything the file provider can
+        // declare, so the challenge must also be served on websecure — Let's
+        // Encrypt follows the redirect and ignores the (missing) cert, but
+        // only reaches us if that path is routed there too.
+        let config = render(&[route("api.example.com", "one")], &[]);
+        assert!(config.contains("PathPrefix(`/.well-known/acme-challenge/`)"));
+        assert!(config.contains("        - web\n        - websecure\n"));
+        assert!(config.contains("priority: 9000"));
+        assert!(config.contains("url: \"http://orchestrator:8050\""));
+    }
+
+    #[test]
+    fn a_domain_without_a_certificate_still_routes() {
+        let config = render(&[route("api.example.com", "one")], &[]);
+        assert!(config.contains("convex-custom-api-example-com:"));
+        assert!(!config.contains("tls:\n  certificates:"));
+    }
+
+    #[test]
+    fn renders_valid_yaml_when_there_are_no_domains() {
+        let config = render(&[], &[]);
+        assert!(config.contains("routers: {}"));
+        assert!(config.contains("services: {}"));
+        assert!(!config.contains("acme-challenge"));
+    }
+
+    #[test]
+    fn skips_duplicate_domains() {
+        let config = render(
+            &[
+                route("api.example.com", "one"),
+                route("api.example.com", "two"),
+            ],
+            &[],
+        );
+        assert!(config.contains("orchestrator-one:3210"));
+        assert!(!config.contains("orchestrator-two"));
+    }
+}

--- a/crates/orchestrator/src/lib.rs
+++ b/crates/orchestrator/src/lib.rs
@@ -4,8 +4,10 @@
 //! See `docs/superpowers/specs/2026-05-02-convex-orchestrator-design.md`
 //! for the full design.
 
+pub mod acme;
 pub mod auth;
 pub mod config;
+pub mod custom_domains;
 pub mod host_capacity;
 pub mod errors;
 pub mod ids;
@@ -14,6 +16,7 @@ pub mod provisioner;
 pub mod proxy;
 pub mod router;
 pub mod routes;
+pub mod secrets;
 pub mod state;
 pub mod storage;
 pub mod stub_data;

--- a/crates/orchestrator/src/main.rs
+++ b/crates/orchestrator/src/main.rs
@@ -183,6 +183,39 @@ struct Args {
         default_value = "quay.io/minio/minio:latest"
     )]
     minio_image: String,
+
+    /// Directory watched by Traefik's file provider. Custom-domain routers
+    /// are rendered here; unset disables the custom domains feature.
+    #[arg(long, env = "CONVEX_ORCHESTRATOR_TRAEFIK_DYNAMIC_DIR")]
+    traefik_dynamic_dir: Option<PathBuf>,
+
+    /// Host:port Traefik uses to reach this orchestrator when forwarding
+    /// ACME HTTP-01 challenge requests.
+    #[arg(
+        long,
+        env = "CONVEX_ORCHESTRATOR_UPSTREAM",
+        default_value = "orchestrator:8050"
+    )]
+    orchestrator_upstream: String,
+
+    /// Path the Traefik dynamic directory is mounted at inside the Traefik
+    /// container (this process may see it at a different path).
+    #[arg(
+        long,
+        env = "CONVEX_ORCHESTRATOR_TRAEFIK_CERT_DIR",
+        default_value = "/dynamic"
+    )]
+    traefik_cert_dir: String,
+
+    /// Contact address registered with the ACME server, used only for
+    /// expiry warnings.
+    #[arg(long, env = "CONVEX_ORCHESTRATOR_ACME_CONTACT_EMAIL")]
+    acme_contact_email: Option<String>,
+
+    /// ACME directory URL. Defaults to Let's Encrypt production; point at
+    /// their staging directory to test without burning rate limit.
+    #[arg(long, env = "CONVEX_ORCHESTRATOR_ACME_DIRECTORY_URL")]
+    acme_directory_url: Option<String>,
 }
 
 fn init_tracing() {
@@ -230,11 +263,30 @@ async fn main() -> anyhow::Result<()> {
         enable_sidecars: args.enable_sidecars,
         postgres_image: args.postgres_image,
         minio_image: args.minio_image,
+        traefik_dynamic_dir: args.traefik_dynamic_dir,
+        orchestrator_upstream: args.orchestrator_upstream,
+        traefik_cert_dir: args.traefik_cert_dir,
+        acme_contact_email: args.acme_contact_email,
+        acme_directory_url: args.acme_directory_url,
     };
 
     tracing::info!(?config.data_root, "starting convex-orchestrator");
 
     let state = OrchestratorState::new(config).await?;
+
+    // Reconcile the Traefik custom-domain config from the database on boot.
+    // The dynamic directory may be an empty volume (fresh host) or stale
+    // (domains changed while this process was down), and Traefik only knows
+    // what the file says. A failure here must not stop the orchestrator from
+    // serving — custom domains are not on the critical path.
+    if let Err(e) = orchestrator::custom_domains::sync_traefik_config(&state).await {
+        tracing::error!(error = %e, "failed to write Traefik custom-domain config on startup");
+    }
+
+    // Issues and renews custom-domain certificates in the background, and
+    // retries domains whose first attempt failed (usually DNS that hadn't
+    // propagated yet).
+    orchestrator::acme::renewal::spawn(state.clone());
 
     let app = orchestrator::router::build_router(state.clone());
 

--- a/crates/orchestrator/src/router.rs
+++ b/crates/orchestrator/src/router.rs
@@ -57,6 +57,9 @@ pub fn build_router(state: OrchestratorState) -> Router {
         .nest("/api/internal", internal_router)
         .nest("/api", api_router)
         .nest("/v1", management_router)
+        // Unauthenticated by design: the ACME server is an anonymous client.
+        // Traefik forwards this path here for every custom domain.
+        .merge(routes::acme_challenge::router())
         .route("/version", get(version))
         .route("/health", get(health))
         .fallback(not_found)
@@ -208,6 +211,15 @@ async fn not_found() -> impl IntoResponse {
         crate::routes::dashboard::access_tokens::delete_access_token,
         crate::routes::dashboard::env_vars::list_env_vars,
         crate::routes::dashboard::env_vars::update_env_vars,
+        crate::routes::dashboard::custom_domains::list_custom_domains,
+        crate::routes::dashboard::custom_domains::create_custom_domain,
+        crate::routes::dashboard::custom_domains::delete_custom_domain,
+        crate::routes::dashboard::custom_domains::verify_custom_domain,
+        crate::routes::dashboard::custom_domains::retry_custom_domain,
+        crate::routes::dashboard::custom_domains::list_dns_creds,
+        crate::routes::dashboard::custom_domains::create_dns_cred,
+        crate::routes::dashboard::custom_domains::delete_dns_cred,
+        crate::routes::acme_challenge::serve_challenge,
         crate::routes::dashboard::audit_log::get_audit_log_events,
         crate::routes::dashboard::billing_stub::orb_subscription,
         crate::routes::dashboard::billing_stub::empty_list,

--- a/crates/orchestrator/src/routes/acme_challenge.rs
+++ b/crates/orchestrator/src/routes/acme_challenge.rs
@@ -1,0 +1,46 @@
+//! Serves ACME HTTP-01 challenge responses.
+//!
+//! Traefik routes `/.well-known/acme-challenge/` for every custom domain here
+//! on the plain HTTP entrypoint (see `custom_domains::render_config`), which
+//! is what lets a domain be validated *before* it has a certificate.
+//!
+//! Deliberately unauthenticated: the ACME server is an anonymous client, and
+//! the tokens are single-use, high-entropy values that only exist in memory
+//! while an order is in flight.
+
+use axum::{
+    extract::{
+        Path,
+        State,
+    },
+    http::StatusCode,
+    routing::get,
+    Router,
+};
+
+use crate::state::OrchestratorState;
+
+pub fn router() -> Router<OrchestratorState> {
+    Router::new().route(
+        "/.well-known/acme-challenge/{token}",
+        get(serve_challenge),
+    )
+}
+
+#[utoipa::path(
+    get,
+    path = "/.well-known/acme-challenge/{token}",
+    params(("token" = String, Path)),
+    responses(
+        (status = 200, description = "Key authorization for an in-flight challenge"),
+        (status = 404),
+    ),
+    tag = "acme",
+)]
+pub(crate) async fn serve_challenge(
+    State(state): State<OrchestratorState>,
+    Path(token): Path<String>,
+) -> Result<String, StatusCode> {
+    // Unknown tokens are indistinguishable from expired ones; 404 either way.
+    state.challenges.get(&token).ok_or(StatusCode::NOT_FOUND)
+}

--- a/crates/orchestrator/src/routes/dashboard/custom_domains.rs
+++ b/crates/orchestrator/src/routes/dashboard/custom_domains.rs
@@ -1,0 +1,499 @@
+//! Custom domain management for a deployment, plus the DNS provider
+//! credentials the dns-01 challenge needs.
+//!
+//! Every mutation re-renders the Traefik dynamic config (see
+//! `crate::custom_domains`) so routing follows the database immediately
+//! rather than at the next container restart. Issuance runs in the
+//! background: an ACME order takes tens of seconds (DNS propagation alone is
+//! ~15s), which is far too long to hold an HTTP request open.
+
+use axum::{
+    extract::{
+        Path,
+        State,
+    },
+    http::StatusCode,
+    routing::{
+        get,
+        post,
+    },
+    Json,
+    Router,
+};
+use orchestrator_api_types::dashboard::{
+    CreateCustomDomainArgs,
+    CreateDnsCredentialArgs,
+    CustomDomain,
+    CustomDomainArgs,
+    DnsCredential,
+    DnsProviderInfo,
+    DnsProviderField,
+    ListCustomDomains,
+    ListDnsCredentials,
+    VerifyCustomDomainResponse,
+};
+
+use crate::{
+    acme::{
+        self,
+        dns_providers::{
+            self,
+            Provider,
+        },
+        ChallengeKind,
+    },
+    auth::identity::AuthIdentity,
+    custom_domains,
+    errors::{
+        ApiError,
+        ApiResult,
+    },
+    state::OrchestratorState,
+};
+
+pub fn router() -> Router<OrchestratorState> {
+    Router::new()
+        .route(
+            "/deployments/{deployment_id}/custom_domains/list",
+            get(list_custom_domains),
+        )
+        .route(
+            "/deployments/{deployment_id}/custom_domains/create",
+            post(create_custom_domain),
+        )
+        .route(
+            "/deployments/{deployment_id}/custom_domains/delete",
+            post(delete_custom_domain),
+        )
+        .route(
+            "/deployments/{deployment_id}/custom_domains/verify",
+            post(verify_custom_domain),
+        )
+        .route(
+            "/deployments/{deployment_id}/custom_domains/retry",
+            post(retry_custom_domain),
+        )
+        .route("/teams/{team_id}/dns_credentials/list", get(list_dns_creds))
+        .route(
+            "/teams/{team_id}/dns_credentials/create",
+            post(create_dns_cred),
+        )
+        .route(
+            "/teams/{team_id}/dns_credentials/{credential_id}/delete",
+            post(delete_dns_cred),
+        )
+}
+
+fn to_api(record: crate::storage::CustomDomainRecord) -> CustomDomain {
+    CustomDomain {
+        id: record.id,
+        deployment_id: record.deployment_id,
+        domain: record.domain,
+        cert_state: record.cert_state,
+        created_at: record.created_at,
+        challenge_type: record.challenge_type,
+        dns_credential_id: record.dns_credential_id,
+        last_error: record.last_error,
+    }
+}
+
+// ---------- Custom domains ----------
+
+#[utoipa::path(
+    get,
+    path = "/api/dashboard/deployments/{deployment_id}/custom_domains/list",
+    params(("deployment_id" = i64, Path)),
+    responses((status = 200, body = ListCustomDomains)),
+    tag = "dashboard",
+)]
+pub(crate) async fn list_custom_domains(
+    _auth: AuthIdentity,
+    State(state): State<OrchestratorState>,
+    Path(deployment_id): Path<i64>,
+) -> ApiResult<Json<ListCustomDomains>> {
+    let domains = state
+        .storage
+        .list_custom_domains(deployment_id)
+        .await
+        .map_err(ApiError::Internal)?;
+
+    Ok(Json(ListCustomDomains {
+        domains: domains.into_iter().map(to_api).collect(),
+        target_host: state.config.router_host.clone(),
+        routing_enabled: state.config.traefik_dynamic_dir.is_some(),
+        providers: Provider::all()
+            .iter()
+            .map(|p| DnsProviderInfo {
+                provider: p.as_str().to_string(),
+                fields: p
+                    .required_fields()
+                    .iter()
+                    .map(|f| DnsProviderField {
+                        key: f.key.to_string(),
+                        label: f.label.to_string(),
+                        help: f.help.to_string(),
+                    })
+                    .collect(),
+            })
+            .collect(),
+    }))
+}
+
+#[utoipa::path(
+    post,
+    path = "/api/dashboard/deployments/{deployment_id}/custom_domains/create",
+    params(("deployment_id" = i64, Path)),
+    request_body = CreateCustomDomainArgs,
+    responses((status = 200, body = CustomDomain), (status = 400)),
+    tag = "dashboard",
+)]
+pub(crate) async fn create_custom_domain(
+    _auth: AuthIdentity,
+    State(state): State<OrchestratorState>,
+    Path(deployment_id): Path<i64>,
+    Json(args): Json<CreateCustomDomainArgs>,
+) -> ApiResult<Json<CustomDomain>> {
+    let domain = custom_domains::validate_domain(&args.domain)
+        .map_err(|e| ApiError::BadRequest(e.to_string()))?;
+
+    let challenge = ChallengeKind::parse(args.challenge_type.as_deref().unwrap_or("http-01"))
+        .map_err(|e| ApiError::BadRequest(e.to_string()))?;
+
+    // A wildcard can only ever be validated over dns-01 — there's no single
+    // host an HTTP request could be served from. Catch it here rather than
+    // letting the background job fail a minute later.
+    if domain.starts_with("*.") && challenge != ChallengeKind::Dns01 {
+        return Err(ApiError::BadRequest(
+            "wildcard domains require the dns-01 challenge".to_string(),
+        ));
+    }
+    if challenge == ChallengeKind::Dns01 && args.dns_credential_id.is_none() {
+        return Err(ApiError::BadRequest(
+            "select a DNS provider credential to use the dns-01 challenge".to_string(),
+        ));
+    }
+
+    // `domain` is globally UNIQUE — two deployments can't both claim it, and
+    // Traefik couldn't route it if they did. Translate the constraint
+    // violation into a message the dashboard can show verbatim.
+    if state
+        .storage
+        .get_custom_domain(&domain)
+        .await
+        .map_err(ApiError::Internal)?
+        .is_some()
+    {
+        return Err(ApiError::BadRequest(format!(
+            "{domain} is already attached to a deployment"
+        )));
+    }
+
+    let record = state
+        .storage
+        .create_custom_domain(
+            deployment_id,
+            &domain,
+            challenge.as_str(),
+            args.dns_credential_id,
+        )
+        .await
+        .map_err(ApiError::Internal)?;
+
+    // Route first so the ACME HTTP-01 challenge path resolves, then issue.
+    custom_domains::sync_traefik_config(&state)
+        .await
+        .map_err(ApiError::Internal)?;
+    spawn_issuance(state.clone(), domain);
+
+    Ok(Json(to_api(record)))
+}
+
+#[utoipa::path(
+    post,
+    path = "/api/dashboard/deployments/{deployment_id}/custom_domains/delete",
+    params(("deployment_id" = i64, Path)),
+    request_body = CustomDomainArgs,
+    responses((status = 200)),
+    tag = "dashboard",
+)]
+pub(crate) async fn delete_custom_domain(
+    _auth: AuthIdentity,
+    State(state): State<OrchestratorState>,
+    Path(deployment_id): Path<i64>,
+    Json(args): Json<CustomDomainArgs>,
+) -> ApiResult<StatusCode> {
+    // Normalize so a domain stored lowercase is still matched when the caller
+    // sends it back with different casing.
+    let domain = custom_domains::validate_domain(&args.domain)
+        .map_err(|e| ApiError::BadRequest(e.to_string()))?;
+
+    state
+        .storage
+        .delete_custom_domain(deployment_id, &domain)
+        .await
+        .map_err(ApiError::Internal)?;
+    state
+        .storage
+        .delete_certificate(&domain)
+        .await
+        .map_err(ApiError::Internal)?;
+
+    custom_domains::sync_traefik_config(&state)
+        .await
+        .map_err(ApiError::Internal)?;
+
+    Ok(StatusCode::OK)
+}
+
+#[utoipa::path(
+    post,
+    path = "/api/dashboard/deployments/{deployment_id}/custom_domains/retry",
+    params(("deployment_id" = i64, Path)),
+    request_body = CustomDomainArgs,
+    responses((status = 200)),
+    tag = "dashboard",
+)]
+pub(crate) async fn retry_custom_domain(
+    _auth: AuthIdentity,
+    State(state): State<OrchestratorState>,
+    Path(_deployment_id): Path<i64>,
+    Json(args): Json<CustomDomainArgs>,
+) -> ApiResult<StatusCode> {
+    let domain = custom_domains::validate_domain(&args.domain)
+        .map_err(|e| ApiError::BadRequest(e.to_string()))?;
+    spawn_issuance(state, domain);
+    Ok(StatusCode::ACCEPTED)
+}
+
+#[utoipa::path(
+    post,
+    path = "/api/dashboard/deployments/{deployment_id}/custom_domains/verify",
+    params(("deployment_id" = i64, Path)),
+    request_body = CustomDomainArgs,
+    responses((status = 200, body = VerifyCustomDomainResponse)),
+    tag = "dashboard",
+)]
+pub(crate) async fn verify_custom_domain(
+    _auth: AuthIdentity,
+    State(state): State<OrchestratorState>,
+    Path(_deployment_id): Path<i64>,
+    Json(args): Json<CustomDomainArgs>,
+) -> ApiResult<Json<VerifyCustomDomainResponse>> {
+    let domain = custom_domains::validate_domain(&args.domain)
+        .map_err(|e| ApiError::BadRequest(e.to_string()))?;
+
+    let (cert_state, error) = custom_domains::probe_domain(&domain).await;
+
+    state
+        .storage
+        .set_custom_domain_status(&domain, &cert_state, error.as_deref())
+        .await
+        .map_err(ApiError::Internal)?;
+
+    Ok(Json(VerifyCustomDomainResponse {
+        domain,
+        cert_state,
+        error,
+    }))
+}
+
+/// Issues (or renews) a certificate off the request path, recording the
+/// outcome — including the failure reason — on the domain row.
+pub fn spawn_issuance(state: OrchestratorState, domain: String) {
+    tokio::spawn(async move {
+        if let Err(e) = state
+            .storage
+            .set_custom_domain_status(&domain, "issuing", None)
+            .await
+        {
+            tracing::warn!(error = %e, %domain, "could not mark domain as issuing");
+        }
+
+        match issue_now(&state, &domain).await {
+            Ok(()) => {
+                tracing::info!(%domain, "issued certificate");
+            },
+            Err(e) => {
+                // `{e:#}` includes the anyhow context chain, which is where
+                // the actionable part usually lives (which zone, which token).
+                let message = format!("{e:#}");
+                tracing::warn!(error = %message, %domain, "certificate issuance failed");
+                if let Err(e) = state
+                    .storage
+                    .set_custom_domain_status(&domain, "failed", Some(&message))
+                    .await
+                {
+                    tracing::warn!(error = %e, %domain, "could not record issuance failure");
+                }
+            },
+        }
+    });
+}
+
+async fn issue_now(state: &OrchestratorState, domain: &str) -> anyhow::Result<()> {
+    let record = state
+        .storage
+        .get_custom_domain(domain)
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("{domain} is no longer configured"))?;
+
+    let challenge = ChallengeKind::parse(&record.challenge_type)?;
+
+    let dns = match (challenge, record.dns_credential_id) {
+        (ChallengeKind::Dns01, Some(id)) => {
+            let stored = state
+                .storage
+                .get_dns_credential_secrets(id)
+                .await?
+                .ok_or_else(|| anyhow::anyhow!("the selected DNS credential no longer exists"))?;
+            let provider = Provider::parse(&stored.provider)?;
+            let plaintext = state.secrets.open(&stored.sealed)?;
+            let secrets: dns_providers::Secrets = serde_json::from_slice(&plaintext)?;
+            Some((provider, secrets))
+        },
+        (ChallengeKind::Dns01, None) => {
+            anyhow::bail!("dns-01 was selected but no DNS credential is attached")
+        },
+        (ChallengeKind::Http01, _) => None,
+    };
+
+    let issued = acme::issue(state, domain, challenge, dns).await?;
+
+    state
+        .storage
+        .upsert_certificate(
+            domain,
+            &issued.cert_pem,
+            &issued.key_pem,
+            issued.issued_at,
+            issued.renew_after,
+        )
+        .await?;
+
+    // Publish the new certificate to Traefik, then confirm it's actually
+    // being served before calling the domain active.
+    custom_domains::sync_traefik_config(state).await?;
+
+    let (cert_state, error) = custom_domains::probe_domain(domain).await;
+    state
+        .storage
+        .set_custom_domain_status(domain, &cert_state, error.as_deref())
+        .await?;
+
+    Ok(())
+}
+
+// ---------- DNS provider credentials ----------
+
+#[utoipa::path(
+    get,
+    path = "/api/dashboard/teams/{team_id}/dns_credentials/list",
+    params(("team_id" = i64, Path)),
+    responses((status = 200, body = ListDnsCredentials)),
+    tag = "dashboard",
+)]
+pub(crate) async fn list_dns_creds(
+    _auth: AuthIdentity,
+    State(state): State<OrchestratorState>,
+    Path(team_id): Path<i64>,
+) -> ApiResult<Json<ListDnsCredentials>> {
+    let creds = state
+        .storage
+        .list_dns_credentials(team_id)
+        .await
+        .map_err(ApiError::Internal)?;
+
+    // Deliberately no secret material in the response — the sealed blob is
+    // never loaded by this query, so it can't leak through here.
+    Ok(Json(ListDnsCredentials {
+        credentials: creds
+            .into_iter()
+            .map(|c| DnsCredential {
+                id: c.id,
+                name: c.name,
+                provider: c.provider,
+                created_at: c.created_at,
+            })
+            .collect(),
+        providers: Provider::all()
+            .iter()
+            .map(|p| DnsProviderInfo {
+                provider: p.as_str().to_string(),
+                fields: p
+                    .required_fields()
+                    .iter()
+                    .map(|f| DnsProviderField {
+                        key: f.key.to_string(),
+                        label: f.label.to_string(),
+                        help: f.help.to_string(),
+                    })
+                    .collect(),
+            })
+            .collect(),
+    }))
+}
+
+#[utoipa::path(
+    post,
+    path = "/api/dashboard/teams/{team_id}/dns_credentials/create",
+    params(("team_id" = i64, Path)),
+    request_body = CreateDnsCredentialArgs,
+    responses((status = 200, body = DnsCredential), (status = 400)),
+    tag = "dashboard",
+)]
+pub(crate) async fn create_dns_cred(
+    _auth: AuthIdentity,
+    State(state): State<OrchestratorState>,
+    Path(team_id): Path<i64>,
+    Json(args): Json<CreateDnsCredentialArgs>,
+) -> ApiResult<Json<DnsCredential>> {
+    let name = args.name.trim().to_string();
+    if name.is_empty() {
+        return Err(ApiError::BadRequest("name is required".to_string()));
+    }
+    let provider =
+        Provider::parse(&args.provider).map_err(|e| ApiError::BadRequest(e.to_string()))?;
+
+    // Validate up front so a typo surfaces here rather than as a failed
+    // issuance minutes later.
+    let secrets: dns_providers::Secrets = args.secrets.into_iter().collect();
+    dns_providers::build(provider, &secrets).map_err(|e| ApiError::BadRequest(e.to_string()))?;
+
+    let sealed = state.secrets.seal(
+        &serde_json::to_vec(&secrets)
+            .map_err(|e| ApiError::Internal(anyhow::anyhow!(e)))?,
+    );
+
+    let record = state
+        .storage
+        .create_dns_credential(team_id, &name, provider.as_str(), &sealed)
+        .await
+        .map_err(ApiError::Internal)?;
+
+    Ok(Json(DnsCredential {
+        id: record.id,
+        name: record.name,
+        provider: record.provider,
+        created_at: record.created_at,
+    }))
+}
+
+#[utoipa::path(
+    post,
+    path = "/api/dashboard/teams/{team_id}/dns_credentials/{credential_id}/delete",
+    params(("team_id" = i64, Path), ("credential_id" = i64, Path)),
+    responses((status = 200)),
+    tag = "dashboard",
+)]
+pub(crate) async fn delete_dns_cred(
+    _auth: AuthIdentity,
+    State(state): State<OrchestratorState>,
+    Path((team_id, credential_id)): Path<(i64, i64)>,
+) -> ApiResult<StatusCode> {
+    state
+        .storage
+        .delete_dns_credential(team_id, credential_id)
+        .await
+        .map_err(ApiError::Internal)?;
+    Ok(StatusCode::OK)
+}

--- a/crates/orchestrator/src/routes/dashboard/mod.rs
+++ b/crates/orchestrator/src/routes/dashboard/mod.rs
@@ -4,6 +4,7 @@ pub(crate) mod access_tokens;
 pub(crate) mod audit_log;
 pub(crate) mod billing_stub;
 pub(crate) mod cloud_backups_stub;
+pub(crate) mod custom_domains;
 pub(crate) mod deployments;
 pub(crate) mod env_vars;
 pub(crate) mod host_capacity;
@@ -29,6 +30,7 @@ pub fn router() -> Router<OrchestratorState> {
         .merge(teams::router())
         .merge(projects::router())
         .merge(deployments::router())
+        .merge(custom_domains::router())
         .merge(access_tokens::router())
         .merge(env_vars::router())
         .merge(audit_log::router())

--- a/crates/orchestrator/src/routes/mod.rs
+++ b/crates/orchestrator/src/routes/mod.rs
@@ -1,5 +1,6 @@
 //! HTTP route handlers grouped by API surface.
 
+pub mod acme_challenge;
 pub mod dashboard;
 pub mod deployment_internal;
 pub mod helpers;

--- a/crates/orchestrator/src/secrets.rs
+++ b/crates/orchestrator/src/secrets.rs
@@ -1,0 +1,100 @@
+//! Sealing for secrets the orchestrator stores but must never hand back:
+//! DNS provider API tokens and the ACME account key.
+//!
+//! Both are written to Postgres, so a database dump alone shouldn't be enough
+//! to take over someone's DNS zone or mint certificates in our name. The key
+//! is derived from the orchestrator's service key, which already has to be
+//! secret and is supplied out of band.
+
+use anyhow::Context;
+use sha2::{
+    Digest,
+    Sha256,
+};
+
+/// Nonce is prepended to the ciphertext, so a sealed blob is
+/// `[nonce][ciphertext]` and callers only ever handle one opaque `Vec<u8>`.
+#[derive(Clone)]
+pub struct SecretSealer {
+    key: sodium_secretbox::Key,
+}
+
+impl SecretSealer {
+    /// Derives the sealing key from the service key.
+    ///
+    /// Hashing rather than truncating means any length of service key works,
+    /// and the sealing key isn't literally the service key — so a leak of one
+    /// derived value doesn't hand over the other.
+    pub fn from_service_key(service_key: &str) -> anyhow::Result<Self> {
+        let mut hasher = Sha256::new();
+        hasher.update(b"convex-orchestrator/secret-sealer/v1");
+        hasher.update(service_key.as_bytes());
+        let digest = hasher.finalize();
+        let key = sodium_secretbox::Key::from_slice(&digest)
+            .context("deriving secret sealing key")?;
+        Ok(Self { key })
+    }
+
+    pub fn seal(&self, plaintext: &[u8]) -> Vec<u8> {
+        let nonce = sodium_secretbox::gen_nonce();
+        let ciphertext = sodium_secretbox::seal(plaintext, &nonce, &self.key);
+        let mut out = Vec::with_capacity(sodium_secretbox::NONCEBYTES + ciphertext.len());
+        out.extend_from_slice(&nonce.0);
+        out.extend_from_slice(&ciphertext);
+        out
+    }
+
+    pub fn open(&self, sealed: &[u8]) -> anyhow::Result<Vec<u8>> {
+        anyhow::ensure!(
+            sealed.len() > sodium_secretbox::NONCEBYTES,
+            "sealed value is too short to contain a nonce"
+        );
+        let (nonce_bytes, ciphertext) = sealed.split_at(sodium_secretbox::NONCEBYTES);
+        let nonce = sodium_secretbox::Nonce::from_slice(nonce_bytes)
+            .context("reading nonce from sealed value")?;
+        sodium_secretbox::open(ciphertext, &nonce, &self.key)
+            .map_err(|_| anyhow::anyhow!("could not decrypt stored secret — has SERVICE_KEY changed?"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn round_trips_a_secret() {
+        let sealer = SecretSealer::from_service_key("service-key").unwrap();
+        let sealed = sealer.seal(b"cf-token");
+        assert_eq!(sealer.open(&sealed).unwrap(), b"cf-token");
+    }
+
+    #[test]
+    fn ciphertext_does_not_contain_the_plaintext() {
+        let sealer = SecretSealer::from_service_key("service-key").unwrap();
+        let sealed = sealer.seal(b"cf-token");
+        assert!(!sealed.windows(8).any(|w| w == b"cf-token"));
+    }
+
+    #[test]
+    fn reuses_a_fresh_nonce_per_seal() {
+        // Identical plaintexts must not produce identical ciphertexts, or the
+        // database leaks which deployments share a token.
+        let sealer = SecretSealer::from_service_key("service-key").unwrap();
+        assert_ne!(sealer.seal(b"same"), sealer.seal(b"same"));
+    }
+
+    #[test]
+    fn a_different_service_key_cannot_open_the_secret() {
+        let sealed = SecretSealer::from_service_key("one").unwrap().seal(b"secret");
+        assert!(SecretSealer::from_service_key("two")
+            .unwrap()
+            .open(&sealed)
+            .is_err());
+    }
+
+    #[test]
+    fn rejects_truncated_values() {
+        let sealer = SecretSealer::from_service_key("service-key").unwrap();
+        assert!(sealer.open(b"short").is_err());
+    }
+}

--- a/crates/orchestrator/src/state.rs
+++ b/crates/orchestrator/src/state.rs
@@ -29,6 +29,12 @@ pub struct OrchestratorState {
     pub config: Arc<OrchestratorConfig>,
     pub provisioner: Arc<dyn Provisioner>,
     pub host_capacity: Arc<crate::host_capacity::HostCapacityReader>,
+    /// Seals DNS provider tokens and the ACME account key before they hit
+    /// Postgres.
+    pub secrets: crate::secrets::SecretSealer,
+    /// In-flight HTTP-01 challenge tokens, served by the orchestrator's
+    /// `/.well-known/acme-challenge/` route.
+    pub challenges: crate::acme::ChallengeStore,
 }
 
 impl OrchestratorState {
@@ -70,11 +76,23 @@ impl OrchestratorState {
             },
         };
 
+        // Sealing key is derived from the service key. Without one configured
+        // we still need *a* key, but fall back to the database URL so a dev
+        // instance works — an operator running without a service key already
+        // has no secrets worth protecting.
+        let sealing_material = config
+            .service_key
+            .clone()
+            .unwrap_or_else(|| config.database_url.clone());
+        let secrets = crate::secrets::SecretSealer::from_service_key(&sealing_material)?;
+
         let state = Self {
             storage,
             config: Arc::new(config),
             provisioner,
             host_capacity: Arc::new(crate::host_capacity::HostCapacityReader::new()),
+            secrets,
+            challenges: crate::acme::ChallengeStore::new(),
         };
 
         state.bootstrap_if_empty().await?;

--- a/crates/orchestrator/src/storage/acme.rs
+++ b/crates/orchestrator/src/storage/acme.rs
@@ -1,0 +1,275 @@
+//! Storage for ACME state: the account key, issued certificates, and the DNS
+//! provider credentials used for the dns-01 challenge.
+//!
+//! Sealed columns (`secrets`, `credentials`) are returned as raw bytes; only
+//! `SecretSealer` can open them, and nothing here ever hands a decrypted
+//! secret to an API response.
+
+use super::Storage;
+use crate::time::now_unix_ms;
+
+#[derive(Debug, Clone)]
+pub struct AcmeAccountRecord {
+    pub account_url: String,
+    pub credentials: Vec<u8>,
+}
+
+#[derive(Debug, Clone)]
+pub struct DnsCredentialRecord {
+    pub id: i64,
+    pub team_id: i64,
+    pub name: String,
+    pub provider: String,
+    pub created_at: i64,
+}
+
+/// Separate from [`DnsCredentialRecord`] so the sealed blob is only loaded
+/// when an issuance actually needs it — list endpoints can't leak what they
+/// never fetch.
+#[derive(Debug, Clone)]
+pub struct DnsCredentialSecrets {
+    pub provider: String,
+    pub sealed: Vec<u8>,
+}
+
+#[derive(Debug, Clone)]
+pub struct StoredCertificate {
+    pub domain: String,
+    pub cert_pem: String,
+    pub key_pem: String,
+    pub issued_at: i64,
+    pub renew_after: i64,
+}
+
+impl Storage {
+    // ---------- ACME account ----------
+
+    pub async fn get_acme_account(
+        &self,
+        directory_url: &str,
+    ) -> anyhow::Result<Option<AcmeAccountRecord>> {
+        let conn = self.pool().acquire().await?;
+        let row = conn
+            .client()
+            .query_opt(
+                "SELECT account_url, credentials FROM acme_accounts WHERE directory_url = $1",
+                &[&directory_url],
+            )
+            .await?;
+        Ok(row.map(|r| AcmeAccountRecord {
+            account_url: r.get(0),
+            credentials: r.get(1),
+        }))
+    }
+
+    pub async fn upsert_acme_account(
+        &self,
+        directory_url: &str,
+        account_url: &str,
+        credentials: &[u8],
+    ) -> anyhow::Result<()> {
+        let conn = self.pool().acquire().await?;
+        conn.client()
+            .execute(
+                "INSERT INTO acme_accounts (directory_url, account_url, credentials, created_at)
+                 VALUES ($1, $2, $3, $4)
+                 ON CONFLICT (directory_url) DO UPDATE
+                   SET account_url = EXCLUDED.account_url,
+                       credentials = EXCLUDED.credentials",
+                &[
+                    &directory_url,
+                    &account_url,
+                    &credentials.to_vec(),
+                    &now_unix_ms(),
+                ],
+            )
+            .await?;
+        Ok(())
+    }
+
+    // ---------- DNS provider credentials ----------
+
+    pub async fn list_dns_credentials(
+        &self,
+        team_id: i64,
+    ) -> anyhow::Result<Vec<DnsCredentialRecord>> {
+        let conn = self.pool().acquire().await?;
+        let rows = conn
+            .client()
+            .query(
+                "SELECT id, team_id, name, provider, created_at
+                 FROM dns_provider_credentials WHERE team_id = $1 ORDER BY name",
+                &[&team_id],
+            )
+            .await?;
+        Ok(rows
+            .into_iter()
+            .map(|r| DnsCredentialRecord {
+                id: r.get(0),
+                team_id: r.get(1),
+                name: r.get(2),
+                provider: r.get(3),
+                created_at: r.get(4),
+            })
+            .collect())
+    }
+
+    pub async fn create_dns_credential(
+        &self,
+        team_id: i64,
+        name: &str,
+        provider: &str,
+        sealed: &[u8],
+    ) -> anyhow::Result<DnsCredentialRecord> {
+        let now = now_unix_ms();
+        let conn = self.pool().acquire().await?;
+        // Re-saving under the same name rotates the token rather than
+        // erroring, which is what an operator pasting a fresh token expects.
+        let row = conn
+            .client()
+            .query_one(
+                "INSERT INTO dns_provider_credentials
+                     (team_id, name, provider, secrets, created_at)
+                 VALUES ($1, $2, $3, $4, $5)
+                 ON CONFLICT (team_id, name) DO UPDATE
+                   SET provider = EXCLUDED.provider,
+                       secrets = EXCLUDED.secrets
+                 RETURNING id, created_at",
+                &[&team_id, &name, &provider, &sealed.to_vec(), &now],
+            )
+            .await?;
+        Ok(DnsCredentialRecord {
+            id: row.get(0),
+            team_id,
+            name: name.to_string(),
+            provider: provider.to_string(),
+            created_at: row.get(1),
+        })
+    }
+
+    pub async fn delete_dns_credential(&self, team_id: i64, id: i64) -> anyhow::Result<()> {
+        let conn = self.pool().acquire().await?;
+        conn.client()
+            .execute(
+                "DELETE FROM dns_provider_credentials WHERE team_id = $1 AND id = $2",
+                &[&team_id, &id],
+            )
+            .await?;
+        Ok(())
+    }
+
+    pub async fn get_dns_credential_secrets(
+        &self,
+        id: i64,
+    ) -> anyhow::Result<Option<DnsCredentialSecrets>> {
+        let conn = self.pool().acquire().await?;
+        let row = conn
+            .client()
+            .query_opt(
+                "SELECT provider, secrets FROM dns_provider_credentials WHERE id = $1",
+                &[&id],
+            )
+            .await?;
+        Ok(row.map(|r| DnsCredentialSecrets {
+            provider: r.get(0),
+            sealed: r.get(1),
+        }))
+    }
+
+    // ---------- Certificates ----------
+
+    pub async fn upsert_certificate(
+        &self,
+        domain: &str,
+        cert_pem: &str,
+        key_pem: &str,
+        issued_at: i64,
+        renew_after: i64,
+    ) -> anyhow::Result<()> {
+        let conn = self.pool().acquire().await?;
+        conn.client()
+            .execute(
+                "INSERT INTO custom_domain_certs
+                     (domain, cert_pem, key_pem, issued_at, renew_after)
+                 VALUES ($1, $2, $3, $4, $5)
+                 ON CONFLICT (domain) DO UPDATE
+                   SET cert_pem = EXCLUDED.cert_pem,
+                       key_pem = EXCLUDED.key_pem,
+                       issued_at = EXCLUDED.issued_at,
+                       renew_after = EXCLUDED.renew_after",
+                &[&domain, &cert_pem, &key_pem, &issued_at, &renew_after],
+            )
+            .await?;
+        Ok(())
+    }
+
+    pub async fn delete_certificate(&self, domain: &str) -> anyhow::Result<()> {
+        let conn = self.pool().acquire().await?;
+        conn.client()
+            .execute(
+                "DELETE FROM custom_domain_certs WHERE domain = $1",
+                &[&domain],
+            )
+            .await?;
+        Ok(())
+    }
+
+    /// Every stored certificate. Used to rebuild the Traefik dynamic
+    /// directory, which may be an empty volume on a fresh host.
+    pub async fn list_certificates(&self) -> anyhow::Result<Vec<StoredCertificate>> {
+        let conn = self.pool().acquire().await?;
+        let rows = conn
+            .client()
+            .query(
+                "SELECT domain, cert_pem, key_pem, issued_at, renew_after
+                 FROM custom_domain_certs ORDER BY domain",
+                &[],
+            )
+            .await?;
+        Ok(rows
+            .into_iter()
+            .map(|r| StoredCertificate {
+                domain: r.get(0),
+                cert_pem: r.get(1),
+                key_pem: r.get(2),
+                issued_at: r.get(3),
+                renew_after: r.get(4),
+            })
+            .collect())
+    }
+
+    /// Domains whose certificate is due for renewal, plus domains that have
+    /// no certificate at all (a first issuance that failed, or one added
+    /// while the ACME server was unreachable).
+    pub async fn domains_needing_certificates(
+        &self,
+        now: i64,
+    ) -> anyhow::Result<Vec<super::CustomDomainRecord>> {
+        let conn = self.pool().acquire().await?;
+        let rows = conn
+            .client()
+            .query(
+                "SELECT cd.id, cd.deployment_id, cd.domain, cd.cert_state, cd.created_at,
+                        cd.challenge_type, cd.dns_credential_id, cd.last_error
+                 FROM custom_domains cd
+                 LEFT JOIN custom_domain_certs c ON c.domain = cd.domain
+                 WHERE c.domain IS NULL OR c.renew_after <= $1
+                 ORDER BY cd.domain",
+                &[&now],
+            )
+            .await?;
+        Ok(rows
+            .into_iter()
+            .map(|r| super::CustomDomainRecord {
+                id: r.get(0),
+                deployment_id: r.get(1),
+                domain: r.get(2),
+                cert_state: r.get(3),
+                created_at: r.get(4),
+                challenge_type: r.get(5),
+                dns_credential_id: r.get(6),
+                last_error: r.get(7),
+            })
+            .collect())
+    }
+}

--- a/crates/orchestrator/src/storage/custom_domains.rs
+++ b/crates/orchestrator/src/storage/custom_domains.rs
@@ -8,6 +8,24 @@ pub struct CustomDomainRecord {
     pub domain: String,
     pub cert_state: String,
     pub created_at: i64,
+    /// `http-01` or `dns-01`. Chosen per domain in the dashboard.
+    pub challenge_type: String,
+    /// DNS provider credential used for `dns-01`. `None` for `http-01`,
+    /// which needs no credentials at all.
+    pub dns_credential_id: Option<i64>,
+    /// Why the last issuance attempt failed, verbatim. Only the operator can
+    /// fix the usual causes (DNS not pointed here, token lacks zone access).
+    pub last_error: Option<String>,
+}
+
+/// A custom domain plus the name of the deployment it fronts. Rendering the
+/// Traefik file-provider config needs the deployment name to derive the
+/// upstream container host, so the join happens in SQL rather than N+1
+/// lookups per domain.
+#[derive(Debug, Clone)]
+pub struct CustomDomainRoute {
+    pub domain: String,
+    pub deployment_name: String,
 }
 
 impl Storage {
@@ -15,16 +33,26 @@ impl Storage {
         &self,
         deployment_id: i64,
         domain: &str,
+        challenge_type: &str,
+        dns_credential_id: Option<i64>,
     ) -> anyhow::Result<CustomDomainRecord> {
         let now = now_unix_ms();
         let conn = self.pool().acquire().await?;
         let row = conn
             .client()
             .query_one(
-                "INSERT INTO custom_domains (deployment_id, domain, cert_state, created_at)
-                 VALUES ($1, $2, 'pending', $3)
+                "INSERT INTO custom_domains
+                     (deployment_id, domain, cert_state, created_at, challenge_type,
+                      dns_credential_id)
+                 VALUES ($1, $2, 'pending', $3, $4, $5)
                  RETURNING id",
-                &[&deployment_id, &domain, &now],
+                &[
+                    &deployment_id,
+                    &domain,
+                    &now,
+                    &challenge_type,
+                    &dns_credential_id,
+                ],
             )
             .await?;
         Ok(CustomDomainRecord {
@@ -33,7 +61,54 @@ impl Storage {
             domain: domain.to_string(),
             cert_state: "pending".to_string(),
             created_at: now,
+            challenge_type: challenge_type.to_string(),
+            dns_credential_id,
+            last_error: None,
         })
+    }
+
+    /// Records the result of an issuance attempt. `cert_state` is only ever
+    /// written from an observed outcome, never assumed.
+    pub async fn set_custom_domain_status(
+        &self,
+        domain: &str,
+        cert_state: &str,
+        last_error: Option<&str>,
+    ) -> anyhow::Result<()> {
+        let conn = self.pool().acquire().await?;
+        conn.client()
+            .execute(
+                "UPDATE custom_domains SET cert_state = $2, last_error = $3 WHERE domain = $1",
+                &[&domain, &cert_state, &last_error],
+            )
+            .await?;
+        Ok(())
+    }
+
+    pub async fn get_custom_domain(
+        &self,
+        domain: &str,
+    ) -> anyhow::Result<Option<CustomDomainRecord>> {
+        let conn = self.pool().acquire().await?;
+        let row = conn
+            .client()
+            .query_opt(
+                "SELECT id, deployment_id, domain, cert_state, created_at, challenge_type,
+                        dns_credential_id, last_error
+                 FROM custom_domains WHERE domain = $1",
+                &[&domain],
+            )
+            .await?;
+        Ok(row.map(|r| CustomDomainRecord {
+            id: r.get(0),
+            deployment_id: r.get(1),
+            domain: r.get(2),
+            cert_state: r.get(3),
+            created_at: r.get(4),
+            challenge_type: r.get(5),
+            dns_credential_id: r.get(6),
+            last_error: r.get(7),
+        }))
     }
 
     pub async fn delete_custom_domain(
@@ -51,6 +126,51 @@ impl Storage {
         Ok(())
     }
 
+    /// Every custom domain across all deployments, joined to the deployment
+    /// name. Used to re-render the Traefik dynamic config, which is written
+    /// whole rather than patched per-domain.
+    pub async fn list_all_custom_domain_routes(&self) -> anyhow::Result<Vec<CustomDomainRoute>> {
+        let conn = self.pool().acquire().await?;
+        let rows = conn
+            .client()
+            .query(
+                "SELECT cd.domain, d.name
+                 FROM custom_domains cd
+                 JOIN deployments d ON d.id = cd.deployment_id
+                 ORDER BY cd.domain",
+                &[],
+            )
+            .await?;
+        Ok(rows
+            .into_iter()
+            .map(|r| CustomDomainRoute {
+                domain: r.get(0),
+                deployment_name: r.get(1),
+            })
+            .collect())
+    }
+
+    /// Records the outcome of a reachability probe. `cert_state` is the only
+    /// signal the dashboard has for whether ACME actually issued a cert, so
+    /// it is set from an observed HTTPS response rather than optimistically
+    /// on insert.
+    pub async fn set_custom_domain_cert_state(
+        &self,
+        deployment_id: i64,
+        domain: &str,
+        cert_state: &str,
+    ) -> anyhow::Result<()> {
+        let conn = self.pool().acquire().await?;
+        conn.client()
+            .execute(
+                "UPDATE custom_domains SET cert_state = $3
+                 WHERE deployment_id = $1 AND domain = $2",
+                &[&deployment_id, &domain, &cert_state],
+            )
+            .await?;
+        Ok(())
+    }
+
     pub async fn list_custom_domains(
         &self,
         deployment_id: i64,
@@ -59,7 +179,8 @@ impl Storage {
         let rows = conn
             .client()
             .query(
-                "SELECT id, deployment_id, domain, cert_state, created_at
+                "SELECT id, deployment_id, domain, cert_state, created_at, challenge_type,
+                        dns_credential_id, last_error
                  FROM custom_domains WHERE deployment_id = $1",
                 &[&deployment_id],
             )
@@ -72,6 +193,9 @@ impl Storage {
                 domain: r.get(2),
                 cert_state: r.get(3),
                 created_at: r.get(4),
+                challenge_type: r.get(5),
+                dns_credential_id: r.get(6),
+                last_error: r.get(7),
             })
             .collect())
     }

--- a/crates/orchestrator/src/storage/migrations.rs
+++ b/crates/orchestrator/src/storage/migrations.rs
@@ -68,5 +68,20 @@ pub async fn run(pool: &PgPool) -> anyhow::Result<()> {
             "#,
         )
         .await?;
+    // Custom-domain certificate management. Domains created before this
+    // migration used a Traefik-side cert resolver and carry no challenge
+    // preference, so default them to `http-01`: it needs no credentials and
+    // matches the behaviour they already had.
+    conn.client()
+        .batch_execute(
+            r#"
+            ALTER TABLE custom_domains
+              ADD COLUMN IF NOT EXISTS challenge_type TEXT NOT NULL DEFAULT 'http-01',
+              ADD COLUMN IF NOT EXISTS dns_credential_id BIGINT
+                REFERENCES dns_provider_credentials(id) ON DELETE SET NULL,
+              ADD COLUMN IF NOT EXISTS last_error TEXT;
+            "#,
+        )
+        .await?;
     Ok(())
 }

--- a/crates/orchestrator/src/storage/mod.rs
+++ b/crates/orchestrator/src/storage/mod.rs
@@ -1,6 +1,7 @@
 //! Postgres-backed storage for the orchestrator.
 
 pub mod access_tokens;
+mod acme;
 mod audit_log;
 mod custom_domains;
 pub mod deployments;
@@ -25,7 +26,16 @@ pub use self::{
         AuditEntry,
         AuditQuery,
     },
-    custom_domains::CustomDomainRecord,
+    acme::{
+        AcmeAccountRecord,
+        DnsCredentialRecord,
+        DnsCredentialSecrets,
+        StoredCertificate,
+    },
+    custom_domains::{
+        CustomDomainRecord,
+        CustomDomainRoute,
+    },
     deployments::{
         DeploymentClass,
         DeploymentRecord,

--- a/crates/orchestrator/src/storage/schema.rs
+++ b/crates/orchestrator/src/storage/schema.rs
@@ -130,6 +130,44 @@ CREATE TABLE IF NOT EXISTS custom_domains (
     created_at BIGINT NOT NULL
 );
 
+-- DNS provider API credentials, used for the ACME DNS-01 challenge.
+-- `secrets` is a sodium-secretbox sealed JSON blob (never returned to the
+-- dashboard) so a database dump doesn't leak the operator's DNS API tokens.
+CREATE TABLE IF NOT EXISTS dns_provider_credentials (
+    id BIGSERIAL PRIMARY KEY,
+    team_id BIGINT NOT NULL REFERENCES teams(id) ON DELETE CASCADE,
+    name TEXT NOT NULL,
+    provider TEXT NOT NULL,
+    secrets BYTEA NOT NULL,
+    created_at BIGINT NOT NULL,
+    UNIQUE (team_id, name)
+);
+
+-- One ACME account (and its private key) per directory URL. The key is
+-- sealed like DNS credentials: whoever holds it can issue certificates for
+-- any domain this orchestrator has validated.
+CREATE TABLE IF NOT EXISTS acme_accounts (
+    id BIGSERIAL PRIMARY KEY,
+    directory_url TEXT NOT NULL UNIQUE,
+    account_url TEXT NOT NULL,
+    credentials BYTEA NOT NULL,
+    created_at BIGINT NOT NULL
+);
+
+-- Issued certificates, keyed by domain. Kept in the database rather than
+-- only on disk so the Traefik dynamic directory can be rebuilt from scratch
+-- (new host, wiped volume) without re-running ACME and burning rate limit.
+-- `renew_after` is our own policy (issued_at + 60d), not a claim about the
+-- certificate's notAfter — we don't parse the cert, so recording an expiry
+-- we haven't read would be inventing a fact.
+CREATE TABLE IF NOT EXISTS custom_domain_certs (
+    domain TEXT PRIMARY KEY,
+    cert_pem TEXT NOT NULL,
+    key_pem TEXT NOT NULL,
+    issued_at BIGINT NOT NULL,
+    renew_after BIGINT NOT NULL
+);
+
 -- Per-project admin grants. Layered on top of team_members: a member can
 -- only be a project_admin if they're already on the team. A team admin
 -- has implicit admin rights on every project regardless of this table —

--- a/crates/orchestrator/tests/integration.rs
+++ b/crates/orchestrator/tests/integration.rs
@@ -344,6 +344,11 @@ async fn deployment_internal_flow_against_real_db() {
         enable_sidecars: false,
         postgres_image: "postgres:16-alpine".into(),
         minio_image: "quay.io/minio/minio:latest".into(),
+        traefik_dynamic_dir: None,
+        orchestrator_upstream: "orchestrator:8050".into(),
+        traefik_cert_dir: "/dynamic".into(),
+        acme_contact_email: None,
+        acme_directory_url: None,
     };
 
     // Construct OrchestratorState the public way, then swap in the stub
@@ -651,6 +656,11 @@ async fn test_state(
         enable_sidecars: false,
         postgres_image: "postgres:16-alpine".into(),
         minio_image: "quay.io/minio/minio:latest".into(),
+        traefik_dynamic_dir: None,
+        orchestrator_upstream: "orchestrator:8050".into(),
+        traefik_cert_dir: "/dynamic".into(),
+        acme_contact_email: None,
+        acme_directory_url: None,
     };
 
     OrchestratorState::new(config)

--- a/crates/orchestrator_api_types/src/dashboard.rs
+++ b/crates/orchestrator_api_types/src/dashboard.rs
@@ -269,3 +269,108 @@ pub struct DeviceAuthorizeResponse {
     pub access_token: String,
     pub member_id: u64,
 }
+
+#[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct CustomDomain {
+    pub id: i64,
+    pub deployment_id: i64,
+    pub domain: String,
+    /// `pending` -> `issuing` -> `active`, or `failed`. Only ever set from an
+    /// observed outcome: `active` means an HTTPS request to the domain
+    /// actually succeeded, not that issuance was requested.
+    pub cert_state: String,
+    pub created_at: i64,
+    /// `http-01` (no credentials needed) or `dns-01` (needs a DNS provider
+    /// credential, and is the only option for wildcards).
+    pub challenge_type: String,
+    pub dns_credential_id: Option<i64>,
+    /// Verbatim reason the last issuance failed, if it did.
+    pub last_error: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct DnsProviderField {
+    pub key: String,
+    pub label: String,
+    pub help: String,
+}
+
+/// A DNS provider the orchestrator can drive, plus the secret fields its
+/// credential form needs. Sent to the dashboard so adding a provider doesn't
+/// require a matching dashboard change.
+#[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct DnsProviderInfo {
+    pub provider: String,
+    pub fields: Vec<DnsProviderField>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct DnsCredential {
+    pub id: i64,
+    pub name: String,
+    pub provider: String,
+    pub created_at: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ListDnsCredentials {
+    pub credentials: Vec<DnsCredential>,
+    pub providers: Vec<DnsProviderInfo>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateDnsCredentialArgs {
+    pub name: String,
+    pub provider: String,
+    /// Provider secrets keyed by the field `key`s advertised in
+    /// [`DnsProviderInfo`]. Sealed before storage and never returned.
+    pub secrets: std::collections::BTreeMap<String, String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateCustomDomainArgs {
+    pub domain: String,
+    /// Defaults to `http-01`, which needs no credentials.
+    #[serde(default)]
+    pub challenge_type: Option<String>,
+    #[serde(default)]
+    pub dns_credential_id: Option<i64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ListCustomDomains {
+    pub domains: Vec<CustomDomain>,
+    /// Providers available for dns-01, with their credential form fields.
+    pub providers: Vec<DnsProviderInfo>,
+    /// Hostname the operator should CNAME/A-record the custom domain at.
+    /// Empty when the orchestrator has no public router host configured.
+    pub target_host: String,
+    /// False when the orchestrator has no Traefik dynamic directory wired up,
+    /// in which case adding a domain would record a row that never routes.
+    pub routing_enabled: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct CustomDomainArgs {
+    pub domain: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct VerifyCustomDomainResponse {
+    pub domain: String,
+    pub cert_state: String,
+    /// Why the probe failed, when it did. Surfaced verbatim in the dashboard
+    /// because the causes (DNS not pointed here, ACME rate limit) are things
+    /// only the operator can fix.
+    pub error: Option<String>,
+}

--- a/npm-packages/dashboard-orchestrator/jest.config.ts
+++ b/npm-packages/dashboard-orchestrator/jest.config.ts
@@ -13,6 +13,12 @@ const customJestConfig = {
     "^@common/(.*)$": "<rootDir>/../dashboard-common/src/$1",
     "^@ui/(.*)$": "<rootDir>/../@convex-dev/design-system/src/$1",
     "^lodash-es$": "lodash",
+    // Workspace packages aren't always discoverable from
+    // `dashboard-common/src` when jest is invoked from
+    // `dashboard-orchestrator`. Map the bare specifier to the workspace
+    // package's CJS build so Jest's resolver finds it deterministically.
+    // Same fix dashboard-self-hosted applies.
+    "^id-encoding$": "<rootDir>/../id-encoding",
   },
   roots: ["<rootDir>"],
 };

--- a/npm-packages/dashboard-orchestrator/src/__tests__/customDomains.test.tsx
+++ b/npm-packages/dashboard-orchestrator/src/__tests__/customDomains.test.tsx
@@ -1,0 +1,250 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { SWRConfig } from "swr";
+import { CustomDomainsCard } from "../components/CustomDomainsCard";
+
+const mockList = jest.fn();
+const mockCreate = jest.fn();
+const mockDelete = jest.fn();
+const mockVerify = jest.fn();
+const mockRetry = jest.fn();
+const mockListCreds = jest.fn();
+
+jest.mock("../lib/config", () => ({
+  orchestratorUrl: () => "http://orchestrator.test",
+}));
+
+jest.mock("../lib/useOrchestratorToken", () => ({
+  useAccessToken: () => "pat_test",
+}));
+
+jest.mock("../lib/orchestratorApi", () => ({
+  listCustomDomains: (...a: unknown[]) => mockList(...a),
+  createCustomDomain: (...a: unknown[]) => mockCreate(...a),
+  deleteCustomDomain: (...a: unknown[]) => mockDelete(...a),
+  verifyCustomDomain: (...a: unknown[]) => mockVerify(...a),
+  retryCustomDomain: (...a: unknown[]) => mockRetry(...a),
+  listDnsCredentials: (...a: unknown[]) => mockListCreds(...a),
+  createDnsCredential: jest.fn(),
+  deleteDnsCredential: jest.fn(),
+}));
+
+function renderCard() {
+  // `provider` gives each test a fresh cache so one test's domains don't
+  // leak into the next through SWR's module-level store.
+  return render(
+    <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>
+      <CustomDomainsCard
+        deploymentId={7}
+        deploymentName="happy-otter-123"
+        teamId={3}
+      />
+    </SWRConfig>,
+  );
+}
+
+beforeEach(() => {
+  mockList.mockReset();
+  mockCreate.mockReset();
+  mockDelete.mockReset();
+  mockVerify.mockReset();
+  mockRetry.mockReset();
+  mockListCreds.mockReset();
+  mockList.mockResolvedValue({
+    domains: [],
+    targetHost: "convex.example.com",
+    routingEnabled: true,
+    providers: [{ provider: "cloudflare", fields: [] }],
+  });
+  mockListCreds.mockResolvedValue({
+    credentials: [{ id: 5, name: "cf", provider: "cloudflare", createdAt: 0 }],
+    providers: [{ provider: "cloudflare", fields: [] }],
+  });
+});
+
+test("shows the CNAME target the operator has to point DNS at", async () => {
+  renderCard();
+  await waitFor(() =>
+    expect(screen.getByText("convex.example.com")).toBeInTheDocument(),
+  );
+});
+
+test("adds a domain and refreshes the list", async () => {
+  const user = userEvent.setup();
+  mockCreate.mockResolvedValue({});
+  renderCard();
+  await waitFor(() => expect(mockList).toHaveBeenCalled());
+
+  await user.type(screen.getByLabelText("Domain"), "api.example.com");
+  await user.click(screen.getByRole("button", { name: "Add" }));
+
+  await waitFor(() =>
+    expect(mockCreate).toHaveBeenCalledWith(
+      "http://orchestrator.test",
+      "pat_test",
+      7,
+      "api.example.com",
+      "http-01",
+      null,
+    ),
+  );
+  // Re-listed so the new row appears without a manual reload.
+  await waitFor(() => expect(mockList).toHaveBeenCalledTimes(2));
+});
+
+test("surfaces the server's rejection instead of silently failing", async () => {
+  const user = userEvent.setup();
+  mockCreate.mockRejectedValue(
+    new Error("api.example.com is already attached to a deployment"),
+  );
+  renderCard();
+  await waitFor(() => expect(mockList).toHaveBeenCalled());
+
+  await user.type(screen.getByLabelText("Domain"), "api.example.com");
+  await user.click(screen.getByRole("button", { name: "Add" }));
+
+  await waitFor(() =>
+    expect(
+      screen.getByText("api.example.com is already attached to a deployment"),
+    ).toBeInTheDocument(),
+  );
+});
+
+test("reports a domain as pending until a probe confirms the certificate", async () => {
+  mockList.mockResolvedValue({
+    domains: [
+      {
+        id: 1,
+        deploymentId: 7,
+        domain: "api.example.com",
+        certState: "pending",
+        createdAt: 0,
+        challengeType: "http-01",
+        dnsCredentialId: null,
+        lastError: null,
+      },
+    ],
+    targetHost: "convex.example.com",
+    routingEnabled: true,
+    providers: [{ provider: "cloudflare", fields: [] }],
+  });
+  renderCard();
+
+  await waitFor(() => expect(screen.getByText("Pending")).toBeInTheDocument());
+  expect(screen.queryByText("Active")).not.toBeInTheDocument();
+});
+
+test("shows why a check failed so the operator can fix DNS", async () => {
+  const user = userEvent.setup();
+  mockList.mockResolvedValue({
+    domains: [
+      {
+        id: 1,
+        deploymentId: 7,
+        domain: "api.example.com",
+        certState: "pending",
+        createdAt: 0,
+        challengeType: "http-01",
+        dnsCredentialId: null,
+        lastError: null,
+      },
+    ],
+    targetHost: "convex.example.com",
+    routingEnabled: true,
+    providers: [{ provider: "cloudflare", fields: [] }],
+  });
+  mockVerify.mockResolvedValue({
+    domain: "api.example.com",
+    certState: "pending",
+    error: "dns error: no such host",
+  });
+  renderCard();
+  await waitFor(() => expect(mockList).toHaveBeenCalled());
+
+  await user.click(screen.getByRole("button", { name: "Check" }));
+
+  await waitFor(() =>
+    expect(screen.getByText("dns error: no such host")).toBeInTheDocument(),
+  );
+});
+
+test("warns when the orchestrator cannot actually route custom domains", async () => {
+  mockList.mockResolvedValue({
+    domains: [],
+    targetHost: "convex.example.com",
+    routingEnabled: false,
+    providers: [],
+  });
+  renderCard();
+
+  await waitFor(() =>
+    expect(
+      screen.getByText(/Custom domain routing is not enabled/),
+    ).toBeInTheDocument(),
+  );
+});
+
+test("sends the dns-01 challenge with the chosen credential", async () => {
+  const user = userEvent.setup();
+  mockCreate.mockResolvedValue({});
+  renderCard();
+  await waitFor(() => expect(mockListCreds).toHaveBeenCalled());
+
+  await user.type(screen.getByLabelText("Domain"), "*.example.com");
+  await user.selectOptions(screen.getByLabelText("Challenge"), "dns-01");
+  await user.selectOptions(await screen.findByLabelText("Credential"), "5");
+  await user.click(screen.getByRole("button", { name: "Add" }));
+
+  await waitFor(() =>
+    expect(mockCreate).toHaveBeenCalledWith(
+      "http://orchestrator.test",
+      "pat_test",
+      7,
+      "*.example.com",
+      "dns-01",
+      5,
+    ),
+  );
+});
+
+test("warns that a wildcard cannot use the http-01 challenge", async () => {
+  const user = userEvent.setup();
+  renderCard();
+  await waitFor(() => expect(mockList).toHaveBeenCalled());
+
+  await user.type(screen.getByLabelText("Domain"), "*.example.com");
+
+  expect(
+    screen.getByText(/Wildcard domains can only be validated with DNS-01/),
+  ).toBeInTheDocument();
+});
+
+test("surfaces a failed issuance and offers a retry", async () => {
+  const user = userEvent.setup();
+  mockList.mockResolvedValue({
+    domains: [
+      {
+        id: 1,
+        deploymentId: 7,
+        domain: "api.example.com",
+        certState: "failed",
+        createdAt: 0,
+        challengeType: "dns-01",
+        dnsCredentialId: 5,
+        lastError: "Cloudflare rejected the token",
+      },
+    ],
+    targetHost: "convex.example.com",
+    routingEnabled: true,
+    providers: [],
+  });
+  renderCard();
+
+  await waitFor(() =>
+    expect(
+      screen.getByText("Cloudflare rejected the token"),
+    ).toBeInTheDocument(),
+  );
+  await user.click(screen.getByRole("button", { name: "Retry" }));
+  await waitFor(() => expect(mockRetry).toHaveBeenCalled());
+});

--- a/npm-packages/dashboard-orchestrator/src/__tests__/login.test.tsx
+++ b/npm-packages/dashboard-orchestrator/src/__tests__/login.test.tsx
@@ -10,10 +10,13 @@ jest.mock("next/router", () => ({
   useRouter: () => mockUseRouter(),
 }));
 
+// The factory must reach `mockSignInEmail` lazily: `jest.mock` is hoisted
+// above the `const` declarations, so capturing the binding directly throws a
+// TDZ ReferenceError when `login.tsx` requires this module.
 jest.mock("../lib/auth-client", () => ({
   authClient: {
     signIn: {
-      email: mockSignInEmail,
+      email: (...args: unknown[]) => mockSignInEmail(...args),
       social: jest.fn(),
     },
     signUp: {

--- a/npm-packages/dashboard-orchestrator/src/__tests__/loginSessionCache.test.tsx
+++ b/npm-packages/dashboard-orchestrator/src/__tests__/loginSessionCache.test.tsx
@@ -1,0 +1,132 @@
+// Regression test for the "I have to refresh the page before logging in"
+// bug. The orchestrator caches the `/api/orchestrator/token` session lookup
+// in SWR with a 30s deduping interval (see `_app.tsx`). While signed out
+// that key is cached as `null`. After a successful sign-in the app used to
+// client-side navigate straight to `/`, where `IndexPage` read the *stale*
+// `null` session out of the cache — within the dedupe window, so no refetch
+// happened — decided the user was signed out, and bounced back to `/login`.
+// A manual browser refresh cleared the in-memory cache, which is why logging
+// in "worked" only after refreshing first.
+
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { SWRConfig } from "swr";
+import LoginPage from "../pages/login";
+import IndexPage from "../pages/index";
+
+const mockReplace = jest.fn();
+const mockSignInEmail = jest.fn();
+const mockListTeams = jest.fn();
+
+jest.mock("next/router", () => ({
+  useRouter: () => ({ query: {}, replace: mockReplace }),
+}));
+
+jest.mock("../lib/auth-client", () => ({
+  authClient: {
+    signIn: {
+      email: (...args: unknown[]) => mockSignInEmail(...args),
+      social: jest.fn(),
+    },
+    signUp: { email: jest.fn() },
+  },
+}));
+
+jest.mock("../lib/config", () => ({
+  orchestratorUrl: () => "http://orchestrator.test",
+}));
+
+jest.mock("../lib/orchestratorApi", () => ({
+  listTeams: (...args: unknown[]) => mockListTeams(...args),
+}));
+
+// Mirrors the SWR options `_app.tsx` installs app-wide — the 30s
+// `dedupingInterval` is the part that makes the stale entry sticky.
+function AppShell({ children }: { children: React.ReactNode }) {
+  return (
+    <SWRConfig
+      value={{
+        revalidateOnFocus: false,
+        revalidateOnReconnect: false,
+        dedupingInterval: 30_000,
+        keepPreviousData: true,
+        shouldRetryOnError: false,
+      }}
+    >
+      {children}
+    </SWRConfig>
+  );
+}
+
+let signedIn = false;
+
+beforeEach(() => {
+  mockReplace.mockReset();
+  mockSignInEmail.mockReset();
+  mockListTeams.mockReset();
+  signedIn = false;
+
+  mockSignInEmail.mockImplementation(async () => {
+    signedIn = true;
+    return {};
+  });
+  mockListTeams.mockResolvedValue([{ id: 1, name: "Acme", slug: "acme" }]);
+
+  global.fetch = jest.fn(async (input: RequestInfo | URL) => {
+    const url = String(input);
+    if (url.startsWith("/api/orchestrator/token")) {
+      return signedIn
+        ? ({
+            ok: true,
+            status: 200,
+            json: async () => ({
+              accessToken: "pat_test",
+              memberId: 1,
+              teamSlug: "acme",
+              role: "admin",
+            }),
+          } as Response)
+        : ({ ok: false, status: 401 } as Response);
+    }
+    throw new Error(`unexpected fetch: ${url}`);
+  }) as unknown as typeof fetch;
+});
+
+test("signing in lands on the team page without a manual refresh first", async () => {
+  const user = userEvent.setup();
+
+  // 1. Signed out: the index page bounces to /login and, in doing so,
+  //    populates the SWR cache with a `null` session.
+  const loggedOut = render(
+    <AppShell>
+      <IndexPage />
+    </AppShell>,
+  );
+  await waitFor(() => expect(mockReplace).toHaveBeenCalledWith("/login"));
+  loggedOut.unmount();
+
+  // 2. The user signs in successfully on /login.
+  mockReplace.mockReset();
+  const login = render(
+    <AppShell>
+      <LoginPage />
+    </AppShell>,
+  );
+  await user.type(screen.getByLabelText("Email"), "user@example.com");
+  await user.type(screen.getByLabelText("Password"), "password123");
+  await user.click(screen.getByRole("button", { name: "Sign in" }));
+  await waitFor(() => expect(mockSignInEmail).toHaveBeenCalled());
+  login.unmount();
+
+  // 3. Landing back on `/` must resolve the *new* session rather than the
+  //    cached signed-out one, and route to the user's team.
+  mockReplace.mockReset();
+  render(
+    <AppShell>
+      <IndexPage />
+    </AppShell>,
+  );
+
+  await waitFor(() => expect(mockReplace).toHaveBeenCalledWith("/t/acme"));
+  expect(mockReplace).not.toHaveBeenCalledWith("/login");
+});

--- a/npm-packages/dashboard-orchestrator/src/components/CustomDomainsCard.tsx
+++ b/npm-packages/dashboard-orchestrator/src/components/CustomDomainsCard.tsx
@@ -1,0 +1,293 @@
+// Custom domain management for a single deployment.
+//
+// The orchestrator issues certificates itself (Traefik's cert resolvers are
+// static config and could never be driven from here), so this card exposes
+// the choice Traefik would otherwise have baked into a restart: which ACME
+// challenge to use, and which DNS credential to use with it.
+//
+// Nothing here claims a domain is live on its own — `certState` reaches
+// `active` only after the orchestrator has completed a real HTTPS request
+// against the domain.
+
+import { useState } from "react";
+import { Button } from "@ui/Button";
+import { TextInput } from "@ui/TextInput";
+import { Sheet } from "@ui/Sheet";
+import { Spinner } from "@ui/Spinner";
+import { ConfirmationDialog } from "@ui/ConfirmationDialog";
+import { CopyButton } from "@common/elements/CopyButton";
+import { CheckCircledIcon, TrashIcon } from "@radix-ui/react-icons";
+import { useCustomDomains, useDnsCredentials } from "../hooks/useCustomDomains";
+
+type Challenge = "http-01" | "dns-01";
+
+export function CustomDomainsCard({
+  deploymentId,
+  deploymentName,
+  teamId,
+  heading = "Custom Domains",
+}: {
+  deploymentId: number | undefined;
+  deploymentName?: string;
+  teamId?: number;
+  heading?: string;
+}) {
+  const {
+    domains,
+    targetHost,
+    routingEnabled,
+    error,
+    isLoading,
+    add,
+    remove,
+    retry,
+    verify,
+  } = useCustomDomains(deploymentId);
+  const { credentials } = useDnsCredentials(teamId);
+
+  const [draft, setDraft] = useState("");
+  const [challenge, setChallenge] = useState<Challenge>("http-01");
+  const [credentialId, setCredentialId] = useState<string>("");
+  const [submitting, setSubmitting] = useState(false);
+  const [formError, setFormError] = useState<string | null>(null);
+  const [pendingDelete, setPendingDelete] = useState<string | null>(null);
+  const [busy, setBusy] = useState<string | null>(null);
+  const [probeErrors, setProbeErrors] = useState<Record<string, string>>({});
+
+  const isWildcard = draft.trim().startsWith("*.");
+
+  const onAdd = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const domain = draft.trim();
+    if (!domain) return;
+    setSubmitting(true);
+    setFormError(null);
+    try {
+      await add(
+        domain,
+        challenge,
+        challenge === "dns-01" && credentialId ? Number(credentialId) : null,
+      );
+      setDraft("");
+    } catch (err) {
+      setFormError((err as Error).message);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const onVerify = async (domain: string) => {
+    setBusy(domain);
+    try {
+      const result = await verify(domain);
+      setProbeErrors((prev) => ({ ...prev, [domain]: result?.error ?? "" }));
+    } catch (err) {
+      setProbeErrors((prev) => ({ ...prev, [domain]: (err as Error).message }));
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const onRetry = async (domain: string) => {
+    setBusy(domain);
+    try {
+      await retry(domain);
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  return (
+    <Sheet>
+      <h3>{heading}</h3>
+      {deploymentName && (
+        <p className="mt-1 text-xs text-content-secondary">
+          Deployment <code>{deploymentName}</code>
+        </p>
+      )}
+
+      {!routingEnabled && !isLoading && (
+        <p className="mt-2 max-w-prose text-sm text-content-warning">
+          Custom domain routing is not enabled on this orchestrator. Set{" "}
+          <code className="rounded-sm bg-background-tertiary px-1 text-xs">
+            CONVEX_ORCHESTRATOR_TRAEFIK_DYNAMIC_DIR
+          </code>{" "}
+          and restart it — until then a domain added here would be recorded but
+          never routed.
+        </p>
+      )}
+
+      <p className="mt-2 max-w-prose text-sm text-content-secondary">
+        Point a CNAME at{" "}
+        <code className="rounded-sm bg-background-tertiary px-1 text-xs">
+          {targetHost || "your orchestrator host"}
+        </code>
+        , then add the hostname below. The certificate is issued and renewed
+        automatically — no Traefik restart, and nothing to edit on the server.
+      </p>
+
+      <form onSubmit={onAdd} className="mt-4 flex flex-col gap-3">
+        <div className="flex flex-wrap items-end gap-2">
+          <div className="min-w-40 grow">
+            <TextInput
+              id="custom-domain"
+              label="Domain"
+              placeholder="api.example.com"
+              value={draft}
+              onChange={(e) => setDraft(e.target.value)}
+            />
+          </div>
+          <label className="flex flex-col gap-1 text-sm">
+            <span className="text-content-primary">Challenge</span>
+            <select
+              aria-label="Challenge"
+              className="h-9 rounded-sm border bg-background-secondary px-2 text-sm"
+              value={challenge}
+              onChange={(e) => setChallenge(e.target.value as Challenge)}
+            >
+              <option value="http-01">HTTP-01 (no setup)</option>
+              <option value="dns-01">DNS-01 (needs credential)</option>
+            </select>
+          </label>
+          {challenge === "dns-01" && (
+            <label className="flex flex-col gap-1 text-sm">
+              <span className="text-content-primary">Credential</span>
+              <select
+                aria-label="Credential"
+                className="h-9 rounded-sm border bg-background-secondary px-2 text-sm"
+                value={credentialId}
+                onChange={(e) => setCredentialId(e.target.value)}
+              >
+                <option value="">Select…</option>
+                {credentials?.map((c) => (
+                  <option key={c.id} value={String(c.id)}>
+                    {c.name} ({c.provider})
+                  </option>
+                ))}
+              </select>
+            </label>
+          )}
+          <Button type="submit" disabled={submitting || !draft.trim()}>
+            Add
+          </Button>
+        </div>
+
+        {isWildcard && challenge !== "dns-01" && (
+          <p className="text-xs text-content-warning">
+            Wildcard domains can only be validated with DNS-01 — there is no
+            single host an HTTP challenge could be served from.
+          </p>
+        )}
+        {challenge === "dns-01" && credentials?.length === 0 && (
+          <p className="text-xs text-content-warning">
+            No DNS credentials yet. Add one below to use DNS-01.
+          </p>
+        )}
+        {formError && (
+          <p className="text-xs text-content-error" role="alert">
+            {formError}
+          </p>
+        )}
+      </form>
+
+      <div className="mt-4 flex flex-col gap-2">
+        {isLoading && <Spinner className="size-4" />}
+        {error && (
+          <p className="text-sm text-content-error">
+            Could not load custom domains: {error.message}
+          </p>
+        )}
+        {domains?.length === 0 && (
+          <p className="text-sm text-content-secondary">
+            No custom domains yet.
+          </p>
+        )}
+        {domains?.map((d) => {
+          const probeError = probeErrors[d.domain];
+          return (
+            <div
+              key={d.domain}
+              className="flex flex-col gap-1 rounded-sm border p-3"
+            >
+              <div className="flex flex-wrap items-center gap-2">
+                <code className="grow truncate text-sm">{d.domain}</code>
+                <span className="text-xs text-content-secondary">
+                  {d.challengeType}
+                </span>
+                <CopyButton text={d.domain} />
+                <CertStateBadge certState={d.certState} />
+                <Button
+                  size="xs"
+                  variant="neutral"
+                  disabled={busy === d.domain}
+                  onClick={() => void onVerify(d.domain)}
+                >
+                  {busy === d.domain ? "Checking…" : "Check"}
+                </Button>
+                {d.certState === "failed" && (
+                  <Button
+                    size="xs"
+                    variant="neutral"
+                    disabled={busy === d.domain}
+                    onClick={() => void onRetry(d.domain)}
+                  >
+                    Retry
+                  </Button>
+                )}
+                <Button
+                  size="xs"
+                  variant="danger"
+                  icon={<TrashIcon />}
+                  aria-label={`Remove ${d.domain}`}
+                  onClick={() => setPendingDelete(d.domain)}
+                />
+              </div>
+              {(probeError || d.lastError) && (
+                <p className="text-xs text-content-error">
+                  {probeError || d.lastError}
+                </p>
+              )}
+            </div>
+          );
+        })}
+      </div>
+
+      {pendingDelete && (
+        <ConfirmationDialog
+          onClose={() => setPendingDelete(null)}
+          onConfirm={async () => {
+            await remove(pendingDelete);
+            setPendingDelete(null);
+          }}
+          confirmText="Remove"
+          variant="danger"
+          dialogTitle="Remove custom domain"
+          dialogBody={`${pendingDelete} will stop routing to this deployment as soon as Traefik reloads, and its certificate will be deleted.`}
+        />
+      )}
+    </Sheet>
+  );
+}
+
+function CertStateBadge({ certState }: { certState: string }) {
+  if (certState === "active") {
+    return (
+      <span className="flex items-center gap-1 text-xs text-content-success">
+        <CheckCircledIcon />
+        Active
+      </span>
+    );
+  }
+  if (certState === "issuing") {
+    return (
+      <span className="flex items-center gap-1 text-xs text-content-secondary">
+        <Spinner className="size-3" />
+        Issuing
+      </span>
+    );
+  }
+  if (certState === "failed") {
+    return <span className="text-xs text-content-error">Failed</span>;
+  }
+  return <span className="text-xs text-content-secondary">Pending</span>;
+}

--- a/npm-packages/dashboard-orchestrator/src/components/DnsCredentialsCard.tsx
+++ b/npm-packages/dashboard-orchestrator/src/components/DnsCredentialsCard.tsx
@@ -1,0 +1,164 @@
+// DNS provider credentials for the ACME dns-01 challenge.
+//
+// Tokens are sealed by the orchestrator before they hit Postgres and are
+// never sent back, so this card can list and replace credentials but can
+// never show one. Saving under an existing name rotates the token.
+
+import { useState } from "react";
+import { Button } from "@ui/Button";
+import { TextInput } from "@ui/TextInput";
+import { Sheet } from "@ui/Sheet";
+import { Spinner } from "@ui/Spinner";
+import { ConfirmationDialog } from "@ui/ConfirmationDialog";
+import { TrashIcon } from "@radix-ui/react-icons";
+import { useDnsCredentials } from "../hooks/useCustomDomains";
+
+export function DnsCredentialsCard({ teamId }: { teamId: number | undefined }) {
+  const { credentials, providers, error, isLoading, add, remove } =
+    useDnsCredentials(teamId);
+
+  const [name, setName] = useState("");
+  const [provider, setProvider] = useState("");
+  const [secrets, setSecrets] = useState<Record<string, string>>({});
+  const [submitting, setSubmitting] = useState(false);
+  const [formError, setFormError] = useState<string | null>(null);
+  const [pendingDelete, setPendingDelete] = useState<number | null>(null);
+
+  const selected = providers.find((p) => p.provider === provider);
+
+  const onSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    if (!name.trim() || !provider) return;
+    setSubmitting(true);
+    setFormError(null);
+    try {
+      await add(name.trim(), provider, secrets);
+      setName("");
+      setProvider("");
+      setSecrets({});
+    } catch (err) {
+      setFormError((err as Error).message);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Sheet>
+      <h3>DNS Provider Credentials</h3>
+      <p className="mt-2 max-w-prose text-sm text-content-secondary">
+        Needed only for the <code>dns-01</code> challenge — which is what lets
+        you issue a wildcard certificate, or validate a domain when port 80
+        isn&apos;t reachable. Tokens are encrypted before storage and never
+        shown again. Saving under an existing name replaces the token.
+      </p>
+
+      <form onSubmit={onSubmit} className="mt-4 flex flex-col gap-3">
+        <div className="flex flex-wrap items-end gap-2">
+          <div className="min-w-40 grow">
+            <TextInput
+              id="dns-cred-name"
+              label="Name"
+              placeholder="cloudflare-prod"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+            />
+          </div>
+          <label className="flex flex-col gap-1 text-sm">
+            <span className="text-content-primary">Provider</span>
+            <select
+              aria-label="Provider"
+              className="h-9 rounded-sm border bg-background-secondary px-2 text-sm"
+              value={provider}
+              onChange={(e) => {
+                setProvider(e.target.value);
+                setSecrets({});
+              }}
+            >
+              <option value="">Select…</option>
+              {providers.map((p) => (
+                <option key={p.provider} value={p.provider}>
+                  {p.provider}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
+
+        {selected?.fields.map((field) => (
+          <TextInput
+            key={field.key}
+            id={`dns-cred-${field.key}`}
+            label={field.label}
+            type="password"
+            autoComplete="off"
+            description={field.help}
+            value={secrets[field.key] ?? ""}
+            onChange={(e) =>
+              setSecrets((prev) => ({ ...prev, [field.key]: e.target.value }))
+            }
+          />
+        ))}
+
+        {formError && (
+          <p className="text-xs text-content-error" role="alert">
+            {formError}
+          </p>
+        )}
+
+        <div>
+          <Button
+            type="submit"
+            disabled={submitting || !name.trim() || !provider}
+          >
+            Save credential
+          </Button>
+        </div>
+      </form>
+
+      <div className="mt-4 flex flex-col gap-2">
+        {isLoading && <Spinner className="size-4" />}
+        {error && (
+          <p className="text-sm text-content-error">
+            Could not load credentials: {error.message}
+          </p>
+        )}
+        {credentials?.length === 0 && (
+          <p className="text-sm text-content-secondary">
+            No DNS credentials yet.
+          </p>
+        )}
+        {credentials?.map((c) => (
+          <div
+            key={c.id}
+            className="flex items-center gap-2 rounded-sm border p-3"
+          >
+            <span className="grow truncate text-sm">{c.name}</span>
+            <span className="text-xs text-content-secondary">{c.provider}</span>
+            <Button
+              size="xs"
+              variant="danger"
+              icon={<TrashIcon />}
+              aria-label={`Remove ${c.name}`}
+              onClick={() => setPendingDelete(c.id)}
+            />
+          </div>
+        ))}
+      </div>
+
+      {pendingDelete !== null && (
+        <ConfirmationDialog
+          onClose={() => setPendingDelete(null)}
+          onConfirm={async () => {
+            await remove(pendingDelete);
+            setPendingDelete(null);
+          }}
+          confirmText="Remove"
+          variant="danger"
+          dialogTitle="Remove DNS credential"
+          dialogBody="Domains using this credential will fail to renew until another one is attached."
+        />
+      )}
+    </Sheet>
+  );
+}

--- a/npm-packages/dashboard-orchestrator/src/hooks/useCustomDomains.ts
+++ b/npm-packages/dashboard-orchestrator/src/hooks/useCustomDomains.ts
@@ -1,0 +1,112 @@
+import useSWR from "swr";
+import {
+  createCustomDomain,
+  createDnsCredential,
+  deleteCustomDomain,
+  deleteDnsCredential,
+  listCustomDomains,
+  listDnsCredentials,
+  retryCustomDomain,
+  verifyCustomDomain,
+} from "../lib/orchestratorApi";
+import { useAccessToken } from "../lib/useOrchestratorToken";
+import { orchestratorUrl } from "../lib/config";
+
+export function useCustomDomains(deploymentId: number | undefined) {
+  const token = useAccessToken();
+  const url = orchestratorUrl();
+  const { data, error, isLoading, mutate } = useSWR(
+    token && deploymentId ? ["customDomains", deploymentId, token] : null,
+    () => listCustomDomains(url, token!, deploymentId!),
+    // Issuance happens in the background and can take a minute (DNS
+    // propagation), so poll while the page is open rather than making the
+    // operator reload to watch a domain go active.
+    { refreshInterval: 10_000 },
+  );
+
+  const add = async (
+    domain: string,
+    challengeType: "http-01" | "dns-01",
+    dnsCredentialId?: number | null,
+  ) => {
+    if (!token || !deploymentId) return;
+    await createCustomDomain(
+      url,
+      token,
+      deploymentId,
+      domain,
+      challengeType,
+      dnsCredentialId,
+    );
+    await mutate();
+  };
+
+  const remove = async (domain: string) => {
+    if (!token || !deploymentId) return;
+    await deleteCustomDomain(url, token, deploymentId, domain);
+    await mutate();
+  };
+
+  const retry = async (domain: string) => {
+    if (!token || !deploymentId) return;
+    await retryCustomDomain(url, token, deploymentId, domain);
+    await mutate();
+  };
+
+  // Returns the probe result so the caller can surface *why* a domain is
+  // still pending — the causes (DNS not pointed here, ACME rate limit) are
+  // only fixable by the operator.
+  const verify = async (domain: string) => {
+    if (!token || !deploymentId) return undefined;
+    const result = await verifyCustomDomain(url, token, deploymentId, domain);
+    await mutate();
+    return result;
+  };
+
+  return {
+    domains: data?.domains,
+    targetHost: data?.targetHost,
+    routingEnabled: data?.routingEnabled ?? false,
+    providers: data?.providers ?? [],
+    error,
+    isLoading,
+    add,
+    remove,
+    retry,
+    verify,
+  };
+}
+
+export function useDnsCredentials(teamId: number | undefined) {
+  const token = useAccessToken();
+  const url = orchestratorUrl();
+  const { data, error, isLoading, mutate } = useSWR(
+    token && teamId ? ["dnsCredentials", teamId, token] : null,
+    () => listDnsCredentials(url, token!, teamId!),
+  );
+
+  const add = async (
+    name: string,
+    provider: string,
+    secrets: Record<string, string>,
+  ) => {
+    if (!token || !teamId) return;
+    await createDnsCredential(url, token, teamId, name, provider, secrets);
+    await mutate();
+  };
+
+  const remove = async (credentialId: number) => {
+    if (!token || !teamId) return;
+    await deleteDnsCredential(url, token, teamId, credentialId);
+    await mutate();
+  };
+
+  return {
+    credentials: data?.credentials,
+    providers: data?.providers ?? [],
+    error,
+    isLoading,
+    add,
+    remove,
+  };
+}

--- a/npm-packages/dashboard-orchestrator/src/lib/orchestratorApi.ts
+++ b/npm-packages/dashboard-orchestrator/src/lib/orchestratorApi.ts
@@ -434,3 +434,188 @@ export async function restartDeployment(
     },
   );
 }
+
+// ---------- Custom domains ----------
+
+export const customDomainSchema = z.object({
+  id: z.number(),
+  deploymentId: z.number(),
+  domain: z.string(),
+  certState: z.string(),
+  createdAt: z.number(),
+  challengeType: z.string(),
+  dnsCredentialId: z.number().nullable(),
+  lastError: z.string().nullable(),
+});
+
+export const dnsProviderFieldSchema = z.object({
+  key: z.string(),
+  label: z.string(),
+  help: z.string(),
+});
+
+/** Provider list is served by the orchestrator so adding one there needs no
+ * dashboard change. */
+export const dnsProviderInfoSchema = z.object({
+  provider: z.string(),
+  fields: z.array(dnsProviderFieldSchema),
+});
+export type DnsProviderInfo = z.infer<typeof dnsProviderInfoSchema>;
+
+export const dnsCredentialSchema = z.object({
+  id: z.number(),
+  name: z.string(),
+  provider: z.string(),
+  createdAt: z.number(),
+});
+export type DnsCredential = z.infer<typeof dnsCredentialSchema>;
+
+export const listDnsCredentialsSchema = z.object({
+  credentials: z.array(dnsCredentialSchema),
+  providers: z.array(dnsProviderInfoSchema),
+});
+export type ListDnsCredentialsResponse = z.infer<
+  typeof listDnsCredentialsSchema
+>;
+export type CustomDomain = z.infer<typeof customDomainSchema>;
+
+export const listCustomDomainsSchema = z.object({
+  domains: z.array(customDomainSchema),
+  targetHost: z.string(),
+  routingEnabled: z.boolean(),
+  providers: z.array(dnsProviderInfoSchema),
+});
+export type ListCustomDomainsResponse = z.infer<typeof listCustomDomainsSchema>;
+
+export const verifyCustomDomainSchema = z.object({
+  domain: z.string(),
+  certState: z.string(),
+  error: z.string().nullable(),
+});
+export type VerifyCustomDomainResponse = z.infer<
+  typeof verifyCustomDomainSchema
+>;
+
+export async function listCustomDomains(
+  baseUrl: string,
+  token: string,
+  deploymentId: number,
+): Promise<ListCustomDomainsResponse> {
+  const data = await request<unknown>(
+    baseUrl,
+    `/api/dashboard/deployments/${deploymentId}/custom_domains/list`,
+    { token },
+  );
+  return listCustomDomainsSchema.parse(data);
+}
+
+export async function createCustomDomain(
+  baseUrl: string,
+  token: string,
+  deploymentId: number,
+  domain: string,
+  challengeType: "http-01" | "dns-01" = "http-01",
+  dnsCredentialId?: number | null,
+): Promise<CustomDomain> {
+  const data = await request<unknown>(
+    baseUrl,
+    `/api/dashboard/deployments/${deploymentId}/custom_domains/create`,
+    {
+      method: "POST",
+      token,
+      body: JSON.stringify({
+        domain,
+        challengeType,
+        dnsCredentialId: dnsCredentialId ?? null,
+      }),
+    },
+  );
+  return customDomainSchema.parse(data);
+}
+
+/** Re-runs issuance for a domain whose last attempt failed. */
+export async function retryCustomDomain(
+  baseUrl: string,
+  token: string,
+  deploymentId: number,
+  domain: string,
+): Promise<void> {
+  await request<unknown>(
+    baseUrl,
+    `/api/dashboard/deployments/${deploymentId}/custom_domains/retry`,
+    { method: "POST", token, body: JSON.stringify({ domain }) },
+  );
+}
+
+export async function listDnsCredentials(
+  baseUrl: string,
+  token: string,
+  teamId: number,
+): Promise<ListDnsCredentialsResponse> {
+  const data = await request<unknown>(
+    baseUrl,
+    `/api/dashboard/teams/${teamId}/dns_credentials/list`,
+    { token },
+  );
+  return listDnsCredentialsSchema.parse(data);
+}
+
+export async function createDnsCredential(
+  baseUrl: string,
+  token: string,
+  teamId: number,
+  name: string,
+  provider: string,
+  secrets: Record<string, string>,
+): Promise<DnsCredential> {
+  const data = await request<unknown>(
+    baseUrl,
+    `/api/dashboard/teams/${teamId}/dns_credentials/create`,
+    {
+      method: "POST",
+      token,
+      body: JSON.stringify({ name, provider, secrets }),
+    },
+  );
+  return dnsCredentialSchema.parse(data);
+}
+
+export async function deleteDnsCredential(
+  baseUrl: string,
+  token: string,
+  teamId: number,
+  credentialId: number,
+): Promise<void> {
+  await request<unknown>(
+    baseUrl,
+    `/api/dashboard/teams/${teamId}/dns_credentials/${credentialId}/delete`,
+    { method: "POST", token },
+  );
+}
+
+export async function deleteCustomDomain(
+  baseUrl: string,
+  token: string,
+  deploymentId: number,
+  domain: string,
+): Promise<void> {
+  await request<unknown>(
+    baseUrl,
+    `/api/dashboard/deployments/${deploymentId}/custom_domains/delete`,
+    { method: "POST", token, body: JSON.stringify({ domain }) },
+  );
+}
+
+export async function verifyCustomDomain(
+  baseUrl: string,
+  token: string,
+  deploymentId: number,
+  domain: string,
+): Promise<VerifyCustomDomainResponse> {
+  const data = await request<unknown>(
+    baseUrl,
+    `/api/dashboard/deployments/${deploymentId}/custom_domains/verify`,
+    { method: "POST", token, body: JSON.stringify({ domain }) },
+  );
+  return verifyCustomDomainSchema.parse(data);
+}

--- a/npm-packages/dashboard-orchestrator/src/lib/useOrchestratorToken.ts
+++ b/npm-packages/dashboard-orchestrator/src/lib/useOrchestratorToken.ts
@@ -24,6 +24,23 @@ async function fetcher(url: string): Promise<OrchestratorSession | null> {
   return (await res.json()) as OrchestratorSession;
 }
 
+/**
+ * SWR cache key for the plain (no invite code) session lookup. Exported so
+ * sign-in can invalidate the cached signed-out session by key rather than
+ * re-spelling the URL — see `pages/login.tsx`.
+ */
+export const ORCHESTRATOR_SESSION_KEY = "/api/orchestrator/token";
+
+/**
+ * One-shot session fetch, outside of React. Sign-in feeds the result straight
+ * into the SWR cache so the next page reads the new session rather than the
+ * stale signed-out one — a bare `mutate(key)` only marks the entry for
+ * revalidation, which does nothing while no component is subscribed to it.
+ */
+export function fetchOrchestratorSession(): Promise<OrchestratorSession | null> {
+  return fetcher(ORCHESTRATOR_SESSION_KEY);
+}
+
 export function useOrchestratorSession() {
   return useOrchestratorSessionForInvite(undefined);
 }
@@ -35,8 +52,8 @@ export function useOrchestratorSessionForInvite(
     inviteCode === null
       ? null
       : inviteCode
-        ? `/api/orchestrator/token?inviteCode=${encodeURIComponent(inviteCode)}`
-        : "/api/orchestrator/token";
+        ? `${ORCHESTRATOR_SESSION_KEY}?inviteCode=${encodeURIComponent(inviteCode)}`
+        : ORCHESTRATOR_SESSION_KEY;
 
   return useSWR<OrchestratorSession | null>(key, fetcher, {
     revalidateOnFocus: false,

--- a/npm-packages/dashboard-orchestrator/src/pages/index.tsx
+++ b/npm-packages/dashboard-orchestrator/src/pages/index.tsx
@@ -13,6 +13,7 @@ export default function IndexPage() {
     data: session,
     error: sessionError,
     isLoading,
+    isValidating,
   } = useOrchestratorSession();
   const token = session?.accessToken ?? null;
 
@@ -22,7 +23,11 @@ export default function IndexPage() {
   );
 
   useEffect(() => {
-    if (isLoading) return;
+    // Never route off a session that is still settling. SWR serves the cached
+    // value synchronously on mount (`keepPreviousData`), so a signed-out
+    // `null` left over from before sign-in would otherwise bounce a
+    // just-authenticated user back to /login while the refetch is in flight.
+    if (isLoading || isValidating) return;
     // Not signed in (or BetterAuth session expired) → login.
     if (sessionError || !session) {
       void router.replace("/login");
@@ -36,7 +41,15 @@ export default function IndexPage() {
         void router.replace(`/t/${session.teamSlug}`);
       }
     }
-  }, [isLoading, sessionError, session, teams, teamsError, router]);
+  }, [
+    isLoading,
+    isValidating,
+    sessionError,
+    session,
+    teams,
+    teamsError,
+    router,
+  ]);
 
   return (
     <div className="flex size-full flex-col items-center justify-center gap-4">

--- a/npm-packages/dashboard-orchestrator/src/pages/login.tsx
+++ b/npm-packages/dashboard-orchestrator/src/pages/login.tsx
@@ -15,7 +15,12 @@ import {
 import Link from "next/link";
 import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
+import { useSWRConfig } from "swr";
 import { authClient } from "../lib/auth-client";
+import {
+  ORCHESTRATOR_SESSION_KEY,
+  fetchOrchestratorSession,
+} from "../lib/useOrchestratorToken";
 import { ConvexOrb } from "../components/ConvexOrb";
 
 type Mode = "signin" | "signup";
@@ -32,6 +37,7 @@ function safeRedirect(raw: string | string[] | undefined): string {
 
 export default function LoginPage() {
   const router = useRouter();
+  const { mutate } = useSWRConfig();
   const redirectTo = safeRedirect(router.query.redirect);
   const [mode, setMode] = useState<Mode>("signin");
   const [email, setEmail] = useState("");
@@ -102,6 +108,17 @@ export default function LoginPage() {
         if (res.error) throw new Error(res.error.message ?? "sign-up failed");
       }
       remember("email");
+      // While signed out, the session key is cached as `null`, and `_app.tsx`
+      // installs a 30s `dedupingInterval`. Navigating straight to `/` would
+      // let IndexPage read that stale `null` — no refetch happens inside the
+      // dedupe window — conclude the user is signed out, and bounce right
+      // back here. (That's why signing in only "worked" after a manual
+      // refresh, which cleared the in-memory cache.) Write the new session
+      // into the cache and wait for it before routing. `revalidate: false`
+      // because we're supplying the authoritative value ourselves.
+      await mutate(ORCHESTRATOR_SESSION_KEY, fetchOrchestratorSession(), {
+        revalidate: false,
+      });
       void router.replace(redirectTo);
     } catch (err) {
       setError((err as Error).message);

--- a/npm-packages/dashboard-orchestrator/src/pages/t/[team]/[project]/[deploymentName]/settings/custom-domains.tsx
+++ b/npm-packages/dashboard-orchestrator/src/pages/t/[team]/[project]/[deploymentName]/settings/custom-domains.tsx
@@ -1,24 +1,80 @@
 import { DeploymentSettingsLayout } from "@common/layouts/DeploymentSettingsLayout";
 import { Sheet } from "@ui/Sheet";
-import Link from "next/link";
 import { useRouter } from "next/router";
+import useSWR from "swr";
+import { useMemo } from "react";
+import {
+  listDeployments,
+  listProjects,
+  listTeams,
+} from "../../../../../../lib/orchestratorApi";
+import { useAccessToken } from "../../../../../../lib/useOrchestratorToken";
+import { orchestratorUrl } from "../../../../../../lib/config";
+import { CustomDomainsCard } from "../../../../../../components/CustomDomainsCard";
+import { DnsCredentialsCard } from "../../../../../../components/DnsCredentialsCard";
 
+// The route is keyed by deployment *name*, but the custom-domains API is
+// keyed by deployment id, so resolve team -> project -> deployment to get it.
 export default function CustomDomains() {
   const router = useRouter();
-  const { team, project } = router.query as { team?: string; project?: string };
+  const query = router.query as {
+    team?: string;
+    project?: string;
+    deploymentName?: string;
+  };
+  const { team: teamSlug, project: projectSlug, deploymentName } = query;
+  const token = useAccessToken();
+  const url = orchestratorUrl();
+
+  const { data: teams } = useSWR(token ? ["teams", token] : null, () =>
+    listTeams(url, token!),
+  );
+  const team = useMemo(
+    () => teams?.find((t) => t.slug === teamSlug),
+    [teams, teamSlug],
+  );
+
+  const { data: projects } = useSWR(
+    token && team ? ["projects", team.id, token] : null,
+    () => listProjects(url, token!, team!.id),
+  );
+  const project = useMemo(
+    () => projects?.find((p) => p.slug === projectSlug),
+    [projects, projectSlug],
+  );
+
+  const { data: deployments } = useSWR(
+    token && project ? ["deployments", project.id, token] : null,
+    () => listDeployments(url, token!, project!.id),
+  );
+  const deployment = useMemo(
+    () => deployments?.find((d) => d.name === deploymentName),
+    [deployments, deploymentName],
+  );
+
   return (
     <DeploymentSettingsLayout page="custom-domains">
-      <Sheet>
-        <h3>Custom Domains</h3>
-        <p className="mt-2 max-w-prose text-content-secondary">
-          Custom domains are managed by the orchestrator at the project level.{" "}
-          {team && project && (
-            <Link href={`/t/${team}/${project}/settings`} className="underline">
-              Open project settings
-            </Link>
-          )}
-        </p>
-      </Sheet>
+      {deployment === undefined ? (
+        <Sheet>
+          <h3>Custom Domains</h3>
+          <p className="mt-2 text-sm text-content-secondary">
+            {deployments === undefined
+              ? "Loading…"
+              : `No deployment named ${deploymentName ?? ""} in this project.`}
+          </p>
+        </Sheet>
+      ) : (
+        <div className="flex flex-col gap-6">
+          <CustomDomainsCard
+            deploymentId={deployment.id}
+            deploymentName={deployment.name}
+            teamId={team?.id}
+          />
+          {/* The domains card points here when dns-01 is selected without a
+              credential. Without this the hint would be a dead end. */}
+          <DnsCredentialsCard teamId={team?.id} />
+        </div>
+      )}
     </DeploymentSettingsLayout>
   );
 }

--- a/npm-packages/dashboard-orchestrator/src/pages/t/[team]/[project]/settings/index.tsx
+++ b/npm-packages/dashboard-orchestrator/src/pages/t/[team]/[project]/settings/index.tsx
@@ -26,6 +26,8 @@ import { tierDefaultsForName } from "../../../../../components/backendSettings/t
 import { useHostCapacity } from "../../../../../hooks/useHostCapacity";
 import { useKnobRegistry } from "../../../../../hooks/useKnobRegistry";
 import { useProjectSettings } from "../../../../../hooks/useProjectSettings";
+import { CustomDomainsCard } from "../../../../../components/CustomDomainsCard";
+import { DnsCredentialsCard } from "../../../../../components/DnsCredentialsCard";
 
 const SECTION_IDS = {
   projectForm: "project-form",
@@ -33,6 +35,7 @@ const SECTION_IDS = {
   projectAdmins: "project-admins",
   backend: "backend",
   envVars: "env-vars",
+  customDomains: "custom-domains",
   deleteProject: "delete-project",
 } as const;
 
@@ -42,6 +45,7 @@ const sections: Array<{ id: string; label: string }> = [
   { id: SECTION_IDS.projectAdmins, label: "Project Admins" },
   { id: SECTION_IDS.backend, label: "Backend" },
   { id: SECTION_IDS.envVars, label: "Environment Variables" },
+  { id: SECTION_IDS.customDomains, label: "Custom Domains" },
   { id: SECTION_IDS.deleteProject, label: "Delete Project" },
 ];
 
@@ -161,6 +165,9 @@ export default function ProjectSettingsPage() {
                 </div>
                 <div id={SECTION_IDS.envVars}>
                   <EnvVarsSection project={project} token={token} url={url} />
+                </div>
+                <div id={SECTION_IDS.customDomains}>
+                  <CustomDomainsSection team={team} project={project} />
                 </div>
                 <div id={SECTION_IDS.deleteProject}>
                   <DeleteProjectSection
@@ -786,6 +793,67 @@ function ProjectAdminsSection({
         )}
       </ul>
     </Sheet>
+  );
+}
+
+// Custom domains attach to a *deployment* (that's what a hostname has to
+// resolve to), but operators think about them per project — so the project
+// settings page renders one card per deployment rather than making them go
+// hunting through each deployment's settings.
+function CustomDomainsSection({
+  team,
+  project,
+}: {
+  team: Team;
+  project: Project;
+}) {
+  const token = useAccessToken();
+  const url = orchestratorUrl();
+  const { data: deployments } = useSWR(
+    token ? ["deployments", project.id, token] : null,
+    () => listDeployments(url, token!, project.id),
+  );
+
+  if (deployments === undefined) {
+    return (
+      <Sheet>
+        <h3>Custom Domains</h3>
+        <p className="mt-2 text-sm text-content-secondary">Loading…</p>
+      </Sheet>
+    );
+  }
+
+  if (deployments.length === 0) {
+    return (
+      <Sheet>
+        <h3>Custom Domains</h3>
+        <p className="mt-2 text-sm text-content-secondary">
+          This project has no deployments yet. Create one before attaching a
+          custom domain.
+        </p>
+      </Sheet>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-6">
+      {deployments.map((d) => (
+        <CustomDomainsCard
+          key={d.id}
+          deploymentId={d.id}
+          deploymentName={d.name}
+          teamId={team.id}
+          heading={
+            deployments.length > 1
+              ? `Custom Domains — ${d.deploymentType ?? d.kind ?? d.name}`
+              : "Custom Domains"
+          }
+        />
+      ))}
+      {/* Credentials are team-scoped and shared by every domain, so they sit
+          below the per-deployment cards rather than inside each one. */}
+      <DnsCredentialsCard teamId={team.id} />
+    </div>
   );
 }
 

--- a/self-hosted/advanced/orchestrator.md
+++ b/self-hosted/advanced/orchestrator.md
@@ -58,8 +58,10 @@ own infrastructure and behave the same way.
 - The public Convex Management API (`/v1/...`).
 - Audit log.
 - Default project-level environment variables.
-- Custom domain registration (records only — certificate provisioning is left to
-  your reverse proxy).
+- Custom domains, end to end: managed entirely in the dashboard, routed via
+  Traefik's file provider, with certificates the orchestrator issues itself over
+  HTTP-01 or DNS-01 (Cloudflare, DigitalOcean, Hetzner) and renews
+  automatically. See [Custom domains](#custom-domains).
 
 **Stubbed** (returns sensible empty / defaults so the dashboard renders without
 errors, but the cloud-only feature is not implemented):
@@ -255,6 +257,67 @@ instead.
 | `BETTER_AUTH_REQUIRE_EMAIL_VERIFICATION` / `BETTER_AUTH_SMTP_URL` / `BETTER_AUTH_SMTP_FROM`                          | `0` / unset / `no-reply@orchestrator`                                              | Optional SMTP for password reset / verification links.                                                                                |
 | `ORCHESTRATOR_IMAGE` / `DASHBOARD_ORCHESTRATOR_IMAGE` / `DASHBOARD_IMAGE`                                            | `ghcr.io/defy-works/convex-{orchestrator,dashboard-orchestrator,dashboard}:latest` | Pin to a specific image tag.                                                                                                          |
 | `RUST_LOG`                                                                                                           | `orchestrator=info,tower_http=warn`                                                | Orchestrator log filter.                                                                                                              |
+| `TRAEFIK_DYNAMIC_DIR`                                                                                                | `/convex/traefik-dynamic`                                                          | Directory the orchestrator renders custom-domain routers into, watched by Traefik's file provider. Unset to disable custom domains.   |
+| `CUSTOM_DOMAIN_CERT_RESOLVER`                                                                                        | `lehttp`                                                                           | ACME resolver for custom-domain certs. Must be HTTP-01 based — see Custom domains below.                                              |
+
+### Custom domains
+
+A deployment is normally reached at `<name>.${ROUTER_HOST}`, covered by the
+wildcard cert. A **custom domain** points a hostname you own at a specific
+deployment instead — managed entirely in the dashboard under **Project Settings
+→ Custom Domains** (also on each deployment's **Settings → Custom Domains**). No
+Traefik restart, no editing files over SSH.
+
+#### Why the orchestrator runs ACME instead of Traefik
+
+Traefik can issue certificates itself, but `certificatesResolvers` is _static_
+configuration: adding a DNS provider or rotating an API token would mean editing
+the compose file and restarting Traefik. That can't be driven from a dashboard.
+
+Traefik's _file_ provider, by contrast, hot-reloads both routers and
+`tls.certificates`. So the orchestrator owns the ACME conversation and writes
+finished certificates into the shared dynamic directory. The result:
+
+- DNS credentials are entered in the dashboard, sealed into Postgres, and used
+  by the next issuance immediately.
+- Custom domains need **zero** static Traefik configuration beyond pointing the
+  file provider at a directory (already in the compose file).
+- Routers for domains added after a backend container was created still work —
+  docker labels are fixed at create time, file-provider routers are not.
+
+#### Choosing a challenge
+
+| Challenge           | Setup                     | Use when                                                               |
+| ------------------- | ------------------------- | ---------------------------------------------------------------------- |
+| `http-01` (default) | None                      | The normal case. Port 80 must reach Traefik.                           |
+| `dns-01`            | A DNS provider credential | You want a **wildcard** (`*.example.com`), or port 80 isn't reachable. |
+
+Supported DNS providers: **Cloudflare**, **DigitalOcean**, and **Hetzner**. Add
+a token under **DNS Provider Credentials** on the same page; the form fields are
+advertised by the orchestrator, so a new provider appears in the dashboard
+without a dashboard release. Tokens are encrypted with a key derived from
+`SERVICE_KEY` and are never returned by the API.
+
+#### Adding a domain
+
+1. Create a CNAME from your domain to `${ROUTER_HOST}` (shown in the dashboard
+   as the target host).
+2. For `dns-01` only: save a DNS provider credential.
+3. Add the hostname, pick the challenge, and hit **Add**.
+
+Issuance runs in the background — an order takes tens of seconds, and DNS
+propagation longer. The domain moves `pending` → `issuing` → `active`, or
+`failed` with the reason shown verbatim (bad token, zone not found, DNS not
+pointed here). **Retry** re-runs it. A background sweep also retries domains
+that never got a certificate, so "I added it before the CNAME propagated" heals
+itself.
+
+`active` means the orchestrator completed a real HTTPS request against the
+domain — not merely that issuance was requested.
+
+Certificates renew automatically at 60 days, well inside the 90-day Let's
+Encrypt lifetime. Set `ACME_DIRECTORY_URL` to the Let's Encrypt **staging**
+directory while testing so you don't burn production rate limit.
 
 ## Running the orchestrator
 

--- a/self-hosted/docker/docker-compose.orchestrator.yml
+++ b/self-hosted/docker/docker-compose.orchestrator.yml
@@ -45,6 +45,9 @@ services:
     volumes:
       - orchestrator-data:/convex/data
       - /var/run/docker.sock:/var/run/docker.sock
+      # Custom-domain routers are rendered here and read by Traefik's file
+      # provider. Written by the orchestrator, read-only on the Traefik side.
+      - traefik-dynamic:/convex/traefik-dynamic
     labels:
       - "traefik.enable=true"
       # Orchestrator API on ORCHESTRATOR_HOST. Priority above the
@@ -98,6 +101,24 @@ services:
       - CONVEX_ORCHESTRATOR_DEFAULT_TEAM_NAME=${DEFAULT_TEAM_NAME:-Self-Hosted}
       - CONVEX_ORCHESTRATOR_ADMIN_EMAILS=${ADMIN_EMAILS:-admin@example.com}
       - CONVEX_ORCHESTRATOR_REGISTRATION=${REGISTRATION_MODE:-allowlist}
+      # Custom domains. Routers and certificates for domains added through
+      # the dashboard are rendered into this directory (Traefik's file
+      # provider watches it), because docker labels are fixed when a backend
+      # container is created and can't pick up a domain added later. Unset
+      # the directory to turn the feature off — the dashboard then reports it
+      # as unavailable rather than recording domains that would never route.
+      - CONVEX_ORCHESTRATOR_TRAEFIK_DYNAMIC_DIR=${TRAEFIK_DYNAMIC_DIR:-/convex/traefik-dynamic}
+      # Path the same volume is mounted at inside the Traefik container, used
+      # when writing certFile/keyFile paths Traefik has to resolve.
+      - CONVEX_ORCHESTRATOR_TRAEFIK_CERT_DIR=${TRAEFIK_CERT_DIR:-/dynamic}
+      # How Traefik reaches this service to forward ACME HTTP-01 challenges.
+      - CONVEX_ORCHESTRATOR_UPSTREAM=${CONVEX_ORCHESTRATOR_UPSTREAM:-orchestrator:8050}
+      # Registered with Let's Encrypt for expiry warnings. Falls back to the
+      # same address the wildcard cert uses.
+      - CONVEX_ORCHESTRATOR_ACME_CONTACT_EMAIL=${ACME_CONTACT_EMAIL:-${LETSENCRYPT_EMAIL:-}}
+      # Point at the LE staging directory to exercise issuance without
+      # burning production rate limit.
+      - CONVEX_ORCHESTRATOR_ACME_DIRECTORY_URL=${ACME_DIRECTORY_URL:-}
       - RUST_LOG=${RUST_LOG:-orchestrator=info,tower_http=warn}
     healthcheck:
       test: curl -fsS http://localhost:8050/health || exit 1
@@ -171,6 +192,9 @@ services:
     volumes:
       - traefik-acme:/acme
       - /var/run/docker.sock:/var/run/docker.sock:ro
+      # Custom-domain routers written by the orchestrator. Read-only here:
+      # the orchestrator owns the file, Traefik only watches it.
+      - traefik-dynamic:/dynamic:ro
     environment:
       # DNS provider creds — pass through whichever ones your provider
       # needs. See https://doc.traefik.io/traefik/https/acme/#providers
@@ -188,6 +212,14 @@ services:
       - "--api.dashboard=false"
       - "--providers.docker=true"
       - "--providers.docker.exposedbydefault=false"
+      # File provider for custom domains. The orchestrator rewrites
+      # /dynamic/conf/custom-domains.yml whenever a domain is added, removed,
+      # or issued a certificate; Traefik hot-reloads it, so no restart is
+      # needed. Points at `conf/` and not the volume root on purpose: the
+      # provider parses every file in this directory, and the certificate
+      # PEMs live in the sibling `certs/` directory.
+      - "--providers.file.directory=/dynamic/conf"
+      - "--providers.file.watch=true"
       - "--entrypoints.web.address=:80"
       - "--entrypoints.web.http.redirections.entrypoint.to=websecure"
       - "--entrypoints.web.http.redirections.entrypoint.scheme=https"
@@ -201,8 +233,15 @@ services:
       # returns SERVFAIL for SOA queries on apex domains, which makes
       # lego walk up to the TLD and fail with "could not find zone".
       - "--certificatesresolvers.le.acme.dnschallenge.resolvers=${DNS_RESOLVERS:-1.1.1.1:53,8.8.8.8:53}"
+      # Second resolver for customer-supplied custom domains. These live in
+      # DNS zones we don't control, so the DNS-01 challenge `le` uses can't
+      # work — HTTP-01 proves control by serving a token over :80 on the
+      # domain itself. The global web->websecure redirect does not interfere:
+      # Traefik answers ACME challenges on an internal router that takes
+      # precedence over the redirection.
 
 volumes:
   pgdata:
   orchestrator-data:
   traefik-acme:
+  traefik-dynamic:


### PR DESCRIPTION
Self-hosted CI and release pipeline for the Defy fork:

- RunsOn v2 runner setup: .github/runs-on.yml defines xlarge-x64 and
  xlarge-arm64 profiles (4 vCPU / 16 GB RAM m7-family spot on
  ubuntu24); workflows migrated to v2 label syntax with per-job
  runs-on IDs to prevent matrix runner stealing.
- Build deps: apt-get update before installing Rust build deps;
  install rocksdb, snappy, cmake, libclang so Cargo links against
  system libs (ROCKSDB_LIB_DIR / SNAPPY_LIB_DIR) instead of compiling
  rocksdb from source.
- Caches: point sccache at the fork's defy-convex-runner R2 bucket and
  move the BuildKit S3 cache prefix under cache/ to match the RunsOn
  EC2 instance role's s3:PutObject scope.
- Release automation: auto-tag release images as :latest on release
  branch pushes; publish fork-owned Docker images under a configurable
  GHCR namespace; tag_self_hosted_images_latest workflow.
- Upstream sync: sync_upstream workflow keeps enhanced and release
  aligned with upstream, with a bootstrap that handles an initially
  missing origin/release.
- Test + formatting fixes: test_self_hosted_backend image expression
  fix; workflow files formatted for dprint.<!-- Describe your PR here. -->



<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
While signed out, the `/api/orchestrator/token` session is cached by SWR
as `null`, and `_app.tsx` installs a 30s `dedupingInterval`. After a
successful sign-in the client-side navigation to `/` read that stale
`null` back — no refetch happens inside the dedupe window — concluded
the user was signed out, and bounced straight back to `/login`.
Refreshing the browser first cleared the in-memory cache, which is why
signing in only appeared to work after a manual reload.

Seed the new session into the SWR cache and await it before navigating.

Also stop IndexPage treating "session not loaded yet" as "signed out".
SWR's `isLoading` is false on the first render pass (the request only
starts in a post-mount effect), so a freshly loaded page could redirect
to /login before the session was known. Only `null` — the bridge
answering 401 — means signed out.

The regression test drives the whole signed-out -> sign-in -> land flow
and fails with `Received: "/login"` without the fix.

Drive-by: login.test.tsx could not run at all. Its hoisted `jest.mock`
factory captured `mockSignInEmail` directly, which throws a TDZ
ReferenceError when login.tsx requires the module.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dashboard management for custom domains, including creation, deletion, verification, retries, certificate status, and routing details.
  * Added DNS credential management for Cloudflare, DigitalOcean, and Hetzner.
  * Added automatic HTTPS certificate issuance and renewal using HTTP-01 or DNS-01 challenges.
  * Added custom-domain routing and certificate integration for self-hosted deployments.
* **Bug Fixes**
  * Improved login navigation by preventing stale session data from redirecting users back to sign-in.
* **Documentation**
  * Documented custom-domain setup, supported providers, verification, renewal, and self-hosted configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->