### PR TITLE
Install yarn in dashboard Docker build stages

### DIFF
--- a/self-hosted/docker-build/Dockerfile.dashboard
+++ b/self-hosted/docker-build/Dockerfile.dashboard
@@ -17,6 +17,12 @@ NODE_VERSION=$(cat /nvmrc | tr -d 'v\n')
 apt-get install -y --no-install-recommends nodejs=${NODE_VERSION}-1nodesource1
 EOF
 
+# The git-hosted docusaurus-openapi-docs dependency (allowlisted in
+# pnpm-workspace.yaml onlyBuiltDependencies) runs `yarn install` in its
+# prepare step, so pnpm install needs yarn on PATH. CI runners preinstall
+# it; this image doesn't.
+RUN npm install -g yarn
+
 WORKDIR /app
 # pnpm/turbo come pinned from scripts/package-lock.json, so release builds
 # always use the exact vetted versions.

--- a/self-hosted/docker-build/Dockerfile.dashboard-orchestrator
+++ b/self-hosted/docker-build/Dockerfile.dashboard-orchestrator
@@ -22,6 +22,12 @@ NODE_VERSION=$(cat /nvmrc | tr -d 'v\n')
 apt-get install -y --no-install-recommends nodejs=${NODE_VERSION}-1nodesource1
 EOF
 
+# The git-hosted docusaurus-openapi-docs dependency (allowlisted in
+# pnpm-workspace.yaml onlyBuiltDependencies) runs `yarn install` in its
+# prepare step, so pnpm install needs yarn on PATH. CI runners preinstall
+# it; this image doesn't.
+RUN npm install -g yarn
+
 WORKDIR /app
 # pnpm/turbo come pinned from scripts/package-lock.json, so release builds
 # always use the exact vetted versions.


### PR DESCRIPTION
## Problem

The `dashboard-orchestrator` (and `dashboard`) Docker image builds fail at `pnpm install --frozen-lockfile`:

```
ERR_PNPM_PREPARE_PACKAGE  Failed to prepare git-hosted package fetched from
"https://codeload.github.com/nipunn1313/docusaurus-openapi-docs/tar.gz/33ca8ab...": root@ yarn-install: `yarn install`
spawn ENOENT
```

The git-hosted `docusaurus-openapi-docs` dependency is allowlisted in `pnpm-workspace.yaml` `onlyBuiltDependencies`, so pnpm must run its prepare step — which invokes `yarn install`. The `ubuntu:noble` build stage only installs node/npm, so `yarn` isn't on PATH (`spawn ENOENT`). GitHub CI runners preinstall yarn, which is why the same `pnpm install` passes outside Docker.

## Fix

Add `npm install -g yarn` to the build stage of `Dockerfile.dashboard` and `Dockerfile.dashboard-orchestrator` (the only two Dockerfiles that run a workspace `pnpm install`).

## Verification

The `Build Dashboard Orchestrator` workflow runs on PRs and includes a no-push `docker buildx` build of `Dockerfile.dashboard-orchestrator`, which exercises the previously failing step.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dashboard and dashboard orchestrator builds to reliably complete dependency installation.
  * Resolved build failures related to documentation package preparation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->