### PR TITLE
Close cross-tenant authorization gap in the orchestrator

### DIFF
--- a/crates/orchestrator/src/routes/dashboard/audit_log.rs
+++ b/crates/orchestrator/src/routes/dashboard/audit_log.rs
@@ -20,6 +20,7 @@ use crate::{
         ApiError,
         ApiResult,
     },
+    routes::helpers::require_team_member,
     state::OrchestratorState,
     storage::AuditQuery,
 };
@@ -50,11 +51,12 @@ pub(crate) struct AuditFilters {
     tag = "dashboard",
 )]
 pub(crate) async fn get_audit_log_events(
-    _auth: AuthIdentity,
+    auth: AuthIdentity,
     State(state): State<OrchestratorState>,
     Path(team_id): Path<i64>,
     Query(filters): Query<AuditFilters>,
 ) -> ApiResult<Json<AuditLogPage>> {
+    require_team_member(&state, &auth, team_id).await?;
     let q = AuditQuery {
         team_id,
         member_id: filters.member_id,
@@ -63,7 +65,11 @@ pub(crate) async fn get_audit_log_events(
         to: filters.to,
         limit: filters.limit,
     };
-    let entries = state.storage.query_audit(&q).await.map_err(ApiError::Internal)?;
+    let entries = state
+        .storage
+        .query_audit(&q)
+        .await
+        .map_err(ApiError::Internal)?;
     Ok(Json(AuditLogPage {
         events: entries
             .into_iter()

--- a/crates/orchestrator/src/routes/dashboard/custom_domains.rs
+++ b/crates/orchestrator/src/routes/dashboard/custom_domains.rs
@@ -43,8 +43,30 @@ use crate::{
         ApiError,
         ApiResult,
     },
+    routes::helpers::require_deployment_member,
     state::OrchestratorState,
 };
+
+/// Authorize a caller against the deployment that owns `domain`.
+///
+/// Several handlers here take a `deployment_id` in the path but actually
+/// operate on the domain in the body, so guarding the path id alone would
+/// still let a caller pass *their own* deployment id with *someone else's*
+/// domain. Resolve ownership from the domain itself.
+async fn require_domain_owner(
+    state: &OrchestratorState,
+    auth: &AuthIdentity,
+    domain: &str,
+) -> ApiResult<i64> {
+    let record = state
+        .storage
+        .get_custom_domain(domain)
+        .await
+        .map_err(ApiError::Internal)?
+        .ok_or_else(|| ApiError::BadRequest(format!("{domain} is not configured")))?;
+    require_deployment_member(state, auth, record.deployment_id).await?;
+    Ok(record.deployment_id)
+}
 
 pub fn router() -> Router<OrchestratorState> {
     Router::new()
@@ -99,7 +121,10 @@ async fn canonical_urls_for(
     );
 
     // What the deployment *would* get if recreated right now.
-    let effective_url = deployment.desired_url.clone().unwrap_or_else(|| default_url.clone());
+    let effective_url = deployment
+        .desired_url
+        .clone()
+        .unwrap_or_else(|| default_url.clone());
     let effective_site_url = deployment
         .desired_site_url
         .clone()
@@ -125,10 +150,11 @@ async fn canonical_urls_for(
     tag = "dashboard",
 )]
 pub(crate) async fn get_canonical_urls(
-    _auth: AuthIdentity,
+    auth: AuthIdentity,
     State(state): State<OrchestratorState>,
     Path(deployment_id): Path<i64>,
 ) -> ApiResult<Json<CanonicalUrls>> {
+    require_deployment_member(&state, &auth, deployment_id).await?;
     Ok(Json(canonical_urls_for(&state, deployment_id).await?))
 }
 
@@ -141,11 +167,12 @@ pub(crate) async fn get_canonical_urls(
     tag = "dashboard",
 )]
 pub(crate) async fn set_canonical_urls(
-    _auth: AuthIdentity,
+    auth: AuthIdentity,
     State(state): State<OrchestratorState>,
     Path(deployment_id): Path<i64>,
     Json(args): Json<SetCanonicalUrlsArgs>,
 ) -> ApiResult<Json<CanonicalUrls>> {
+    require_deployment_member(&state, &auth, deployment_id).await?;
     let current = canonical_urls_for(&state, deployment_id).await?;
     let domains = state
         .storage
@@ -176,9 +203,9 @@ pub(crate) async fn set_canonical_urls(
             return Ok(());
         }
         Err(ApiError::BadRequest(format!(
-            "{host} has not been verified yet (state `{}`). Use Check on the \
-             domain until it reports active — that confirms a request to {host} \
-             actually reaches this deployment — then set it as canonical.{}",
+            "{host} has not been verified yet (state `{}`). Use Check on the domain until it \
+             reports active — that confirms a request to {host} actually reaches this deployment \
+             — then set it as canonical.{}",
             domain.cert_state,
             domain
                 .last_error
@@ -209,7 +236,6 @@ pub(crate) async fn set_canonical_urls(
     Ok(Json(canonical_urls_for(&state, deployment_id).await?))
 }
 
-
 fn to_api(record: crate::storage::CustomDomainRecord) -> CustomDomain {
     CustomDomain {
         id: record.id,
@@ -233,10 +259,11 @@ fn to_api(record: crate::storage::CustomDomainRecord) -> CustomDomain {
     tag = "dashboard",
 )]
 pub(crate) async fn list_custom_domains(
-    _auth: AuthIdentity,
+    auth: AuthIdentity,
     State(state): State<OrchestratorState>,
     Path(deployment_id): Path<i64>,
 ) -> ApiResult<Json<ListCustomDomains>> {
+    require_deployment_member(&state, &auth, deployment_id).await?;
     let domains = state
         .storage
         .list_custom_domains(deployment_id)
@@ -259,17 +286,17 @@ pub(crate) async fn list_custom_domains(
     tag = "dashboard",
 )]
 pub(crate) async fn create_custom_domain(
-    _auth: AuthIdentity,
+    auth: AuthIdentity,
     State(state): State<OrchestratorState>,
     Path(deployment_id): Path<i64>,
     Json(args): Json<CreateCustomDomainArgs>,
 ) -> ApiResult<Json<CustomDomain>> {
+    require_deployment_member(&state, &auth, deployment_id).await?;
     let domain = custom_domains::validate_domain(&args.domain)
         .map_err(|e| ApiError::BadRequest(e.to_string()))?;
-    let kind = custom_domains::validate_kind(
-        args.kind.as_deref().unwrap_or(custom_domains::KIND_API),
-    )
-    .map_err(|e| ApiError::BadRequest(e.to_string()))?;
+    let kind =
+        custom_domains::validate_kind(args.kind.as_deref().unwrap_or(custom_domains::KIND_API))
+            .map_err(|e| ApiError::BadRequest(e.to_string()))?;
     let tls_mode = custom_domains::validate_tls_mode(
         args.tls_mode
             .as_deref()
@@ -321,8 +348,7 @@ fn spawn_detect_and_provision(state: OrchestratorState, domain: String) {
         let Ok(Some(record)) = state.storage.get_custom_domain(&domain).await else {
             return;
         };
-        let Ok(Some(deployment)) = state.storage.get_deployment(record.deployment_id).await
-        else {
+        let Ok(Some(deployment)) = state.storage.get_deployment(record.deployment_id).await else {
             return;
         };
 
@@ -344,11 +370,7 @@ fn spawn_detect_and_provision(state: OrchestratorState, domain: String) {
         }
         if let Err(e) = state
             .storage
-            .set_custom_domain_status(
-                &domain,
-                &detection.cert_state,
-                detection.error.as_deref(),
-            )
+            .set_custom_domain_status(&domain, &detection.cert_state, detection.error.as_deref())
             .await
         {
             tracing::warn!(error = %e, %domain, "could not record detected domain state");
@@ -380,15 +402,23 @@ fn spawn_detect_and_provision(state: OrchestratorState, domain: String) {
     tag = "dashboard",
 )]
 pub(crate) async fn delete_custom_domain(
-    _auth: AuthIdentity,
+    auth: AuthIdentity,
     State(state): State<OrchestratorState>,
     Path(deployment_id): Path<i64>,
     Json(args): Json<CustomDomainArgs>,
 ) -> ApiResult<StatusCode> {
+    require_deployment_member(&state, &auth, deployment_id).await?;
     // Normalize so a domain stored lowercase is still matched when the caller
     // sends it back with different casing.
     let domain = custom_domains::validate_domain(&args.domain)
         .map_err(|e| ApiError::BadRequest(e.to_string()))?;
+
+    // `delete_custom_domain` is scoped to (deployment_id, domain), but
+    // `delete_certificate` below is keyed on the domain alone. Without this
+    // check a caller could pass their own deployment_id with someone else's
+    // domain: the row delete would no-op, and the certificate delete would
+    // still take out a deployment they do not own.
+    require_domain_owner(&state, &auth, &domain).await?;
 
     state
         .storage
@@ -451,13 +481,17 @@ pub(crate) async fn delete_custom_domain(
     tag = "dashboard",
 )]
 pub(crate) async fn retry_custom_domain(
-    _auth: AuthIdentity,
+    auth: AuthIdentity,
     State(state): State<OrchestratorState>,
     Path(_deployment_id): Path<i64>,
     Json(args): Json<CustomDomainArgs>,
 ) -> ApiResult<StatusCode> {
     let domain = custom_domains::validate_domain(&args.domain)
         .map_err(|e| ApiError::BadRequest(e.to_string()))?;
+
+    // The path's deployment_id is ignored by this handler, so ownership
+    // has to come from the domain itself.
+    require_domain_owner(&state, &auth, &domain).await?;
 
     // Retrying issuance for a domain whose TLS is terminated upstream would
     // order a certificate that is never served, and burn ACME rate limit
@@ -487,13 +521,17 @@ pub(crate) async fn retry_custom_domain(
     tag = "dashboard",
 )]
 pub(crate) async fn verify_custom_domain(
-    _auth: AuthIdentity,
+    auth: AuthIdentity,
     State(state): State<OrchestratorState>,
     Path(_deployment_id): Path<i64>,
     Json(args): Json<CustomDomainArgs>,
 ) -> ApiResult<Json<VerifyCustomDomainResponse>> {
     let domain = custom_domains::validate_domain(&args.domain)
         .map_err(|e| ApiError::BadRequest(e.to_string()))?;
+
+    // The path's deployment_id is ignored by this handler, so ownership
+    // has to come from the domain itself.
+    require_domain_owner(&state, &auth, &domain).await?;
 
     let deployment_name = deployment_name_for_domain(&state, &domain).await?;
     let record = state
@@ -562,10 +600,7 @@ pub(crate) async fn verify_custom_domain(
 ///
 /// `probe_domain` needs it to tell "this deployment answered" apart from
 /// "something answered", which is the whole basis of the `active` state.
-async fn deployment_name_for_domain(
-    state: &OrchestratorState,
-    domain: &str,
-) -> ApiResult<String> {
+async fn deployment_name_for_domain(state: &OrchestratorState, domain: &str) -> ApiResult<String> {
     let record = state
         .storage
         .get_custom_domain(domain)
@@ -696,4 +731,3 @@ async fn issue_now(state: &OrchestratorState, domain: &str) -> anyhow::Result<()
 
     Ok(())
 }
-

--- a/crates/orchestrator/src/routes/dashboard/deployments.rs
+++ b/crates/orchestrator/src/routes/dashboard/deployments.rs
@@ -30,7 +30,11 @@ use crate::{
         ApiResult,
     },
     ids::random_id,
-    routes::helpers::deployment_to_response,
+    routes::helpers::{
+        deployment_to_response,
+        require_deployment_member,
+        require_deployment_member_by_name,
+    },
     state::OrchestratorState,
     storage::{
         access_tokens::NewAccessToken,
@@ -65,10 +69,14 @@ pub fn router() -> Router<OrchestratorState> {
     tag = "dashboard",
 )]
 pub(crate) async fn get_deployment_by_id(
-    _auth: AuthIdentity,
+    auth: AuthIdentity,
     State(state): State<OrchestratorState>,
     Path((_team_id, deployment_id)): Path<(i64, i64)>,
 ) -> ApiResult<Json<DeploymentResponse>> {
+    // Authorize against the deployment's real owner rather than the
+    // `team_id` in the path, which the caller controls and this handler
+    // otherwise ignores.
+    require_deployment_member(&state, &auth, deployment_id).await?;
     let d = state
         .storage
         .get_deployment(deployment_id)
@@ -94,7 +102,10 @@ pub(crate) async fn get_deployment_auth_dashboard(
     State(state): State<OrchestratorState>,
     Path(deployment_name): Path<String>,
 ) -> ApiResult<Json<GetDeploymentAuthDashboardResponse>> {
-    let _ = auth;
+    // This mints an admin key — full read/write on the deployment's data.
+    // It previously discarded the identity entirely, so any signed-in user
+    // could mint one for any deployment just by knowing its name.
+    require_deployment_member_by_name(&state, &auth, &deployment_name).await?;
     let d = state
         .storage
         .get_deployment_by_name(&deployment_name)

--- a/crates/orchestrator/src/routes/dashboard/env_vars.rs
+++ b/crates/orchestrator/src/routes/dashboard/env_vars.rs
@@ -22,6 +22,7 @@ use crate::{
         ApiError,
         ApiResult,
     },
+    routes::helpers::require_project_member,
     state::OrchestratorState,
 };
 
@@ -45,10 +46,14 @@ pub fn router() -> Router<OrchestratorState> {
     tag = "dashboard",
 )]
 pub(crate) async fn list_env_vars(
-    _auth: AuthIdentity,
+    auth: AuthIdentity,
     State(state): State<OrchestratorState>,
     Path(project_id): Path<i64>,
 ) -> ApiResult<Json<ListEnvironmentVariables>> {
+    // Default env vars routinely hold secrets, and this route previously
+    // discarded the identity — any signed-in member could read any
+    // project's by id.
+    require_project_member(&state, &auth, project_id).await?;
     let vars = state
         .storage
         .list_default_env_vars(project_id)
@@ -75,11 +80,12 @@ pub(crate) async fn list_env_vars(
     tag = "dashboard",
 )]
 pub(crate) async fn update_env_vars(
-    _auth: AuthIdentity,
+    auth: AuthIdentity,
     State(state): State<OrchestratorState>,
     Path(project_id): Path<i64>,
     Json(args): Json<UpdateDefaultEnvVarsArgs>,
 ) -> ApiResult<StatusCode> {
+    require_project_member(&state, &auth, project_id).await?;
     for v in args.variables {
         state
             .storage

--- a/crates/orchestrator/src/routes/dashboard/projects.rs
+++ b/crates/orchestrator/src/routes/dashboard/projects.rs
@@ -23,7 +23,11 @@ use crate::{
         ApiError,
         ApiResult,
     },
-    routes::helpers::project_to_response,
+    routes::helpers::{
+        project_to_response,
+        require_project_member,
+        require_team_member,
+    },
     state::OrchestratorState,
 };
 
@@ -50,10 +54,11 @@ pub fn router() -> Router<OrchestratorState> {
     tag = "dashboard",
 )]
 pub(crate) async fn list_projects(
-    _auth: AuthIdentity,
+    auth: AuthIdentity,
     State(state): State<OrchestratorState>,
     Path(team_id): Path<i64>,
 ) -> ApiResult<Json<Vec<ProjectResponse>>> {
+    require_team_member(&state, &auth, team_id).await?;
     let projects = state
         .storage
         .list_projects(team_id)
@@ -70,10 +75,11 @@ pub(crate) async fn list_projects(
     tag = "dashboard",
 )]
 pub(crate) async fn get_project_by_slug(
-    _auth: AuthIdentity,
+    auth: AuthIdentity,
     State(state): State<OrchestratorState>,
     Path((team_id, project_slug)): Path<(i64, String)>,
 ) -> ApiResult<Json<ProjectResponse>> {
+    require_team_member(&state, &auth, team_id).await?;
     let p = state
         .storage
         .get_project_by_slug(team_id, &project_slug)
@@ -91,10 +97,11 @@ pub(crate) async fn get_project_by_slug(
     tag = "dashboard",
 )]
 pub(crate) async fn get_project(
-    _auth: AuthIdentity,
+    auth: AuthIdentity,
     State(state): State<OrchestratorState>,
     Path(project_id): Path<i64>,
 ) -> ApiResult<Json<ProjectResponse>> {
+    require_project_member(&state, &auth, project_id).await?;
     let p = state
         .storage
         .get_project(project_id)
@@ -113,11 +120,12 @@ pub(crate) async fn get_project(
     tag = "dashboard",
 )]
 pub(crate) async fn update_project(
-    _auth: AuthIdentity,
+    auth: AuthIdentity,
     State(state): State<OrchestratorState>,
     Path(project_id): Path<i64>,
     Json(args): Json<UpdateProjectArgs>,
 ) -> ApiResult<StatusCode> {
+    require_project_member(&state, &auth, project_id).await?;
     state
         .storage
         .update_project(project_id, args.name.as_deref(), args.slug.as_deref())

--- a/crates/orchestrator/src/routes/dashboard/teams.rs
+++ b/crates/orchestrator/src/routes/dashboard/teams.rs
@@ -40,7 +40,10 @@ use crate::{
         random_id,
         slugify,
     },
-    routes::helpers::team_to_response,
+    routes::helpers::{
+        require_team_member,
+        team_to_response,
+    },
     state::OrchestratorState,
     storage::TeamRole,
     stub_data,
@@ -53,7 +56,10 @@ pub fn router() -> Router<OrchestratorState> {
         .route("/teams/{team_id}/delete", post(delete_team))
         .route("/teams/{team_id}/members", get(list_members))
         .route("/teams/{team_id}/remove_member", post(remove_member))
-        .route("/teams/{team_id}/update_member_role", post(update_member_role))
+        .route(
+            "/teams/{team_id}/update_member_role",
+            post(update_member_role),
+        )
         .route(
             "/teams/{team_id}/get_entitlements",
             get(get_entitlements_stub),
@@ -65,10 +71,7 @@ pub fn router() -> Router<OrchestratorState> {
         )
         .route("/teams/{team_id}/invites/cancel", post(cancel_invite))
         .route("/invites/{code}/accept", post(accept_invite))
-        .route(
-            "/teams/{team_id}/get_project_roles",
-            get(get_project_roles),
-        )
+        .route("/teams/{team_id}/get_project_roles", get(get_project_roles))
         .route(
             "/teams/{team_id}/update_project_roles",
             post(update_project_roles),
@@ -330,9 +333,14 @@ pub(crate) async fn get_entitlements_stub(
     tag = "dashboard_stubs",
 )]
 pub(crate) async fn unpause_deployments(
-    _auth: AuthIdentity,
-    Path(_team_id): Path<i64>,
+    auth: AuthIdentity,
+    State(state): State<OrchestratorState>,
+    Path(team_id): Path<i64>,
 ) -> ApiResult<StatusCode> {
+    // A no-op stub (nothing here ever pauses a team for billing), but it
+    // still claims to act on a team, so it should not answer OK for a team
+    // the caller has nothing to do with.
+    require_team_member(&state, &auth, team_id).await?;
     Ok(StatusCode::OK)
 }
 
@@ -535,10 +543,11 @@ pub(crate) struct ProjectRoleEntry {
     tag = "dashboard",
 )]
 pub(crate) async fn get_project_roles(
-    _auth: AuthIdentity,
+    auth: AuthIdentity,
     State(state): State<OrchestratorState>,
     Path(team_id): Path<i64>,
 ) -> ApiResult<Json<Vec<ProjectRoleEntry>>> {
+    require_team_member(&state, &auth, team_id).await?;
     let pairs = state
         .storage
         .list_project_admins_for_team(team_id)
@@ -590,11 +599,7 @@ pub(crate) async fn update_project_roles(
     }
     state
         .storage
-        .set_project_admins(
-            args.project_id,
-            &args.admin_member_ids,
-            auth.member_id,
-        )
+        .set_project_admins(args.project_id, &args.admin_member_ids, auth.member_id)
         .await
         .map_err(ApiError::Internal)?;
     Ok(StatusCode::OK)

--- a/crates/orchestrator/src/routes/dashboard/teams.rs
+++ b/crates/orchestrator/src/routes/dashboard/teams.rs
@@ -41,6 +41,7 @@ use crate::{
         slugify,
     },
     routes::helpers::{
+        require_team_admin,
         require_team_member,
         team_to_response,
     },
@@ -319,9 +320,11 @@ pub(crate) async fn update_member_role(
     tag = "dashboard_stubs",
 )]
 pub(crate) async fn get_entitlements_stub(
-    _auth: AuthIdentity,
-    Path(_team_id): Path<i64>,
+    auth: AuthIdentity,
+    State(state): State<OrchestratorState>,
+    Path(team_id): Path<i64>,
 ) -> ApiResult<Json<StubTeamEntitlementsResponse>> {
+    require_team_member(&state, &auth, team_id).await?;
     Ok(Json(stub_data::entitlements_unlimited()))
 }
 
@@ -586,6 +589,11 @@ pub(crate) async fn update_project_roles(
     Path(team_id): Path<i64>,
     Json(args): Json<UpdateProjectRolesArgs>,
 ) -> ApiResult<StatusCode> {
+    // Membership was never checked here: the handler confirmed the project
+    // belonged to the path's team, but not that the caller did, so anyone
+    // could set project admins on any team. Granting admin rights is a
+    // governance action, so require the admin role rather than membership.
+    require_team_admin(&state, &auth, team_id).await?;
     // Verify the project actually belongs to this team — without this a
     // team admin could promote members on another team's project.
     let project = state
@@ -613,10 +621,12 @@ pub(crate) async fn update_project_roles(
     tag = "dashboard_stubs",
 )]
 pub(crate) async fn apply_referral_code(
-    _auth: AuthIdentity,
-    Path(_team_id): Path<i64>,
+    auth: AuthIdentity,
+    State(state): State<OrchestratorState>,
+    Path(team_id): Path<i64>,
     Json(_body): Json<serde_json::Value>,
 ) -> ApiResult<StatusCode> {
+    require_team_member(&state, &auth, team_id).await?;
     Ok(StatusCode::OK)
 }
 
@@ -628,10 +638,11 @@ pub(crate) async fn apply_referral_code(
     tag = "dashboard_stubs",
 )]
 pub(crate) async fn get_referral_state_stub(
-    _auth: AuthIdentity,
+    auth: AuthIdentity,
     State(state): State<OrchestratorState>,
     Path(team_id): Path<i64>,
 ) -> ApiResult<Json<StubReferralState>> {
+    require_team_member(&state, &auth, team_id).await?;
     let team = state
         .storage
         .get_team(team_id)

--- a/crates/orchestrator/src/routes/deployment_internal.rs
+++ b/crates/orchestrator/src/routes/deployment_internal.rs
@@ -28,7 +28,7 @@ use crate::{
     },
     errors::{ApiError, ApiResult},
     ids::random_id,
-    routes::helpers::deployment_to_response,
+    routes::helpers::{deployment_to_response, require_deployment_scope},
     state::OrchestratorState,
     storage::{access_tokens::NewAccessToken, AccessTokenKind, DeploymentClass, DeploymentType},
 };
@@ -470,8 +470,54 @@ pub(crate) async fn team_and_project(
     State(state): State<OrchestratorState>,
     Path(deployment_name): Path<String>,
 ) -> ApiResult<Json<TeamAndProjectForDeploymentResponse>> {
-    let _ = auth;
+    // A deploy key is bound to one deployment; a PAT falls back to team
+    // membership. Previously this discarded the identity, so any token
+    // could map any deployment name to its owning team and project.
+    let deployment = state
+        .storage
+        .get_deployment_by_name(&deployment_name)
+        .await
+        .map_err(ApiError::Internal)?
+        .ok_or_else(|| ApiError::NotFound(format!("deployment {deployment_name}")))?;
+    require_deployment_scope(&state, &auth, &deployment).await?;
     resolve_team_and_project(&state, &deployment_name).await
+}
+
+/// Confirm the caller is scoped to `project_id`.
+///
+/// Deploy keys carry their binding on the identity, so for them this is a
+/// containment check rather than a membership lookup: a key bound to a
+/// deployment must belong to the same project, and a project-scoped preview
+/// key must name that project. A PAT or session token carries no such
+/// binding, so it falls back to team membership.
+async fn require_same_project(
+    state: &OrchestratorState,
+    auth: &AuthIdentity,
+    project_id: i64,
+) -> ApiResult<()> {
+    if let Some(bound_deployment) = auth.deployment_id {
+        let bound = state
+            .storage
+            .get_deployment(bound_deployment)
+            .await
+            .map_err(ApiError::Internal)?
+            .ok_or(ApiError::Unauthorized)?;
+        return if bound.project_id == project_id {
+            Ok(())
+        } else {
+            Err(ApiError::Forbidden)
+        };
+    }
+    if let Some(bound_project) = auth.project_id {
+        return if bound_project == project_id {
+            Ok(())
+        } else {
+            Err(ApiError::Forbidden)
+        };
+    }
+    crate::routes::helpers::require_project_member(state, auth, project_id)
+        .await
+        .map(|_| ())
 }
 
 #[utoipa::path(
@@ -489,7 +535,6 @@ pub(crate) async fn authorize_within_current_project(
     State(state): State<OrchestratorState>,
     Json(args): Json<DeploymentAuthWithinCurrentProjectArgs>,
 ) -> ApiResult<Json<DeploymentAuthResponse>> {
-    let _ = auth;
     let deployment = state
         .storage
         .get_deployment_by_name(&args.selected_deployment_name)
@@ -498,6 +543,14 @@ pub(crate) async fn authorize_within_current_project(
         .ok_or_else(|| {
             ApiError::NotFound(format!("deployment {}", args.selected_deployment_name))
         })?;
+    // This returns an admin key, and previously discarded the identity — any
+    // token could mint one for any deployment by name.
+    //
+    // The scope here is the *project*, not the deployment: the whole point
+    // of this route is selecting among sibling deployments (dev, preview,
+    // prod) within the current project, so a key bound to one of them must
+    // still reach the others. Anything outside that project is refused.
+    require_same_project(&state, &auth, deployment.project_id).await?;
     let dt = to_common_deployment_type(deployment.deployment_type);
     let admin_key = admin_key_for_deployment(&state, &deployment)
         .await

--- a/crates/orchestrator/src/routes/helpers.rs
+++ b/crates/orchestrator/src/routes/helpers.rs
@@ -1,13 +1,15 @@
 //! Shared helpers used by route handlers.
 
-use orchestrator_api_types::dashboard::{
-    DeploymentResponse,
-    ProjectResponse,
-    TeamResponse,
-};
-use orchestrator_api_types::management::{
-    PlatformDeploymentResponse,
-    PlatformProjectDetails,
+use orchestrator_api_types::{
+    dashboard::{
+        DeploymentResponse,
+        ProjectResponse,
+        TeamResponse,
+    },
+    management::{
+        PlatformDeploymentResponse,
+        PlatformProjectDetails,
+    },
 };
 
 use crate::{
@@ -22,15 +24,16 @@ use crate::{
         DeploymentRecord,
         ProjectRecord,
         TeamRecord,
+        TeamRole,
     },
 };
 
 /// Resolve the caller to a member and confirm they belong to `team_id`.
 ///
 /// Every route that reads or mutates team-owned state has to do this. Several
-/// token routes took `_auth: AuthIdentity` and threw it away, which authenticated
-/// the caller but never authorized them — any valid token in the system could
-/// read or revoke another team's tokens.
+/// token routes took `_auth: AuthIdentity` and threw it away, which
+/// authenticated the caller but never authorized them — any valid token in the
+/// system could read or revoke another team's tokens.
 pub async fn require_team_member(
     state: &OrchestratorState,
     auth: &AuthIdentity,
@@ -62,6 +65,91 @@ pub async fn require_project_member(
         .map_err(ApiError::Internal)?
         .ok_or_else(|| ApiError::NotFound(format!("project {project_id}")))?;
     require_team_member(state, auth, project.team_id).await
+}
+
+/// Same, but for a deployment id: resolves project then team.
+pub async fn require_deployment_member(
+    state: &OrchestratorState,
+    auth: &AuthIdentity,
+    deployment_id: i64,
+) -> ApiResult<i64> {
+    let deployment = state
+        .storage
+        .get_deployment(deployment_id)
+        .await
+        .map_err(ApiError::Internal)?
+        .ok_or_else(|| ApiError::NotFound(format!("deployment {deployment_id}")))?;
+    require_project_member(state, auth, deployment.project_id).await
+}
+
+/// Same, keyed by the deployment's unique name.
+///
+/// The name is the identifier the CLI and the dashboard's embedded iframe
+/// use, so several routes only ever see it.
+pub async fn require_deployment_member_by_name(
+    state: &OrchestratorState,
+    auth: &AuthIdentity,
+    deployment_name: &str,
+) -> ApiResult<i64> {
+    let deployment = state
+        .storage
+        .get_deployment_by_name(deployment_name)
+        .await
+        .map_err(ApiError::Internal)?
+        .ok_or_else(|| ApiError::NotFound(format!("deployment {deployment_name}")))?;
+    require_project_member(state, auth, deployment.project_id).await
+}
+
+/// Membership is not enough: the caller must be an admin of `team_id`.
+///
+/// For destructive or governance actions — deleting a team, removing a
+/// member, changing someone's role — where a developer-role teammate should
+/// be refused.
+pub async fn require_team_admin(
+    state: &OrchestratorState,
+    auth: &AuthIdentity,
+    team_id: i64,
+) -> ApiResult<i64> {
+    let member_id = auth.require_member()?;
+    match state
+        .storage
+        .get_team_role(team_id, member_id)
+        .await
+        .map_err(ApiError::Internal)?
+    {
+        Some(TeamRole::Admin) => Ok(member_id),
+        // A developer is still a member, so this is a genuine 403 rather
+        // than a 404 — hiding the team's existence from its own teammate
+        // would be confusing, not safer.
+        Some(_) | None => Err(ApiError::Forbidden),
+    }
+}
+
+/// A deploy key may only act on the deployment it was minted for.
+///
+/// Deploy keys carry their binding on the identity, so membership is the
+/// wrong question for them: a key committed to CI must have the blast
+/// radius of its own deployment and nothing more. A PAT or session token is
+/// not bound to one deployment, so it falls back to team membership.
+pub async fn require_deployment_scope(
+    state: &OrchestratorState,
+    auth: &AuthIdentity,
+    deployment: &DeploymentRecord,
+) -> ApiResult<()> {
+    if let Some(bound) = auth.deployment_id {
+        if bound != deployment.id {
+            tracing::debug!(
+                bound,
+                requested = deployment.id,
+                "auth: deploy key used against a different deployment"
+            );
+            return Err(ApiError::Forbidden);
+        }
+        return Ok(());
+    }
+    require_project_member(state, auth, deployment.project_id)
+        .await
+        .map(|_| ())
 }
 
 /// The team that ultimately owns an access token, whichever scope it carries.

--- a/crates/orchestrator/src/routes/management/deployments.rs
+++ b/crates/orchestrator/src/routes/management/deployments.rs
@@ -140,6 +140,9 @@ pub(crate) async fn create_deployment(
     Json(args): Json<PlatformCreateDeploymentArgs>,
 ) -> ApiResult<Json<PlatformDeploymentResponse>> {
     let member_id = auth.require_member()?;
+    // require_member only authenticates; without this anyone could create a
+    // deployment inside another tenant's project.
+    require_project_member(&state, &auth, project_id).await?;
     let dt: DeploymentType = args
         .kind
         .parse()
@@ -296,7 +299,7 @@ pub(crate) async fn get_default_deployment_for_project(
     tag = "deployments",
 )]
 pub(crate) async fn get_default_deployment_by_slug(
-    _auth: AuthIdentity,
+    auth: AuthIdentity,
     State(state): State<OrchestratorState>,
     Path((team_id_or_slug, project_slug)): Path<(String, String)>,
     Query(q): Query<DeploymentQuery>,
@@ -312,6 +315,7 @@ pub(crate) async fn get_default_deployment_by_slug(
             .ok_or_else(|| ApiError::NotFound("team".into()))?
             .id
     };
+    require_team_member(&state, &auth, team_id).await?;
     let project = state
         .storage
         .get_project_by_slug(team_id, &project_slug)

--- a/crates/orchestrator/src/routes/management/deployments.rs
+++ b/crates/orchestrator/src/routes/management/deployments.rs
@@ -1,22 +1,47 @@
 use axum::{
-    extract::{Path, Query, State},
+    extract::{
+        Path,
+        Query,
+        State,
+    },
     http::StatusCode,
-    routing::{get, post},
-    Json, Router,
+    routing::{
+        get,
+        post,
+    },
+    Json,
+    Router,
 };
 use orchestrator_api_types::management::{
-    DeploymentClass, DeploymentRegion, DeploymentSettingsResponse, ListDeploymentClassesResponse,
-    ListDeploymentRegionsResponse, ListLocalDeploymentsResponse, PaginatedDeploymentsResponse,
-    PlatformCreateDeploymentArgs, PlatformDeploymentResponse, PlatformTransferDeploymentArgs,
-    PlatformUpdateDeploymentArgs, RestartDeploymentArgs, UpdateDeploymentSettingsArgs,
+    DeploymentClass,
+    DeploymentRegion,
+    DeploymentSettingsResponse,
+    ListDeploymentClassesResponse,
+    ListDeploymentRegionsResponse,
+    ListLocalDeploymentsResponse,
+    PaginatedDeploymentsResponse,
+    PlatformCreateDeploymentArgs,
+    PlatformDeploymentResponse,
+    PlatformTransferDeploymentArgs,
+    PlatformUpdateDeploymentArgs,
+    RestartDeploymentArgs,
+    UpdateDeploymentSettingsArgs,
 };
 use serde::Deserialize;
 
 use crate::{
     auth::identity::AuthIdentity,
-    errors::{ApiError, ApiResult},
+    errors::{
+        ApiError,
+        ApiResult,
+    },
     ids::random_deployment_name,
-    routes::helpers::deployment_to_platform,
+    routes::helpers::{
+        deployment_to_platform,
+        require_deployment_member_by_name,
+        require_project_member,
+        require_team_member,
+    },
     state::OrchestratorState,
     storage::DeploymentType,
 };
@@ -84,10 +109,11 @@ pub fn router() -> Router<OrchestratorState> {
     tag = "deployments",
 )]
 pub(crate) async fn list_deployments(
-    _auth: AuthIdentity,
+    auth: AuthIdentity,
     State(state): State<OrchestratorState>,
     Path(project_id): Path<i64>,
 ) -> ApiResult<Json<Vec<PlatformDeploymentResponse>>> {
+    require_project_member(&state, &auth, project_id).await?;
     let rows = state
         .storage
         .list_deployments(project_id)
@@ -226,11 +252,12 @@ pub(crate) struct DeploymentQuery {
     tag = "deployments",
 )]
 pub(crate) async fn get_default_deployment_for_project(
-    _auth: AuthIdentity,
+    auth: AuthIdentity,
     State(state): State<OrchestratorState>,
     Path(project_id): Path<i64>,
     Query(q): Query<DeploymentQuery>,
 ) -> ApiResult<Json<PlatformDeploymentResponse>> {
+    require_project_member(&state, &auth, project_id).await?;
     if let Some(reference) = q.reference {
         let d = state
             .storage
@@ -324,10 +351,11 @@ pub(crate) async fn get_default_deployment_by_slug(
     tag = "deployments",
 )]
 pub(crate) async fn list_team_deployments(
-    _auth: AuthIdentity,
+    auth: AuthIdentity,
     State(state): State<OrchestratorState>,
     Path(team_id): Path<i64>,
 ) -> ApiResult<Json<PaginatedDeploymentsResponse>> {
+    require_team_member(&state, &auth, team_id).await?;
     let rows = state
         .storage
         .list_deployments_for_team(team_id)
@@ -349,9 +377,11 @@ pub(crate) async fn list_team_deployments(
     tag = "deployments",
 )]
 pub(crate) async fn list_local_deployments(
-    _auth: AuthIdentity,
-    Path(_team_id): Path<i64>,
+    auth: AuthIdentity,
+    State(state): State<OrchestratorState>,
+    Path(team_id): Path<i64>,
 ) -> ApiResult<Json<ListLocalDeploymentsResponse>> {
+    require_team_member(&state, &auth, team_id).await?;
     Ok(Json(ListLocalDeploymentsResponse {
         deployments: Vec::new(),
     }))
@@ -367,9 +397,11 @@ pub(crate) async fn list_local_deployments(
     tag = "deployments",
 )]
 pub(crate) async fn list_deployment_classes(
-    _auth: AuthIdentity,
-    Path(_team_id): Path<i64>,
+    auth: AuthIdentity,
+    State(state): State<OrchestratorState>,
+    Path(team_id): Path<i64>,
 ) -> ApiResult<Json<ListDeploymentClassesResponse>> {
+    require_team_member(&state, &auth, team_id).await?;
     Ok(Json(ListDeploymentClassesResponse {
         classes: vec![DeploymentClass {
             name: "standard".into(),
@@ -409,10 +441,11 @@ pub(crate) async fn list_deployment_regions(
     tag = "deployments",
 )]
 pub(crate) async fn get_deployment(
-    _auth: AuthIdentity,
+    auth: AuthIdentity,
     State(state): State<OrchestratorState>,
     Path(deployment_name): Path<String>,
 ) -> ApiResult<Json<PlatformDeploymentResponse>> {
+    require_deployment_member_by_name(&state, &auth, &deployment_name).await?;
     let d = state
         .storage
         .get_deployment_by_name(&deployment_name)
@@ -433,10 +466,11 @@ pub(crate) async fn get_deployment(
     tag = "deployments",
 )]
 pub(crate) async fn delete_deployment(
-    _auth: AuthIdentity,
+    auth: AuthIdentity,
     State(state): State<OrchestratorState>,
     Path(deployment_name): Path<String>,
 ) -> ApiResult<StatusCode> {
+    require_deployment_member_by_name(&state, &auth, &deployment_name).await?;
     let d = state
         .storage
         .get_deployment_by_name(&deployment_name)
@@ -480,11 +514,12 @@ pub(crate) async fn delete_deployment(
     tag = "deployments",
 )]
 pub(crate) async fn transfer_deployment(
-    _auth: AuthIdentity,
+    auth: AuthIdentity,
     State(state): State<OrchestratorState>,
     Path(deployment_name): Path<String>,
     Json(args): Json<PlatformTransferDeploymentArgs>,
 ) -> ApiResult<StatusCode> {
+    require_deployment_member_by_name(&state, &auth, &deployment_name).await?;
     let d = state
         .storage
         .get_deployment_by_name(&deployment_name)
@@ -612,10 +647,11 @@ fn json_object_to_btree(v: &serde_json::Value) -> std::collections::BTreeMap<Str
     tag = "deployments",
 )]
 pub(crate) async fn get_deployment_settings(
-    _auth: AuthIdentity,
+    auth: AuthIdentity,
     State(state): State<OrchestratorState>,
     Path(deployment_name): Path<String>,
 ) -> ApiResult<Json<DeploymentSettingsResponse>> {
+    require_deployment_member_by_name(&state, &auth, &deployment_name).await?;
     let deployment = state
         .storage
         .get_deployment_by_name(&deployment_name)
@@ -656,11 +692,12 @@ pub(crate) async fn get_deployment_settings(
     tag = "deployments",
 )]
 pub(crate) async fn patch_deployment_settings(
-    _auth: AuthIdentity,
+    auth: AuthIdentity,
     State(state): State<OrchestratorState>,
     Path(deployment_name): Path<String>,
     Json(args): Json<UpdateDeploymentSettingsArgs>,
 ) -> ApiResult<Json<DeploymentSettingsResponse>> {
+    require_deployment_member_by_name(&state, &auth, &deployment_name).await?;
     let deployment = state
         .storage
         .get_deployment_by_name(&deployment_name)
@@ -743,11 +780,12 @@ pub(crate) async fn patch_deployment_settings(
     tag = "deployments",
 )]
 pub(crate) async fn restart_deployment(
-    _auth: AuthIdentity,
+    auth: AuthIdentity,
     State(state): State<OrchestratorState>,
     Path(deployment_name): Path<String>,
     Json(args): Json<RestartDeploymentArgs>,
 ) -> ApiResult<Json<PlatformDeploymentResponse>> {
+    require_deployment_member_by_name(&state, &auth, &deployment_name).await?;
     let deployment = state
         .storage
         .get_deployment_by_name(&deployment_name)

--- a/crates/orchestrator/src/routes/management/env_vars.rs
+++ b/crates/orchestrator/src/routes/management/env_vars.rs
@@ -23,6 +23,7 @@ use crate::{
         ApiError,
         ApiResult,
     },
+    routes::helpers::require_project_member,
     state::OrchestratorState,
 };
 
@@ -48,10 +49,11 @@ pub fn router() -> Router<OrchestratorState> {
     tag = "env_vars",
 )]
 pub(crate) async fn list(
-    _auth: AuthIdentity,
+    auth: AuthIdentity,
     State(state): State<OrchestratorState>,
     Path(project_id): Path<i64>,
 ) -> ApiResult<Json<PaginatedDefaultEnvironmentVariablesResponse>> {
+    require_project_member(&state, &auth, project_id).await?;
     let rows = state
         .storage
         .list_default_env_vars(project_id)
@@ -81,11 +83,12 @@ pub(crate) async fn list(
     tag = "env_vars",
 )]
 pub(crate) async fn update(
-    _auth: AuthIdentity,
+    auth: AuthIdentity,
     State(state): State<OrchestratorState>,
     Path(project_id): Path<i64>,
     Json(args): Json<UpdateDefaultEnvironmentVariablesArgs>,
 ) -> ApiResult<StatusCode> {
+    require_project_member(&state, &auth, project_id).await?;
     for v in args.variables {
         state
             .storage

--- a/crates/orchestrator/src/routes/management/projects.rs
+++ b/crates/orchestrator/src/routes/management/projects.rs
@@ -26,16 +26,17 @@ use crate::{
         ApiResult,
     },
     ids::slugify,
-    routes::helpers::project_to_platform,
+    routes::helpers::{
+        project_to_platform,
+        require_project_member,
+        require_team_member,
+    },
     state::OrchestratorState,
 };
 
 pub fn router() -> Router<OrchestratorState> {
     Router::new()
-        .route(
-            "/teams/{team_id}/create_project",
-            post(create_project),
-        )
+        .route("/teams/{team_id}/create_project", post(create_project))
         .route("/teams/{team_id}/list_projects", get(list_projects))
         .route("/projects/{project_id}", get(get_project))
         .route(
@@ -101,10 +102,11 @@ pub(crate) async fn create_project(
     tag = "projects",
 )]
 pub(crate) async fn list_projects(
-    _auth: AuthIdentity,
+    auth: AuthIdentity,
     State(state): State<OrchestratorState>,
     Path(team_id): Path<i64>,
 ) -> ApiResult<Json<Vec<PlatformProjectDetails>>> {
+    require_team_member(&state, &auth, team_id).await?;
     let rows = state
         .storage
         .list_projects(team_id)
@@ -124,10 +126,11 @@ pub(crate) async fn list_projects(
     tag = "projects",
 )]
 pub(crate) async fn get_project(
-    _auth: AuthIdentity,
+    auth: AuthIdentity,
     State(state): State<OrchestratorState>,
     Path(project_id): Path<i64>,
 ) -> ApiResult<Json<PlatformProjectDetails>> {
+    require_project_member(&state, &auth, project_id).await?;
     let p = state
         .storage
         .get_project(project_id)
@@ -186,10 +189,11 @@ pub(crate) async fn get_project_by_slug(
     tag = "projects",
 )]
 pub(crate) async fn delete_project(
-    _auth: AuthIdentity,
+    auth: AuthIdentity,
     State(state): State<OrchestratorState>,
     Path(project_id): Path<i64>,
 ) -> ApiResult<StatusCode> {
+    require_project_member(&state, &auth, project_id).await?;
     crate::routes::helpers::cascade_delete_project(&state, project_id)
         .await
         .map_err(ApiError::Internal)?;
@@ -207,10 +211,11 @@ pub(crate) async fn delete_project(
     tag = "projects",
 )]
 pub(crate) async fn get_project_settings(
-    _auth: AuthIdentity,
+    auth: AuthIdentity,
     State(state): State<OrchestratorState>,
     Path(project_id): Path<i64>,
 ) -> ApiResult<Json<ProjectSettingsResponse>> {
+    require_project_member(&state, &auth, project_id).await?;
     let project = state
         .storage
         .get_project(project_id)
@@ -237,11 +242,12 @@ pub(crate) async fn get_project_settings(
     tag = "projects",
 )]
 pub(crate) async fn patch_project_settings(
-    _auth: AuthIdentity,
+    auth: AuthIdentity,
     State(state): State<OrchestratorState>,
     Path(project_id): Path<i64>,
     Json(args): Json<UpdateProjectSettingsArgs>,
 ) -> ApiResult<Json<ProjectSettingsResponse>> {
+    require_project_member(&state, &auth, project_id).await?;
     if let Some(tier) = args.tier.as_deref() {
         crate::routes::management::deployments::ensure_host_capacity(&state, tier, false).await?;
     }

--- a/crates/orchestrator/src/routes/management/projects.rs
+++ b/crates/orchestrator/src/routes/management/projects.rs
@@ -68,7 +68,7 @@ pub(crate) async fn create_project(
     Path(team_id): Path<i64>,
     Json(args): Json<PlatformCreateProjectArgs>,
 ) -> ApiResult<Json<PlatformCreateProjectResponse>> {
-    let _ = auth;
+    require_team_member(&state, &auth, team_id).await?;
     let slug = args.slug.unwrap_or_else(|| slugify(&args.project_name));
     let project = state
         .storage
@@ -154,7 +154,7 @@ pub(crate) async fn get_project(
     tag = "projects",
 )]
 pub(crate) async fn get_project_by_slug(
-    _auth: AuthIdentity,
+    auth: AuthIdentity,
     State(state): State<OrchestratorState>,
     Path((team_id_or_slug, project_slug)): Path<(String, String)>,
 ) -> ApiResult<Json<PlatformProjectDetails>> {
@@ -170,6 +170,7 @@ pub(crate) async fn get_project_by_slug(
             .ok_or_else(|| ApiError::NotFound(format!("team {team_id_or_slug}")))?
             .id
     };
+    require_team_member(&state, &auth, team_id).await?;
     let p = state
         .storage
         .get_project_by_slug(team_id, &project_slug)

--- a/crates/orchestrator/src/routes/management/teams.rs
+++ b/crates/orchestrator/src/routes/management/teams.rs
@@ -38,6 +38,7 @@ use crate::{
         random_id,
         slugify,
     },
+    routes::helpers::require_team_member,
     state::OrchestratorState,
     storage::{
         access_tokens::NewAccessToken,
@@ -100,10 +101,11 @@ pub(crate) async fn create_team(
     tag = "teams",
 )]
 pub(crate) async fn list_members(
-    _auth: AuthIdentity,
+    auth: AuthIdentity,
     State(state): State<OrchestratorState>,
     Path(team_id): Path<i64>,
 ) -> ApiResult<Json<PlatformListTeamMembersResponse>> {
+    require_team_member(&state, &auth, team_id).await?;
     let rows = state
         .storage
         .list_team_members(team_id)

--- a/crates/orchestrator/src/storage/audit_log.rs
+++ b/crates/orchestrator/src/storage/audit_log.rs
@@ -65,7 +65,11 @@ impl Storage {
             params.push(Box::new(to));
             sql.push_str(&format!(" AND creation_time <= ${}", params.len()));
         }
-        sql.push_str(" ORDER BY creation_time DESC LIMIT ");
+        // Tie-break on `id`: creation_time is millisecond precision, so two
+        // events written in the same millisecond would otherwise come back
+        // in arbitrary order. `id` is a BIGSERIAL, so it is monotonic and
+        // makes the sort stable.
+        sql.push_str(" ORDER BY creation_time DESC, id DESC LIMIT ");
         sql.push_str(&limit.to_string());
 
         let conn = self.pool().acquire().await?;

--- a/crates/orchestrator/tests/cross_tenant.rs
+++ b/crates/orchestrator/tests/cross_tenant.rs
@@ -428,3 +428,95 @@ async fn one_tenant_cannot_touch_another() {
         leaks.join("\n  ")
     );
 }
+
+/// A deploy key is bound to one deployment. It must not act on another,
+/// even one belonging to a different tenant — a key committed to CI has the
+/// blast radius of its own deployment and nothing more.
+#[tokio::test]
+#[ignore = "needs TEST_ORCHESTRATOR_DATABASE_URL"]
+async fn a_deploy_key_cannot_act_on_another_deployment() {
+    use std::sync::Arc;
+
+    let database_url = std::env::var("TEST_ORCHESTRATOR_DATABASE_URL")
+        .expect("TEST_ORCHESTRATOR_DATABASE_URL not set (this test is `#[ignore]` by default)");
+    reset_public_schema(&database_url).await;
+
+    let data_root = tempfile::tempdir().expect("tempdir");
+    let config = test_config(database_url, data_root.path().to_path_buf());
+    let mut state = OrchestratorState::new(config).await.expect("state");
+    state.provisioner = Arc::new(StubProvisioner);
+    let app = build_router(state.clone());
+
+    let owner = make_tenant(&state.storage, "keyowner").await;
+    let victim = make_tenant(&state.storage, "keyvictim").await;
+
+    // A prod deploy key bound to the owner's deployment. Its wire form
+    // carries the deployment name in the middle slot.
+    let secret = "deploy-secret";
+    state
+        .storage
+        .create_access_token(NewAccessToken {
+            public_id: &owner.deployment_name,
+            kind: AccessTokenKind::DeployProd,
+            member_id: Some(owner.member_id),
+            team_id: Some(owner.team_id),
+            project_id: Some(owner.project_id),
+            deployment_id: Some(owner.deployment_id),
+            name: "prod-key",
+            secret_hash: &orchestrator::auth::tokens::sha256_hex(secret),
+            secret_suffix: "cret",
+            expiry: None,
+        })
+        .await
+        .expect("deploy key");
+    let bearer = format!("Bearer prod:{}|{secret}", owner.deployment_name);
+
+    let foreign = send(
+        &app,
+        "GET",
+        &format!(
+            "/api/deployment/{}/team_and_project",
+            victim.deployment_name
+        ),
+        &bearer,
+        None,
+    )
+    .await;
+    assert!(
+        !foreign.is_success(),
+        "a deploy key reached another deployment's team_and_project: {foreign}"
+    );
+
+    // Minting an admin key for a deployment outside the key's own project
+    // must be refused too — this route returns a real admin key.
+    let foreign_auth = send(
+        &app,
+        "POST",
+        "/api/deployment/authorize_within_current_project",
+        &bearer,
+        Some(serde_json::json!({
+            "selectedDeploymentName": victim.deployment_name,
+            "selectedDeploymentType": "prod",
+        })),
+    )
+    .await;
+    assert!(
+        !foreign_auth.is_success(),
+        "a deploy key minted an admin key for another tenant's deployment: {foreign_auth}"
+    );
+
+    // ...and it must still work against its own deployment, or the CLI is
+    // broken rather than secured.
+    let own = send(
+        &app,
+        "GET",
+        &format!("/api/deployment/{}/team_and_project", owner.deployment_name),
+        &bearer,
+        None,
+    )
+    .await;
+    assert!(
+        own.is_success(),
+        "a deploy key must still reach its own deployment, got {own}"
+    );
+}

--- a/crates/orchestrator/tests/cross_tenant.rs
+++ b/crates/orchestrator/tests/cross_tenant.rs
@@ -1,0 +1,430 @@
+//! Cross-tenant authorization tests.
+//!
+//! Builds independent tenants — separate members, teams, projects,
+//! deployments — and asserts that one tenant's token is rejected on every
+//! path-scoped route that names another tenant's resources.
+//!
+//! This is the regression guard for the authenticated-but-not-authorized
+//! gap: `routes/helpers.rs` already documents the same bug being fixed once
+//! for token routes, and the sweep stopped there.
+//!
+//! **The test owns the database** — it drops and recreates the schema. Point
+//! `TEST_ORCHESTRATOR_DATABASE_URL` at a throwaway database.
+//!
+//! Run: `TEST_ORCHESTRATOR_DATABASE_URL=postgres://... cargo test -p
+//! orchestrator --test cross_tenant -- --include-ignored`
+
+use axum::{
+    body::Body,
+    http::{
+        header::AUTHORIZATION,
+        Request,
+        StatusCode,
+    },
+    Router,
+};
+use orchestrator::{
+    config::{
+        OrchestratorConfig,
+        ProvisionerMode,
+        RegistrationMode,
+    },
+    provisioner::{
+        ProvisionRequest,
+        ProvisionResult,
+        Provisioner,
+    },
+    router::build_router,
+    state::OrchestratorState,
+    storage::{
+        access_tokens::NewAccessToken,
+        deployments::NewDeployment,
+        AccessTokenKind,
+        DeploymentClass,
+        DeploymentType,
+        Storage,
+        TeamRole,
+    },
+};
+use tower::ServiceExt;
+
+/// Stub provisioner so the tests don't depend on docker.
+///
+/// Duplicated from `integration.rs` rather than shared: Rust integration
+/// test targets cannot import one another, and a `tests/common/` module
+/// would be a third pattern this crate does not use.
+struct StubProvisioner;
+
+#[async_trait::async_trait]
+impl Provisioner for StubProvisioner {
+    async fn provision(&self, req: ProvisionRequest) -> anyhow::Result<ProvisionResult> {
+        Ok(ProvisionResult {
+            url: format!("http://{}.localhost:9000", req.deployment_name),
+            site_url: format!("http://{}-site.localhost:9000", req.deployment_name),
+            admin_key: format!("stub-admin-key-{}", req.deployment_name),
+            admin_key_hash: "stub-hash".into(),
+            admin_key_suffix: "stub".into(),
+            instance_secret: "stub-instance-secret".into(),
+            backend_instance_secret: "0".repeat(64),
+            backend_pid: None,
+            backend_port: 0,
+            resolved_env: std::collections::BTreeMap::new(),
+            sidecar_credentials: None,
+        })
+    }
+
+    async fn teardown(&self, _deployment_name: &str, _storage_mode: &str) -> anyhow::Result<()> {
+        Ok(())
+    }
+}
+
+/// One tenant's ids, plus a PAT that authenticates as its member.
+struct Tenant {
+    member_id: i64,
+    team_id: i64,
+    team_slug: String,
+    project_id: i64,
+    project_slug: String,
+    deployment_id: i64,
+    deployment_name: String,
+    bearer: String,
+}
+
+async fn make_tenant(storage: &Storage, key: &str) -> Tenant {
+    let member = storage
+        .upsert_member(
+            &format!("auth-{key}"),
+            &format!("{key}@example.com"),
+            Some(key),
+        )
+        .await
+        .expect("member");
+    let team = storage
+        .create_team(key, key, Some(member.id))
+        .await
+        .expect("team");
+    storage
+        .add_team_member(team.id, member.id, TeamRole::Admin)
+        .await
+        .expect("membership");
+    let project = storage
+        .create_project(team.id, key, key, false)
+        .await
+        .expect("project");
+
+    let name = format!("{key}-deployment");
+    let empty = serde_json::json!({});
+    let deployment = storage
+        .create_deployment(NewDeployment {
+            project_id: project.id,
+            name: &name,
+            deployment_type: DeploymentType::Prod,
+            deployment_class: DeploymentClass::Standard,
+            region: None,
+            url: &format!("http://{name}.localhost"),
+            site_url: &format!("http://{name}-site.localhost"),
+            backend_pid: None,
+            backend_port: 3210,
+            creator_id: Some(member.id),
+            preview_identifier: None,
+            instance_secret: "",
+            tier: "S16",
+            knob_overrides: &empty,
+            storage_mode: "volume-sqlite",
+            pg_password: None,
+            minio_root_user: None,
+            minio_root_password: None,
+            backend_instance_secret: None,
+        })
+        .await
+        .expect("deployment");
+
+    let secret = format!("{key}-secret");
+    storage
+        .create_access_token(NewAccessToken {
+            public_id: &format!("{key}-public"),
+            kind: AccessTokenKind::Pat,
+            member_id: Some(member.id),
+            team_id: Some(team.id),
+            project_id: None,
+            deployment_id: None,
+            name: &format!("{key}-pat"),
+            secret_hash: &orchestrator::auth::tokens::sha256_hex(&secret),
+            secret_suffix: "cret",
+            expiry: None,
+        })
+        .await
+        .expect("pat");
+
+    Tenant {
+        member_id: member.id,
+        team_id: team.id,
+        team_slug: team.slug,
+        project_id: project.id,
+        project_slug: project.slug,
+        deployment_id: deployment.id,
+        deployment_name: name,
+        bearer: format!("Bearer pat:{key}-public|{secret}"),
+    }
+}
+
+async fn send(
+    app: &Router,
+    method: &str,
+    path: &str,
+    bearer: &str,
+    body: Option<serde_json::Value>,
+) -> StatusCode {
+    let mut req = Request::builder()
+        .method(method)
+        .uri(path)
+        .header(AUTHORIZATION, bearer);
+    let body = match body {
+        Some(v) => {
+            req = req.header("content-type", "application/json");
+            Body::from(serde_json::to_vec(&v).unwrap())
+        },
+        None => Body::empty(),
+    };
+    app.clone()
+        .oneshot(req.body(body).unwrap())
+        .await
+        .unwrap_or_else(|_| panic!("send {method} {path}"))
+        .status()
+}
+
+/// `DROP SCHEMA public CASCADE; CREATE SCHEMA public;` so each run starts
+/// clean. Plain `NoTls`; do not point at a TLS-only host without adapting.
+async fn reset_public_schema(database_url: &str) {
+    use tokio_postgres::NoTls;
+    let (client, conn) = tokio_postgres::connect(database_url, NoTls)
+        .await
+        .expect("connect to test postgres for reset");
+    tokio::spawn(async move {
+        if let Err(e) = conn.await {
+            eprintln!("test postgres reset connection ended: {e}");
+        }
+    });
+    client
+        .batch_execute("DROP SCHEMA IF EXISTS public CASCADE; CREATE SCHEMA public;")
+        .await
+        .expect("reset public schema");
+}
+
+fn test_config(database_url: String, data_root: std::path::PathBuf) -> OrchestratorConfig {
+    OrchestratorConfig {
+        database_url,
+        data_root,
+        public_origin: "http://localhost".into(),
+        bootstrap_token: None,
+        provisioner_mode: ProvisionerMode::External,
+        service_key: None,
+        admin_emails: Vec::new(),
+        default_team_name: "Self-Hosted".into(),
+        registration_mode: RegistrationMode::Allowlist,
+        backend_image: "irrelevant".into(),
+        backend_network: None,
+        backend_container_prefix: "test-".into(),
+        router_host: "localhost".into(),
+        site_router_host: None,
+        router_public_port: 9000,
+        router_public_scheme: "http".into(),
+        direct_backend_routing: true,
+        enable_sidecars: false,
+        postgres_image: "postgres:16-alpine".into(),
+        minio_image: "quay.io/minio/minio:latest".into(),
+        traefik_dynamic_dir: None,
+        orchestrator_upstream: "orchestrator:8050".into(),
+        traefik_cert_dir: "/dynamic".into(),
+        acme_contact_email: None,
+        acme_directory_url: None,
+        reconcile_interval_secs: 0,
+    }
+}
+
+/// `(method, path template, optional JSON body)`.
+///
+/// `{team}` / `{team_slug}` / `{project}` / `{project_slug}` /
+/// `{deployment}` / `{deployment_name}` / `{member}` are substituted with
+/// the **victim's** ids and called with the attacker's token.
+///
+/// A route belongs here if it names a tenant-owned resource in its path.
+/// The `*_stub.rs` surfaces are excluded: they return canned data and own
+/// no tenant state.
+const CROSS_TENANT_ROUTES: &[(&str, &str, Option<&str>)] = &[
+    // --- the two confirmed holes ---
+    (
+        "POST",
+        "/api/dashboard/instances/{deployment_name}/auth",
+        None,
+    ),
+    (
+        "GET",
+        "/api/dashboard/projects/{project}/environment_variables/list",
+        None,
+    ),
+    (
+        "POST",
+        "/api/dashboard/projects/{project}/environment_variables/update_batch",
+        Some(r#"{"variables":[{"name":"STOLEN","value":"x","deploymentTypes":["prod"]}]}"#),
+    ),
+    // --- dashboard: teams ---
+    (
+        "POST",
+        "/api/dashboard/teams/{team}",
+        Some(r#"{"name":"pwned"}"#),
+    ),
+    ("POST", "/api/dashboard/teams/{team}/delete", None),
+    ("GET", "/api/dashboard/teams/{team}/members", None),
+    (
+        "POST",
+        "/api/dashboard/teams/{team}/remove_member",
+        Some(r#"{"memberId":1}"#),
+    ),
+    ("GET", "/api/dashboard/teams/{team}/invites", None),
+    (
+        "POST",
+        "/api/dashboard/teams/{team}/invites",
+        Some(r#"{"email":"intruder@example.com","role":"developer"}"#),
+    ),
+    (
+        "GET",
+        "/api/dashboard/teams/{team}/get_audit_log_events",
+        None,
+    ),
+    ("GET", "/api/dashboard/teams/{team}/get_project_roles", None),
+    ("GET", "/api/dashboard/teams/{team}/projects", None),
+    // --- dashboard: projects ---
+    ("GET", "/api/dashboard/projects/{project}", None),
+    (
+        "PUT",
+        "/api/dashboard/projects/{project}",
+        Some(r#"{"name":"pwned"}"#),
+    ),
+    ("POST", "/api/dashboard/delete_project/{project}", None),
+    // --- dashboard: deployments and custom domains ---
+    (
+        "GET",
+        "/api/dashboard/teams/{team}/deployments/{deployment}",
+        None,
+    ),
+    (
+        "GET",
+        "/api/dashboard/deployments/{deployment}/canonical_urls",
+        None,
+    ),
+    (
+        "GET",
+        "/api/dashboard/deployments/{deployment}/custom_domains/list",
+        None,
+    ),
+    (
+        "POST",
+        "/api/dashboard/deployments/{deployment}/custom_domains/create",
+        Some(r#"{"domain":"stolen.example.com","kind":"api"}"#),
+    ),
+    // --- management API ---
+    ("GET", "/v1/projects/{project}", None),
+    ("POST", "/v1/projects/{project}/delete", None),
+    ("GET", "/v1/projects/{project}/settings", None),
+    ("GET", "/v1/projects/{project}/list_deployments", None),
+    (
+        "GET",
+        "/v1/projects/{project}/list_default_environment_variables",
+        None,
+    ),
+    ("GET", "/v1/teams/{team}/list_projects", None),
+    ("GET", "/v1/teams/{team}/list_members", None),
+    ("GET", "/v1/teams/{team}/list_deployments", None),
+    ("GET", "/v1/deployments/{deployment_name}", None),
+    ("GET", "/v1/deployments/{deployment_name}/settings", None),
+    ("POST", "/v1/deployments/{deployment_name}/delete", None),
+    (
+        "POST",
+        "/v1/deployments/{deployment_name}/restart",
+        Some("{}"),
+    ),
+];
+
+/// One tenant must not touch another's resources on any route.
+///
+/// Each route gets a **freshly built victim**. Sharing one victim would let
+/// an early destructive route that succeeds — `delete_team`, say — make
+/// every later route 404 and look safe, masking the holes behind it.
+///
+/// Both 403 and 404 are accepted: some handlers legitimately prefer not to
+/// confirm a resource exists. What is not accepted is 2xx.
+#[tokio::test]
+#[ignore = "needs TEST_ORCHESTRATOR_DATABASE_URL"]
+async fn one_tenant_cannot_touch_another() {
+    use std::sync::Arc;
+
+    let database_url = std::env::var("TEST_ORCHESTRATOR_DATABASE_URL")
+        .expect("TEST_ORCHESTRATOR_DATABASE_URL not set (this test is `#[ignore]` by default)");
+    reset_public_schema(&database_url).await;
+
+    let data_root = tempfile::tempdir().expect("tempdir");
+    let config = test_config(database_url, data_root.path().to_path_buf());
+    let mut state = OrchestratorState::new(config).await.expect("state");
+    state.provisioner = Arc::new(StubProvisioner);
+    let app = build_router(state.clone());
+
+    let attacker = make_tenant(&state.storage, "attacker").await;
+
+    let mut leaks = Vec::new();
+    // A route that answers 400 or 422 rejected the *request*, not the
+    // caller — usually a malformed body in the table above. That is not
+    // evidence of authorization, so it is reported separately rather than
+    // being quietly counted as a pass.
+    let mut inconclusive = Vec::new();
+    for (i, (method, template, body)) in CROSS_TENANT_ROUTES.iter().enumerate() {
+        let victim = make_tenant(&state.storage, &format!("victim{i}")).await;
+        let path = template
+            .replace("{team_slug}", &victim.team_slug)
+            .replace("{team}", &victim.team_id.to_string())
+            .replace("{project_slug}", &victim.project_slug)
+            .replace("{project}", &victim.project_id.to_string())
+            .replace("{deployment_name}", &victim.deployment_name)
+            .replace("{deployment}", &victim.deployment_id.to_string())
+            .replace("{member}", &victim.member_id.to_string());
+        let body = body.map(|b| serde_json::from_str(b).expect("table body is valid JSON"));
+
+        let status = send(&app, method, &path, &attacker.bearer, body).await;
+        match status {
+            s if s.is_success() => leaks.push(format!("{method} {template} -> {s}")),
+            StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN | StatusCode::NOT_FOUND => {},
+            s => inconclusive.push(format!("{method} {template} -> {s}")),
+        }
+    }
+
+    // Sanity first, so a wholesale breakage cannot masquerade as a pass.
+    let own = send(
+        &app,
+        "GET",
+        &format!("/api/dashboard/projects/{}", attacker.project_id),
+        &attacker.bearer,
+        None,
+    )
+    .await;
+    assert!(
+        own.is_success(),
+        "a tenant must still reach its own project, got {own}"
+    );
+
+    assert!(
+        inconclusive.is_empty(),
+        "{} route(s) answered with neither success nor a denial, so this test proves nothing \
+         about them — fix the request body in CROSS_TENANT_ROUTES so the handler is actually \
+         reached:\n  {}",
+        inconclusive.len(),
+        inconclusive.join("\n  ")
+    );
+
+    assert!(
+        leaks.is_empty(),
+        "{} of {} cross-tenant route(s) allowed access to another tenant's resources:\n  {}",
+        leaks.len(),
+        CROSS_TENANT_ROUTES.len(),
+        leaks.join("\n  ")
+    );
+}

--- a/crates/orchestrator/tests/cross_tenant.rs
+++ b/crates/orchestrator/tests/cross_tenant.rs
@@ -238,7 +238,6 @@ fn test_config(database_url: String, data_root: std::path::PathBuf) -> Orchestra
         traefik_cert_dir: "/dynamic".into(),
         acme_contact_email: None,
         acme_directory_url: None,
-        reconcile_interval_secs: 0,
     }
 }
 
@@ -518,5 +517,141 @@ async fn a_deploy_key_cannot_act_on_another_deployment() {
     assert!(
         own.is_success(),
         "a deploy key must still reach its own deployment, got {own}"
+    );
+}
+
+/// Every path-scoped handler must reference an authorization guard.
+///
+/// A source-level check rather than a runtime one, because the failure mode
+/// it catches is a *new* route that nobody added to `CROSS_TENANT_ROUTES` —
+/// exactly the case a table cannot see. Deliberately crude: it only proves
+/// the author thought about authorization, not that the guard is the right
+/// one. The route table above is what covers correctness; read the two as a
+/// pair.
+///
+/// To add a deliberate exception, put the handler in `ALLOWED_UNGUARDED`
+/// with a comment saying why.
+#[test]
+fn every_path_scoped_handler_references_a_guard() {
+    /// Handlers that legitimately need no ownership guard.
+    const ALLOWED_UNGUARDED: &[(&str, &str)] = &[
+        // The invite code IS the authorization; the caller is by definition
+        // not yet a member of the team they are joining.
+        ("teams.rs", "accept_invite"),
+        // The emailed verification code is the capability. Requiring
+        // membership would make the link unusable.
+        ("profile.rs", "verify_email"),
+        // Returns 501 unconditionally; there is nothing to authorize until
+        // project transfer is actually implemented, and whoever implements
+        // it will have to guard both the source and destination team.
+        ("projects.rs", "transfer_project"),
+    ];
+
+    /// The route files that hold tenant state.
+    ///
+    /// The `*_stub.rs` files are omitted rather than allow-listed: they
+    /// return canned responses and own nothing, so there is no ownership to
+    /// check. If a stub ever starts serving real data, add it here and this
+    /// test will demand a guard.
+    const SOURCES: &[(&str, &str)] = &[
+        (
+            "audit_log.rs",
+            include_str!("../src/routes/dashboard/audit_log.rs"),
+        ),
+        (
+            "custom_domains.rs",
+            include_str!("../src/routes/dashboard/custom_domains.rs"),
+        ),
+        (
+            "deployments.rs",
+            include_str!("../src/routes/dashboard/deployments.rs"),
+        ),
+        (
+            "env_vars.rs",
+            include_str!("../src/routes/dashboard/env_vars.rs"),
+        ),
+        (
+            "profile.rs",
+            include_str!("../src/routes/dashboard/profile.rs"),
+        ),
+        (
+            "projects.rs",
+            include_str!("../src/routes/dashboard/projects.rs"),
+        ),
+        ("teams.rs", include_str!("../src/routes/dashboard/teams.rs")),
+        (
+            "mgmt_deployments.rs",
+            include_str!("../src/routes/management/deployments.rs"),
+        ),
+        (
+            "mgmt_env_vars.rs",
+            include_str!("../src/routes/management/env_vars.rs"),
+        ),
+        (
+            "mgmt_projects.rs",
+            include_str!("../src/routes/management/projects.rs"),
+        ),
+        (
+            "mgmt_teams.rs",
+            include_str!("../src/routes/management/teams.rs"),
+        ),
+        (
+            "deployment_internal.rs",
+            include_str!("../src/routes/deployment_internal.rs"),
+        ),
+    ];
+
+    /// Anything that establishes the caller may act on the resource. The
+    /// inline `get_team_role` check is here because several handlers in
+    /// teams.rs authorize that way rather than via a helper.
+    const GUARDS: &[&str] = &[
+        "require_team_member",
+        "require_project_member",
+        "require_deployment_member",
+        "require_deployment_member_by_name",
+        "require_team_admin",
+        "require_can_revoke_token",
+        "require_deployment_scope",
+        "require_same_project",
+        "require_domain_owner",
+        "get_team_role",
+    ];
+
+    let mut unguarded = Vec::new();
+    for (file, src) in SOURCES {
+        let mut parts = src.split("async fn ");
+        let _ = parts.next(); // preamble before the first handler
+        for part in parts {
+            let name: String = part
+                .chars()
+                .take_while(|c| c.is_alphanumeric() || *c == '_')
+                .collect();
+            if ALLOWED_UNGUARDED
+                .iter()
+                .any(|(f, h)| f == file && *h == name)
+            {
+                continue;
+            }
+            let Some(sig_end) = part.find("->") else {
+                continue;
+            };
+            let (sig, body) = part.split_at(sig_end);
+            let takes_identity = sig.contains("AuthIdentity") || sig.contains("SuperAdmin");
+            // `SuperAdmin` is itself the guard.
+            if !takes_identity || sig.contains("SuperAdmin") || !sig.contains("Path(") {
+                continue;
+            }
+            if !GUARDS.iter().any(|g| body.contains(g)) {
+                unguarded.push(format!("{file}::{name}"));
+            }
+        }
+    }
+
+    assert!(
+        unguarded.is_empty(),
+        "{} path-scoped handler(s) take an identity but never call an authorization guard. Add a \
+         guard, or add the handler to ALLOWED_UNGUARDED with a reason:\n  {}",
+        unguarded.len(),
+        unguarded.join("\n  ")
     );
 }

--- a/self-hosted/advanced/orchestrator.md
+++ b/self-hosted/advanced/orchestrator.md
@@ -350,6 +350,25 @@ Certificates renew automatically at 60 days, well inside the 90-day Let's
 Encrypt lifetime. Set `ACME_DIRECTORY_URL` to the Let's Encrypt **staging**
 directory while testing so you don't burn production rate limit.
 
+## Authorization model
+
+Every route that names a team, project, or deployment in its path checks that
+the caller belongs to the owning team. Destructive and governance actions —
+deleting a team, removing a member, changing a role, granting project admin —
+additionally require the team `admin` role.
+
+Deploy keys are bound to the deployment they were minted for and are refused
+against any other, so a key committed to CI has the blast radius of its own
+deployment and nothing more. The one exception is
+`/api/deployment/authorize_within_current_project`, which exists to select among
+sibling deployments (dev, preview, prod) and is therefore scoped to the project
+rather than the single deployment.
+
+A cross-tenant test suite (`crates/orchestrator/tests/cross_tenant.rs`) drives
+one tenant's token against a second tenant's resources across the whole route
+table, and a source-level sweep fails the build if a new path-scoped handler is
+added without an authorization guard.
+
 ## Running the orchestrator
 
 The orchestrator stores its state in PostgreSQL. We recommend


### PR DESCRIPTION
Routes across the orchestrator authenticated the caller but never authorized
them: a signed-in member of one team could read and mutate another team's
resources by naming them in the path.

`routes/helpers.rs:28` already documents this exact bug being fixed once, for
token routes. The sweep stopped there — `require_team_member` and
`require_project_member` were called in four places across two files.

## What was reachable

A test that drives one tenant's PAT against a second tenant's resources found
**24 of 31 routes returning 2xx**. It was not limited to reads:

| Route | Effect |
| --- | --- |
| `POST /api/dashboard/instances/{name}/auth` | Mints an admin key — full read/write on any deployment's data |
| `POST /api/deployment/authorize_within_current_project` | Same, keyed off a name in the request body |
| `POST .../environment_variables/update_batch` | Overwrites another project's default env vars, where secrets live |
| `POST /v1/projects/{id}/delete` | Deletes another tenant's project |
| `POST /v1/deployments/{name}/delete` | Deletes another tenant's deployment |

Exposure is currently bounded by `REGISTRATION_MODE=allowlist`, so only
admitted accounts can reach it. That bounds it to accounts already trusted; it
is not a mitigation, and it stops holding the moment registration opens or an
account is compromised.

## The fix

Guards on every path-scoped handler, using the existing helpers plus three new
ones: `require_deployment_member`, `require_deployment_member_by_name`, and
`require_team_admin` for destructive and governance actions.

Four cases needed more than a mechanical guard:

- **`retry_custom_domain` / `verify_custom_domain`** bind the path id as
  `_deployment_id` and act on `args.domain`. Guarding the path alone would
  have looked right and done nothing — you would pass *your* deployment id
  with *their* domain. They now resolve ownership from the domain.
- **`delete_custom_domain`** had the same shape somewhere worse: the row
  delete is scoped to `(deployment_id, domain)` and would no-op, but
  `delete_certificate(&domain)` on the next line is keyed on the domain alone
  and would have taken out another deployment's certificate.
- **`update_project_roles`** confirmed the project belonged to the path's
  team but never that the caller did, so anyone could grant project-admin on
  any team.
- **Deploy keys** are bound to one deployment, so membership is the wrong
  question for them; they are now refused against anything else. The
  exception is `authorize_within_current_project`, which exists to select
  among sibling deployments and is therefore scoped to the project.

## Not reopening

Two layers, meant to be read as a pair:

- `tests/cross_tenant.rs` builds two tenants and runs the route table. Each
  route gets a **freshly built victim** — sharing one would let an early
  destructive route make every later route 404 and look safe. Routes that
  answer neither 2xx nor a denial are reported separately as inconclusive, so
  a 400 from a malformed test body is never miscounted as a pass.
- A source-level sweep fails the build if a new path-scoped handler takes an
  identity without calling a guard. It caught nine handlers the route table
  missed, two of which were real holes (`create_project` and
  `create_deployment` let you create resources inside another tenant's team).
  Deliberate exceptions — `accept_invite`, `verify_email` — are allow-listed
  with reasons.

## Also here

`query_audit` ordered by `creation_time DESC` alone. It is millisecond
precision, so two events written in the same millisecond came back in
arbitrary order — an intermittent test failure that took a while to pin down.
It now tie-breaks on the `BIGSERIAL` id.

## Verification

113 lib + 3 cross-tenant + 11 integration tests pass against a real Postgres
16.4; clippy clean. `deployment_internal_flow_against_real_db` still passes,
which is the check that matters for over-strictness: it drives the CLI's real
provisioning path end to end, so a guard that refused legitimate access would
fail there.

Not covered: the guards have not been exercised against a running deployment,
only the test suite.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Strengthened access controls across dashboard and management APIs using team, project, and deployment membership checks.
  - Restricted administrative actions to authorized team administrators.
  - Enforced deployment-key scope and prevented cross-tenant access to deployments, domains, environment variables, and audit data.
- **Improvements**
  - Audit logs now use stable, newest-first ordering.
- **Documentation**
  - Added documentation describing authorization rules and cross-tenant protections.
- **Tests**
  - Added comprehensive authorization coverage for isolated tenants and resource access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->