### PR TITLE
Instance admin console for the orchestrator

### DIFF
--- a/crates/orchestrator/openapi.json
+++ b/crates/orchestrator/openapi.json
@@ -3704,6 +3704,198 @@
           }
         }
       }
+    },
+    "/api/admin/deployments/{deployment_id}/pause": {
+      "post": {
+        "tags": ["admin"],
+        "operationId": "pause",
+        "parameters": [
+          {
+            "name": "deployment_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActionResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "not a super-admin"
+          },
+          "409": {
+            "description": "deployment is still provisioning"
+          }
+        }
+      }
+    },
+    "/api/admin/deployments/{deployment_id}/resume": {
+      "post": {
+        "tags": ["admin"],
+        "operationId": "resume",
+        "parameters": [
+          {
+            "name": "deployment_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActionResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "not a super-admin"
+          },
+          "409": {
+            "description": "deployment is still provisioning"
+          }
+        }
+      }
+    },
+    "/api/admin/deployments/{deployment_id}/restart": {
+      "post": {
+        "tags": ["admin"],
+        "operationId": "restart",
+        "parameters": [
+          {
+            "name": "deployment_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RestartArgs"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActionResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "not a super-admin"
+          }
+        }
+      }
+    },
+    "/api/admin/deployments/{deployment_id}/tier": {
+      "post": {
+        "tags": ["admin"],
+        "operationId": "set_tier",
+        "parameters": [
+          {
+            "name": "deployment_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TierArgs"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActionResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "unknown tier"
+          },
+          "403": {
+            "description": "not a super-admin"
+          }
+        }
+      }
+    },
+    "/api/admin/deployments/{deployment_id}/delete": {
+      "post": {
+        "tags": ["admin"],
+        "operationId": "delete",
+        "parameters": [
+          {
+            "name": "deployment_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActionResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "not a super-admin"
+          },
+          "502": {
+            "description": "teardown failed; the deployment was not removed"
+          }
+        }
+      }
     }
   },
   "components": {
@@ -3730,6 +3922,23 @@
           },
           "keySuffix": {
             "type": "string"
+          }
+        }
+      },
+      "ActionResponse": {
+        "type": "object",
+        "required": ["deployment", "state"],
+        "properties": {
+          "deployment": {
+            "type": "string"
+          },
+          "state": {
+            "type": "string",
+            "description": "The row's state after the action."
+          },
+          "containerWarning": {
+            "type": ["string", "null"],
+            "description": "Set when the database changed but the container work did not fully\nsucceed. The action still took effect; the reconciler will converge."
           }
         }
       },
@@ -5499,6 +5708,15 @@
           }
         }
       },
+      "RestartArgs": {
+        "type": "object",
+        "properties": {
+          "force": {
+            "type": ["boolean", "null"],
+            "description": "Bypass the host capacity check, as the management route does."
+          }
+        }
+      },
       "RestartDeploymentArgs": {
         "type": "object",
         "properties": {
@@ -5801,6 +6019,15 @@
             "type": "string"
           },
           "slug": {
+            "type": "string"
+          }
+        }
+      },
+      "TierArgs": {
+        "type": "object",
+        "required": ["tier"],
+        "properties": {
+          "tier": {
             "type": "string"
           }
         }

--- a/crates/orchestrator/openapi.json
+++ b/crates/orchestrator/openapi.json
@@ -4085,6 +4085,136 @@
           }
         }
       }
+    },
+    "/api/admin/teams": {
+      "get": {
+        "tags": ["admin"],
+        "operationId": "list_teams",
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AdminTeamsResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "not a super-admin"
+          }
+        }
+      },
+      "post": {
+        "tags": ["admin"],
+        "operationId": "create_team",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateTeamArgs"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TeamActionResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "invalid name or slug already taken"
+          },
+          "403": {
+            "description": "not a super-admin"
+          }
+        }
+      }
+    },
+    "/api/admin/teams/{team_id}": {
+      "post": {
+        "tags": ["admin"],
+        "operationId": "rename_team",
+        "parameters": [
+          {
+            "name": "team_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RenameTeamArgs"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TeamActionResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "not a super-admin"
+          }
+        }
+      }
+    },
+    "/api/admin/teams/{team_id}/delete": {
+      "post": {
+        "tags": ["admin"],
+        "operationId": "delete_team",
+        "parameters": [
+          {
+            "name": "team_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TeamActionResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "not a super-admin"
+          },
+          "502": {
+            "description": "a deployment could not be torn down"
+          }
+        }
+      }
     }
   },
   "components": {
@@ -4313,6 +4443,62 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/AdminMemberRow"
+            }
+          }
+        }
+      },
+      "AdminTeamRow": {
+        "type": "object",
+        "required": [
+          "id",
+          "name",
+          "slug",
+          "creationTime",
+          "memberCount",
+          "projectCount",
+          "deploymentCount"
+        ],
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "name": {
+            "type": "string"
+          },
+          "slug": {
+            "type": "string"
+          },
+          "creationTime": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "memberCount": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 0
+          },
+          "projectCount": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 0
+          },
+          "deploymentCount": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Shown in the delete confirmation, so the blast radius is visible\nbefore the operator commits to it.",
+            "minimum": 0
+          }
+        }
+      },
+      "AdminTeamsResponse": {
+        "type": "object",
+        "required": ["teams"],
+        "properties": {
+          "teams": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AdminTeamRow"
             }
           }
         }
@@ -4582,7 +4768,8 @@
             "type": "string"
           },
           "slug": {
-            "type": ["string", "null"]
+            "type": ["string", "null"],
+            "description": "Derived from the name when omitted."
           }
         }
       },
@@ -5957,6 +6144,15 @@
           }
         }
       },
+      "RenameTeamArgs": {
+        "type": "object",
+        "required": ["name"],
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        }
+      },
       "RestartArgs": {
         "type": "object",
         "properties": {
@@ -6174,6 +6370,25 @@
         "properties": {
           "grant": {
             "type": "boolean"
+          }
+        }
+      },
+      "TeamActionResponse": {
+        "type": "object",
+        "required": ["teamId", "slug", "deploymentsRemoved"],
+        "properties": {
+          "teamId": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "slug": {
+            "type": "string"
+          },
+          "deploymentsRemoved": {
+            "type": "integer",
+            "format": "int32",
+            "description": "How many deployments the action tore down. Zero for anything but a\ndelete.",
+            "minimum": 0
           }
         }
       },

--- a/crates/orchestrator/openapi.json
+++ b/crates/orchestrator/openapi.json
@@ -4040,10 +4040,96 @@
           }
         }
       }
+    },
+    "/api/admin/deployments/{deployment_id}/access": {
+      "post": {
+        "tags": ["admin"],
+        "operationId": "grant_access",
+        "parameters": [
+          {
+            "name": "deployment_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AccessArgs"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AccessResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "a reason is required"
+          },
+          "403": {
+            "description": "not a super-admin"
+          }
+        }
+      }
     }
   },
   "components": {
     "schemas": {
+      "AccessArgs": {
+        "type": "object",
+        "required": ["reason"],
+        "properties": {
+          "reason": {
+            "type": "string",
+            "description": "Why this access is being taken. Recorded verbatim in both audit logs."
+          }
+        }
+      },
+      "AccessResponse": {
+        "type": "object",
+        "required": [
+          "deployment",
+          "url",
+          "adminKey",
+          "expiresAt",
+          "tenantNotified"
+        ],
+        "properties": {
+          "deployment": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          },
+          "adminKey": {
+            "type": "string",
+            "description": "A freshly minted, short-lived admin key. Shown once."
+          },
+          "expiresAt": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Unix ms. The UI counts down to this so an operator with a dashboard\nopen is not surprised by everything failing at once."
+          },
+          "tenantNotified": {
+            "type": "boolean",
+            "description": "Restates, in the response, that this was recorded where the tenant\ncan see it — so it is visible even to an API caller who never saw\nthe modal."
+          }
+        }
+      },
       "AccessToken": {
         "type": "string"
       },

--- a/crates/orchestrator/openapi.json
+++ b/crates/orchestrator/openapi.json
@@ -3588,6 +3588,122 @@
           }
         ]
       }
+    },
+    "/api/admin/health": {
+      "get": {
+        "tags": ["admin"],
+        "operationId": "admin_health",
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AdminHealthResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "not a super-admin"
+          }
+        }
+      }
+    },
+    "/api/admin/overview": {
+      "get": {
+        "tags": ["admin"],
+        "operationId": "overview",
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OverviewResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "not a super-admin"
+          }
+        }
+      }
+    },
+    "/api/admin/fleet": {
+      "get": {
+        "tags": ["admin"],
+        "operationId": "fleet",
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FleetResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "not a super-admin"
+          }
+        }
+      }
+    },
+    "/api/admin/members": {
+      "get": {
+        "tags": ["admin"],
+        "operationId": "list_members",
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AdminMembersResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "not a super-admin"
+          }
+        }
+      }
+    },
+    "/api/admin/audit": {
+      "get": {
+        "tags": ["admin"],
+        "operationId": "instance_audit",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": ["integer", "null"],
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AdminAuditResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "not a super-admin"
+          }
+        }
+      }
     }
   },
   "components": {
@@ -3614,6 +3730,151 @@
           },
           "keySuffix": {
             "type": "string"
+          }
+        }
+      },
+      "AdminAuditResponse": {
+        "type": "object",
+        "required": ["events"],
+        "properties": {
+          "events": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/InstanceAuditEvent"
+            }
+          }
+        }
+      },
+      "AdminDeploymentRow": {
+        "type": "object",
+        "description": "A deployment as the admin console sees it, with its owning team and\nproject resolved.\n\n`intended_state` is what the database says should be running. What is\n*actually* running is a docker question, filled in by the fleet route —\nthis query cannot know it.",
+        "required": [
+          "id",
+          "name",
+          "deploymentType",
+          "intendedState",
+          "tier",
+          "url",
+          "creationTime",
+          "teamId",
+          "teamSlug",
+          "projectId",
+          "projectSlug"
+        ],
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "name": {
+            "type": "string"
+          },
+          "deploymentType": {
+            "type": "string"
+          },
+          "intendedState": {
+            "type": "string"
+          },
+          "tier": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          },
+          "creationTime": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "teamId": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "teamSlug": {
+            "type": "string"
+          },
+          "projectId": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "projectSlug": {
+            "type": "string"
+          }
+        }
+      },
+      "AdminHealthResponse": {
+        "type": "object",
+        "required": [
+          "version",
+          "database",
+          "provisioner",
+          "reconcileIntervalSecs"
+        ],
+        "properties": {
+          "version": {
+            "type": "string"
+          },
+          "database": {
+            "$ref": "#/components/schemas/DatabaseHealth"
+          },
+          "provisioner": {
+            "$ref": "#/components/schemas/ProvisionerHealth"
+          },
+          "reconcileIntervalSecs": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0
+          }
+        }
+      },
+      "AdminMemberRow": {
+        "type": "object",
+        "description": "A member as the admin console sees them: identity, flags, and every team\nthey belong to.",
+        "required": [
+          "id",
+          "primaryEmail",
+          "creationTime",
+          "isSuperAdmin",
+          "suspended",
+          "teams"
+        ],
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "primaryEmail": {
+            "type": "string"
+          },
+          "name": {
+            "type": ["string", "null"]
+          },
+          "creationTime": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "isSuperAdmin": {
+            "type": "boolean"
+          },
+          "suspended": {
+            "type": "boolean"
+          },
+          "teams": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/MemberTeamRef"
+            }
+          }
+        }
+      },
+      "AdminMembersResponse": {
+        "type": "object",
+        "required": ["members"],
+        "properties": {
+          "members": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AdminMemberRow"
+            }
           }
         }
       },
@@ -3940,6 +4201,23 @@
           }
         }
       },
+      "DatabaseHealth": {
+        "type": "object",
+        "required": ["reachable"],
+        "properties": {
+          "reachable": {
+            "type": "boolean"
+          },
+          "pingMs": {
+            "type": ["integer", "null"],
+            "format": "int64",
+            "minimum": 0
+          },
+          "error": {
+            "type": ["string", "null"]
+          }
+        }
+      },
       "DeleteArgs": {
         "type": "object",
         "required": ["id"],
@@ -4206,7 +4484,13 @@
       },
       "ExchangeSessionResponse": {
         "type": "object",
-        "required": ["accessToken", "memberId", "teamSlug", "role"],
+        "required": [
+          "accessToken",
+          "memberId",
+          "teamSlug",
+          "role",
+          "isSuperAdmin"
+        ],
         "properties": {
           "accessToken": {
             "type": "string"
@@ -4221,6 +4505,52 @@
           },
           "role": {
             "type": "string"
+          },
+          "isSuperAdmin": {
+            "type": "boolean",
+            "description": "Instance-wide operator. The dashboard uses this only to decide\nwhether to render the admin nav; the server-side gate is the\n`SuperAdmin` extractor, so a client that lies about it gains\nnothing."
+          }
+        }
+      },
+      "FleetEntry": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/AdminDeploymentRow"
+          },
+          {
+            "type": "object",
+            "required": ["actualState", "drifted"],
+            "properties": {
+              "actualState": {
+                "type": "string",
+                "description": "`running` / `stopped` / `missing`, or `unknown` when there was\nnothing to inspect or the inspection failed."
+              },
+              "drifted": {
+                "type": "boolean",
+                "description": "True when the container is not doing what the database says it\nshould. Always false when `actual_state` is `unknown` — we do not\nreport drift we could not observe."
+              }
+            }
+          }
+        ]
+      },
+      "FleetResponse": {
+        "type": "object",
+        "required": ["deployments", "driftCount", "containerStatesAvailable"],
+        "properties": {
+          "deployments": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FleetEntry"
+            }
+          },
+          "driftCount": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 0
+          },
+          "containerStatesAvailable": {
+            "type": "boolean",
+            "description": "False when the provisioner does not manage containers, so the UI can\nsay \"not applicable\" rather than rendering a column of `unknown`."
           }
         }
       },
@@ -4296,6 +4626,30 @@
             "type": "integer",
             "format": "int32",
             "minimum": 0
+          }
+        }
+      },
+      "InstanceAuditEvent": {
+        "type": "object",
+        "description": "One instance-scoped event on the wire.\n\nNamed distinctly from `storage::AuditEntry`, which is the team-scoped\nrow type and carries a `team_id` this surface has no use for.",
+        "required": ["id", "action", "metadata", "creationTime"],
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "memberId": {
+            "type": ["integer", "null"],
+            "format": "int64",
+            "description": "`None` for actions taken through the break-glass bootstrap\ncredential, which has no human behind it."
+          },
+          "action": {
+            "type": "string"
+          },
+          "metadata": {},
+          "creationTime": {
+            "type": "integer",
+            "format": "int64"
           }
         }
       },
@@ -4471,12 +4825,93 @@
           }
         }
       },
+      "MemberTeamRef": {
+        "type": "object",
+        "description": "One team membership, flattened for the admin member table.",
+        "required": ["teamId", "teamSlug", "teamName", "role"],
+        "properties": {
+          "teamId": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "teamSlug": {
+            "type": "string"
+          },
+          "teamName": {
+            "type": "string"
+          },
+          "role": {
+            "type": "string"
+          }
+        }
+      },
       "OptIn": {
         "type": "object",
         "required": ["name"],
         "properties": {
           "name": {
             "type": "string"
+          }
+        }
+      },
+      "OverviewResponse": {
+        "type": "object",
+        "required": [
+          "totalMemoryMb",
+          "totalCpus",
+          "allocatedMemoryMb",
+          "allocatedCpus",
+          "deploymentCount",
+          "deploymentsByState",
+          "teamCount",
+          "memberCount"
+        ],
+        "properties": {
+          "totalMemoryMb": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0
+          },
+          "totalCpus": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 0
+          },
+          "allocatedMemoryMb": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0
+          },
+          "allocatedCpus": {
+            "type": "number",
+            "format": "float"
+          },
+          "deploymentCount": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 0
+          },
+          "deploymentsByState": {
+            "type": "object",
+            "description": "Deployment counts keyed by the intended state recorded in the\ndatabase: `running`, `paused`, `disabled`, `provisioning`.",
+            "additionalProperties": {
+              "type": "integer",
+              "format": "int32",
+              "minimum": 0
+            },
+            "propertyNames": {
+              "type": "string"
+            }
+          },
+          "teamCount": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 0
+          },
+          "memberCount": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 0
           }
         }
       },
@@ -4991,6 +5426,22 @@
           },
           "deploymentType": {
             "type": "string"
+          }
+        }
+      },
+      "ProvisionerHealth": {
+        "type": "object",
+        "required": ["mode"],
+        "properties": {
+          "mode": {
+            "type": "string"
+          },
+          "dockerReachable": {
+            "type": ["boolean", "null"],
+            "description": "`None` when the mode does not own containers, so there is no socket\nto check. Reporting `false` there would read as a fault when nothing\nis wrong."
+          },
+          "error": {
+            "type": ["string", "null"]
           }
         }
       },
@@ -5525,6 +5976,10 @@
     {
       "name": "dashboard",
       "description": "/api/dashboard: private dashboard API"
+    },
+    {
+      "name": "admin",
+      "description": "/api/admin: instance-scoped operator API (super-admin only)"
     },
     {
       "name": "dashboard_stubs",

--- a/crates/orchestrator/openapi.json
+++ b/crates/orchestrator/openapi.json
@@ -3896,6 +3896,150 @@
           }
         }
       }
+    },
+    "/api/admin/members/{member_id}/suspend": {
+      "post": {
+        "tags": ["admin"],
+        "operationId": "suspend",
+        "parameters": [
+          {
+            "name": "member_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MemberActionResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "not a super-admin"
+          }
+        }
+      }
+    },
+    "/api/admin/members/{member_id}/unsuspend": {
+      "post": {
+        "tags": ["admin"],
+        "operationId": "unsuspend",
+        "parameters": [
+          {
+            "name": "member_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MemberActionResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "not a super-admin"
+          }
+        }
+      }
+    },
+    "/api/admin/members/{member_id}/super_admin": {
+      "post": {
+        "tags": ["admin"],
+        "operationId": "set_super_admin",
+        "parameters": [
+          {
+            "name": "member_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SuperAdminArgs"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MemberActionResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "not a super-admin"
+          },
+          "409": {
+            "description": "would revoke the last super-admin"
+          }
+        }
+      }
+    },
+    "/api/admin/members/{member_id}/delete": {
+      "post": {
+        "tags": ["admin"],
+        "operationId": "delete",
+        "parameters": [
+          {
+            "name": "member_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MemberActionResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "not a super-admin"
+          },
+          "409": {
+            "description": "would remove the last super-admin"
+          }
+        }
+      }
     }
   },
   "components": {
@@ -5002,6 +5146,25 @@
           }
         }
       },
+      "MemberActionResponse": {
+        "type": "object",
+        "required": ["memberId", "email", "isSuperAdmin", "suspended"],
+        "properties": {
+          "memberId": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "email": {
+            "type": "string"
+          },
+          "isSuperAdmin": {
+            "type": "boolean"
+          },
+          "suspended": {
+            "type": "boolean"
+          }
+        }
+      },
       "MemberDataResponse": {
         "type": "object",
         "required": ["member", "teams"],
@@ -5916,6 +6079,15 @@
           },
           "teamName": {
             "type": ["string", "null"]
+          }
+        }
+      },
+      "SuperAdminArgs": {
+        "type": "object",
+        "required": ["grant"],
+        "properties": {
+          "grant": {
+            "type": "boolean"
           }
         }
       },

--- a/crates/orchestrator/openapi.json
+++ b/crates/orchestrator/openapi.json
@@ -5269,6 +5269,10 @@
             "format": "int64",
             "description": "`None` for actions taken through the break-glass bootstrap\ncredential, which has no human behind it."
           },
+          "memberEmail": {
+            "type": ["string", "null"],
+            "description": "Resolved server-side. `None` when there is no member, or the member\nhas since been deleted."
+          },
           "action": {
             "type": "string"
           },

--- a/crates/orchestrator/src/auth/identity.rs
+++ b/crates/orchestrator/src/auth/identity.rs
@@ -31,6 +31,24 @@ pub struct AuthIdentity {
     pub team_id: Option<i64>,
     pub deployment_id: Option<i64>,
     pub project_id: Option<i64>,
+    /// Instance-wide operator rights.
+    ///
+    /// Only ever `true` for `Session` and `Pat` tokens. A deploy key
+    /// belonging to a super-admin member resolves to `false` — deploy keys
+    /// live in CI config and `.env` files, and a member being an operator
+    /// must not turn every key they ever minted into an instance-wide
+    /// credential.
+    pub is_super_admin: bool,
+    /// This token belongs to the synthetic bootstrap member — the
+    /// break-glass path for an instance whose operator accounts are all
+    /// locked out.
+    ///
+    /// Keyed on `auth_user_id == SYSTEM_AUTH_USER_ID`, not on the token's
+    /// name: members can name their own PATs, so a name check would let
+    /// anyone mint themselves instance root. Only `bootstrap_if_empty`
+    /// creates that member, and `exchange_session` rejects any
+    /// `authUserId` in the `system:` namespace, so it cannot be forged.
+    pub is_bootstrap: bool,
 }
 
 impl AuthIdentity {
@@ -55,6 +73,25 @@ fn extract_bearer(parts: &Parts) -> Option<String> {
 }
 
 async fn resolve(state: &OrchestratorState, raw: &str) -> Result<AuthIdentity, ApiError> {
+    resolve_with_storage(&state.storage, raw).await
+}
+
+/// Resolve a raw bearer token against storage without an HTTP request.
+///
+/// Exists so the integration suite can assert on elevation and suspension
+/// without standing up a router. Delegates to the identical code path the
+/// extractors use, so a test that passes here is not testing a copy.
+pub async fn resolve_for_test(
+    storage: &crate::storage::Storage,
+    raw: &str,
+) -> Result<AuthIdentity, ApiError> {
+    resolve_with_storage(storage, raw).await
+}
+
+async fn resolve_with_storage(
+    storage: &crate::storage::Storage,
+    raw: &str,
+) -> Result<AuthIdentity, ApiError> {
     let parsed = parse_token(raw).map_err(|e| {
         tracing::debug!(
             error = %e,
@@ -65,8 +102,7 @@ async fn resolve(state: &OrchestratorState, raw: &str) -> Result<AuthIdentity, A
         ApiError::Unauthorized
     })?;
     let hash = sha256_hex(parsed.secret);
-    let token = state
-        .storage
+    let token = storage
         .get_access_token_by_hash(&hash)
         .await
         .map_err(ApiError::Internal)?
@@ -104,8 +140,7 @@ async fn resolve(state: &OrchestratorState, raw: &str) -> Result<AuthIdentity, A
                 );
                 ApiError::Unauthorized
             })?;
-            let project = state
-                .storage
+            let project = storage
                 .get_project(project_id)
                 .await
                 .map_err(ApiError::Internal)?
@@ -116,8 +151,7 @@ async fn resolve(state: &OrchestratorState, raw: &str) -> Result<AuthIdentity, A
                     );
                     ApiError::Unauthorized
                 })?;
-            let team = state
-                .storage
+            let team = storage
                 .get_team(project.team_id)
                 .await
                 .map_err(ApiError::Internal)?
@@ -138,8 +172,7 @@ async fn resolve(state: &OrchestratorState, raw: &str) -> Result<AuthIdentity, A
                 );
                 ApiError::Unauthorized
             })?;
-            let dep = state
-                .storage
+            let dep = storage
                 .get_deployment(deployment_id)
                 .await
                 .map_err(ApiError::Internal)?
@@ -201,11 +234,44 @@ async fn resolve(state: &OrchestratorState, raw: &str) -> Result<AuthIdentity, A
         AccessTokenKind::Admin => "admin",
     };
 
+    // Elevation is deliberately narrow. Deploy keys live in CI config and
+    // `.env` files; a member being an operator must not make every key they
+    // ever minted an instance-wide credential.
+    let elevation_eligible = matches!(token.kind, AccessTokenKind::Session | AccessTokenKind::Pat);
+    let mut is_super_admin = false;
+    let mut is_bootstrap = false;
+    if let Some(member_id) = token.member_id {
+        match storage
+            .get_member(member_id)
+            .await
+            .map_err(ApiError::Internal)?
+        {
+            // A suspended or deleted member cannot authenticate at all,
+            // which revokes every live session and PAT without deleting
+            // anything — the point of suspension being reversible.
+            Some(m) if m.suspended || m.deleted => {
+                tracing::debug!(member_id, "auth: member is suspended or deleted");
+                return Err(ApiError::Unauthorized);
+            },
+            Some(m) => {
+                is_bootstrap =
+                    elevation_eligible && m.auth_user_id == crate::state::SYSTEM_AUTH_USER_ID;
+                is_super_admin = elevation_eligible && m.is_super_admin;
+            },
+            None => {
+                tracing::debug!(member_id, "auth: token references a missing member");
+                return Err(ApiError::Unauthorized);
+            },
+        }
+    }
+
     Ok(AuthIdentity {
         member_id: token.member_id,
         team_id: token.team_id,
         deployment_id: token.deployment_id,
         project_id: token.project_id,
+        is_super_admin,
+        is_bootstrap,
         token,
     })
 }

--- a/crates/orchestrator/src/auth/mod.rs
+++ b/crates/orchestrator/src/auth/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod deploy_keys;
 pub mod identity;
+pub mod super_admin;
 pub mod tokens;
 
 pub use deploy_keys::{

--- a/crates/orchestrator/src/auth/super_admin.rs
+++ b/crates/orchestrator/src/auth/super_admin.rs
@@ -1,0 +1,97 @@
+//! Extractor that gates the instance-scoped `/api/admin` surface.
+//!
+//! Handlers take `SuperAdmin` instead of `AuthIdentity`, so the
+//! authorization requirement is part of the function signature and visible
+//! in review. The table-driven 403 test in `tests/integration.rs` is what
+//! actually fails CI if a route is added without it.
+
+use axum::{
+    extract::{
+        FromRef,
+        FromRequestParts,
+    },
+    http::request::Parts,
+};
+
+use crate::{
+    auth::identity::AuthIdentity,
+    errors::ApiError,
+    state::OrchestratorState,
+};
+
+/// Who performed an admin action, for the audit log.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Actor {
+    /// A real member holding `members.is_super_admin`.
+    Member(i64),
+    /// The synthetic bootstrap member — break-glass, no human attribution.
+    Bootstrap,
+}
+
+impl Actor {
+    /// Member id to store on an audit row, or `None` for break-glass.
+    ///
+    /// The bootstrap member does have a row, but recording it would put a
+    /// synthetic account where an operator's name belongs and read as if a
+    /// person did it. `None` plus the `actor` label in the metadata is the
+    /// honest version.
+    pub fn member_id(&self) -> Option<i64> {
+        match self {
+            Self::Member(id) => Some(*id),
+            Self::Bootstrap => None,
+        }
+    }
+
+    pub fn label(&self) -> &'static str {
+        match self {
+            Self::Member(_) => "member",
+            Self::Bootstrap => "bootstrap",
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct SuperAdmin {
+    pub identity: AuthIdentity,
+    pub actor: Actor,
+}
+
+impl<S> FromRequestParts<S> for SuperAdmin
+where
+    OrchestratorState: FromRef<S>,
+    S: Send + Sync,
+{
+    type Rejection = ApiError;
+
+    async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
+        let identity = AuthIdentity::from_request_parts(parts, state).await?;
+        let st: OrchestratorState = OrchestratorState::from_ref(state);
+
+        // Break-glass: the bootstrap member is an instance operator by
+        // definition, so an instance whose operator accounts are all locked
+        // out can still be recovered without psql. Gated on the orchestrator
+        // still having a bootstrap token configured, so an operator can shut
+        // the path off by clearing it.
+        let is_bootstrap = identity.is_bootstrap && st.config.bootstrap_token.is_some();
+
+        if !identity.is_super_admin && !is_bootstrap {
+            tracing::debug!(
+                member_id = ?identity.member_id,
+                token_kind = ?identity.token.kind,
+                "admin: rejecting non-super-admin identity"
+            );
+            return Err(ApiError::Forbidden);
+        }
+
+        // Bootstrap wins the label even if the member also carries the
+        // column, because the credential in play is the break-glass one and
+        // the audit trail should say so.
+        let actor = if is_bootstrap {
+            Actor::Bootstrap
+        } else {
+            Actor::Member(identity.require_member()?)
+        };
+
+        Ok(Self { identity, actor })
+    }
+}

--- a/crates/orchestrator/src/config.rs
+++ b/crates/orchestrator/src/config.rs
@@ -79,6 +79,10 @@ pub struct OrchestratorConfig {
     /// ACME directory to use. Defaults to Let's Encrypt production; point at
     /// the staging directory to exercise the flow without burning rate limit.
     pub acme_directory_url: Option<String>,
+    /// Seconds between reconcile passes over tenant containers. `0` disables
+    /// the periodic loop and restores boot-only behaviour. Docker provisioner
+    /// mode only — the other modes do not own containers.
+    pub reconcile_interval_secs: u64,
 }
 
 impl OrchestratorConfig {
@@ -129,8 +133,7 @@ impl FromStr for ProvisionerMode {
             "process" => Ok(Self::Process),
             "docker" => Ok(Self::Docker),
             other => Err(anyhow::anyhow!(
-                "unknown provisioner mode {other:?} (expected `external`, `process`, or \
-                 `docker`)"
+                "unknown provisioner mode {other:?} (expected `external`, `process`, or `docker`)"
             )),
         }
     }
@@ -194,6 +197,8 @@ mod tests {
             traefik_cert_dir: "/dynamic".into(),
             acme_contact_email: None,
             acme_directory_url: None,
+            // Tests must never start a background reconcile loop.
+            reconcile_interval_secs: 0,
         }
     }
 

--- a/crates/orchestrator/src/errors.rs
+++ b/crates/orchestrator/src/errors.rs
@@ -25,6 +25,11 @@ pub enum ApiError {
     BadRequest(String),
     #[error("not implemented: {0}")]
     NotImplemented(String),
+    /// A downstream the orchestrator depends on failed — in practice the
+    /// docker daemon. Distinct from `Internal` so the caller can tell
+    /// "your request was fine, the machine underneath was not".
+    #[error("upstream failure: {0}")]
+    BadGateway(String),
     #[error(transparent)]
     Internal(#[from] anyhow::Error),
 }
@@ -39,6 +44,7 @@ impl ApiError {
             Self::HostCapacityExceeded { .. } => "host_capacity_exceeded",
             Self::BadRequest(_) => "BadRequest",
             Self::NotImplemented(_) => "NotImplemented",
+            Self::BadGateway(_) => "BadGateway",
             Self::Internal(_) => "InternalServerError",
         }
     }
@@ -52,6 +58,7 @@ impl ApiError {
             Self::HostCapacityExceeded { .. } => StatusCode::CONFLICT,
             Self::BadRequest(_) => StatusCode::BAD_REQUEST,
             Self::NotImplemented(_) => StatusCode::NOT_IMPLEMENTED,
+            Self::BadGateway(_) => StatusCode::BAD_GATEWAY,
             Self::Internal(_) => StatusCode::INTERNAL_SERVER_ERROR,
         }
     }

--- a/crates/orchestrator/src/main.rs
+++ b/crates/orchestrator/src/main.rs
@@ -19,13 +19,17 @@ use tracing_subscriber::{
 )]
 struct Args {
     /// Address for the provisioning API (mirrors prod BigBrain port 8050).
-    #[arg(long, env = "CONVEX_ORCHESTRATOR_PROVISION_ADDR", default_value = "0.0.0.0:8050")]
+    #[arg(
+        long,
+        env = "CONVEX_ORCHESTRATOR_PROVISION_ADDR",
+        default_value = "0.0.0.0:8050"
+    )]
     provision_addr: String,
 
-    /// Postgres connection URL. PlanetScale Postgres requires `sslmode=require`.
-    /// Format: `postgres://user:pass@host:5432/dbname?sslmode=require`.
-    /// Required to start the server; not required when only `--print-openapi`
-    /// is set.
+    /// Postgres connection URL. PlanetScale Postgres requires
+    /// `sslmode=require`. Format: `postgres://user:pass@host:5432/dbname?
+    /// sslmode=require`. Required to start the server; not required when
+    /// only `--print-openapi` is set.
     #[arg(long, env = "CONVEX_ORCHESTRATOR_DATABASE_URL")]
     database_url: Option<String>,
 
@@ -56,7 +60,11 @@ struct Args {
     print_openapi: bool,
 
     /// Provisioner mode: `external`, `process`, or `docker`.
-    #[arg(long, env = "CONVEX_ORCHESTRATOR_PROVISIONER", default_value = "external")]
+    #[arg(
+        long,
+        env = "CONVEX_ORCHESTRATOR_PROVISIONER",
+        default_value = "external"
+    )]
     provisioner: String,
 
     /// Image tag the docker provisioner uses for spawned backends.
@@ -126,6 +134,16 @@ struct Args {
         default_value = "http"
     )]
     router_public_scheme: String,
+
+    /// Seconds between reconcile passes over tenant containers. `0` runs a
+    /// single pass at boot and never again, which was the behaviour before
+    /// this knob existed. Docker provisioner mode only.
+    #[arg(
+        long,
+        env = "CONVEX_ORCHESTRATOR_RECONCILE_INTERVAL_SECS",
+        default_value_t = 60
+    )]
+    reconcile_interval_secs: u64,
 
     /// When true, spawned backend containers get direct Traefik routers for
     /// their API and site hosts. The in-orchestrator proxy remains a
@@ -277,6 +295,7 @@ async fn main() -> anyhow::Result<()> {
         traefik_cert_dir: args.traefik_cert_dir,
         acme_contact_email: args.acme_contact_email,
         acme_directory_url: args.acme_directory_url,
+        reconcile_interval_secs: args.reconcile_interval_secs,
     };
 
     tracing::info!(?config.data_root, "starting convex-orchestrator");

--- a/crates/orchestrator/src/provisioner/lifecycle.rs
+++ b/crates/orchestrator/src/provisioner/lifecycle.rs
@@ -1,0 +1,71 @@
+//! Stopping and starting a deployment's containers without destroying them.
+//!
+//! Distinct from `teardown`, which removes containers and volumes, and from
+//! `respawn`, which recreates them. Pause has to *preserve* the container's
+//! configuration — image, env, volumes, resource limits — because resume
+//! reuses it. `docker stop` does; `docker rm` does not, which is why
+//! `docker::stop_and_remove_container` is the wrong primitive here despite
+//! the similar name.
+
+use tokio::process::Command;
+
+use super::sidecar;
+
+/// Containers to stop when pausing, in the order to stop them.
+///
+/// Backend first: it holds connections to its sidecars, and stopping
+/// Postgres out from under an in-flight request produces errors a user sees
+/// rather than a clean shutdown.
+pub fn containers_for_pause(
+    container_prefix: &str,
+    deployment_name: &str,
+    storage_mode: &str,
+) -> Vec<String> {
+    let backend = format!("{container_prefix}{deployment_name}");
+    if storage_mode != "sidecar" {
+        // volume-sqlite: the backend owns its own storage, so there is
+        // nothing else to stop.
+        return vec![backend];
+    }
+    vec![
+        backend,
+        sidecar::pg_container_name(container_prefix, deployment_name),
+        sidecar::minio_container_name(container_prefix, deployment_name),
+    ]
+}
+
+/// Containers to start when resuming: the exact reverse of the pause order,
+/// so the backend comes up last and finds its dependencies already running.
+pub fn containers_for_resume(
+    container_prefix: &str,
+    deployment_name: &str,
+    storage_mode: &str,
+) -> Vec<String> {
+    let mut v = containers_for_pause(container_prefix, deployment_name, storage_mode);
+    v.reverse();
+    v
+}
+
+/// `docker stop`, with the same grace period the provisioner uses on
+/// teardown.
+///
+/// A container that is already stopped or missing is not an error: pause is
+/// idempotent, and an operator retrying after a partial failure should
+/// converge rather than get stuck on a container that is already where they
+/// want it.
+pub async fn stop_container(name: &str) -> anyhow::Result<()> {
+    let output = Command::new("docker")
+        .args(["stop", "--time", "10", name])
+        .output()
+        .await
+        .map_err(|e| anyhow::anyhow!("docker stop {name}: {e}"))?;
+    if output.status.success() {
+        return Ok(());
+    }
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    if stderr.contains("No such container") {
+        tracing::debug!(container = %name, "docker stop: container already gone");
+        return Ok(());
+    }
+    anyhow::bail!("docker stop {name} failed: {}", stderr.trim())
+}

--- a/crates/orchestrator/src/provisioner/mod.rs
+++ b/crates/orchestrator/src/provisioner/mod.rs
@@ -6,6 +6,7 @@ mod docker;
 pub mod env;
 mod external;
 mod process;
+pub mod lifecycle;
 pub mod sidecar;
 pub mod tiers;
 

--- a/crates/orchestrator/src/reconcile.rs
+++ b/crates/orchestrator/src/reconcile.rs
@@ -1,4 +1,4 @@
-//! Boot-time reconcile of tenant backends.
+//! Periodic reconcile of tenant backends.
 //!
 //! Spawned backends are created with `--restart unless-stopped`, so a host
 //! reboot or docker-daemon restart normally brings them back on its own. What
@@ -10,8 +10,9 @@
 //! API happily while every tenant deployment stayed dark until somebody hit
 //! Restart in the dashboard, one deployment at a time.
 //!
-//! This module closes that gap: on boot, for every deployment row, make the
-//! container match what the database says should be running.
+//! This module closes that gap: on boot and every `reconcile_interval_secs`
+//! thereafter, for every deployment row, make the container match what the
+//! database says should be running.
 //!
 //! Deliberately narrow: it **starts containers that already exist** and does
 //! not create missing ones. Recreating a container goes through
@@ -113,10 +114,22 @@ fn plan(state: DeploymentState, status: ContainerStatus) -> ReconcileAction {
     }
 }
 
-/// Reconcile once in the background, then exit. Mirrors
-/// `acme::renewal::spawn`: never blocks the API from coming up, and a failure
-/// is logged rather than propagated — a tenant that won't start must not stop
-/// the orchestrator from serving the dashboard that reports it.
+/// Whether a given interval means "keep reconciling".
+///
+/// `0` restores the original boot-only behaviour, which is the escape hatch
+/// for an operator who wants to drive reconciliation by hand.
+pub fn periodic_enabled(interval_secs: u64) -> bool {
+    interval_secs > 0
+}
+
+/// Reconcile on an interval in the background.
+///
+/// This used to run once at boot and exit, which left any drift after
+/// startup both invisible and uncorrected — a container stopped by hand at
+/// 09:00 stayed down until somebody noticed. Mirrors `acme::renewal::spawn`:
+/// never blocks the API from coming up, and a failure is logged rather than
+/// propagated — a tenant that won't start must not stop the orchestrator
+/// from serving the dashboard that reports it.
 pub fn spawn(state: OrchestratorState) {
     if !matches!(state.config.provisioner_mode, ProvisionerMode::Docker) {
         // `External` (the default) and `Process` don't own containers, so
@@ -127,10 +140,18 @@ pub fn spawn(state: OrchestratorState) {
         );
         return;
     }
+    let interval_secs = state.config.reconcile_interval_secs;
     tokio::spawn(async move {
         tokio::time::sleep(STARTUP_DELAY).await;
-        if let Err(e) = reconcile_all(&state).await {
-            tracing::error!(error = %e, "deployment reconcile failed");
+        loop {
+            if let Err(e) = reconcile_all(&state).await {
+                tracing::error!(error = %e, "deployment reconcile failed");
+            }
+            if !periodic_enabled(interval_secs) {
+                tracing::info!("periodic reconcile disabled; ran once at boot");
+                return;
+            }
+            tokio::time::sleep(Duration::from_secs(interval_secs)).await;
         }
     });
 }
@@ -173,11 +194,7 @@ pub async fn reconcile_all(state: &OrchestratorState) -> anyhow::Result<()> {
             },
         }
     }
-    tracing::info!(
-        started,
-        failed,
-        "deployment reconcile: finished"
-    );
+    tracing::info!(started, failed, "deployment reconcile: finished");
     Ok(())
 }
 
@@ -291,8 +308,8 @@ async fn ensure_sidecars_ready(
                 // Deliberately fatal for this deployment: bringing a backend up
                 // with no database behind it is worse than leaving it down.
                 anyhow::bail!(
-                    "{kind} sidecar {container} does not exist; deployment \
-                     {deployment_name} needs a full restart to re-provision it"
+                    "{kind} sidecar {container} does not exist; deployment {deployment_name} \
+                     needs a full restart to re-provision it"
                 );
             },
         }

--- a/crates/orchestrator/src/reconcile.rs
+++ b/crates/orchestrator/src/reconcile.rs
@@ -63,8 +63,12 @@ const STARTUP_DELAY: Duration = Duration::from_secs(5);
 const SIDECAR_STORAGE_MODE: &str = "sidecar";
 
 /// What docker currently thinks of a container.
+///
+/// `pub` so the admin fleet route can report actual-vs-intended state using
+/// the same probe the reconciler acts on — two implementations would
+/// eventually disagree about what "drifted" means.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum ContainerStatus {
+pub enum ContainerStatus {
     /// No container by that name.
     Missing,
     /// Exists and its state is `running`.
@@ -344,7 +348,7 @@ async fn start_container(name: &str) -> anyhow::Result<()> {
 
 /// Read a container's state via `docker inspect`. A non-zero exit means no
 /// such container, which is the `Missing` case rather than an error.
-async fn container_status(name: &str) -> anyhow::Result<ContainerStatus> {
+pub async fn container_status(name: &str) -> anyhow::Result<ContainerStatus> {
     let output = Command::new("docker")
         .args(["inspect", "--format", "{{.State.Status}}", name])
         .output()

--- a/crates/orchestrator/src/reconcile.rs
+++ b/crates/orchestrator/src/reconcile.rs
@@ -331,7 +331,7 @@ async fn ensure_sidecars_ready(
 /// container's existing configuration — image, env, volumes, network,
 /// resource limits — so a reconcile can never silently re-provision a
 /// deployment under different settings than it was created with.
-async fn start_container(name: &str) -> anyhow::Result<()> {
+pub async fn start_container(name: &str) -> anyhow::Result<()> {
     let output = Command::new("docker")
         .args(["start", name])
         .output()

--- a/crates/orchestrator/src/router.rs
+++ b/crates/orchestrator/src/router.rs
@@ -3,6 +3,7 @@
 use std::time::Duration;
 
 use axum::{
+    extract::State,
     http::{
         header,
         HeaderName,
@@ -11,6 +12,7 @@ use axum::{
     },
     response::IntoResponse,
     routing::get,
+    Json,
     Router,
 };
 use tower::ServiceBuilder;
@@ -62,6 +64,7 @@ pub fn build_router(state: OrchestratorState) -> Router {
         .merge(routes::acme_challenge::router())
         .route("/version", get(version))
         .route("/health", get(health))
+        .route("/ready", get(ready))
         .fallback(not_found)
         .with_state(state)
         .layer(ServiceBuilder::new().layer(cors))
@@ -77,8 +80,67 @@ async fn version() -> impl IntoResponse {
     )
 }
 
+/// Liveness: is this process running?
+///
+/// Deliberately dependency-free. A liveness probe that failed on a database
+/// blip would get the process killed and restarted, which does not fix a
+/// database problem and, behind a load balancer, cycles every target at
+/// once. Point healthchecks at `/ready` instead.
 async fn health() -> impl IntoResponse {
     StatusCode::OK
+}
+
+/// How long a readiness result is reused.
+const READY_CACHE_TTL: Duration = Duration::from_secs(1);
+
+/// Upper bound on the readiness probe itself. A probe that hangs is a
+/// failure — the point is to answer quickly, not to answer eventually.
+const READY_PROBE_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// Readiness: can this process actually serve requests?
+async fn ready(State(state): State<OrchestratorState>) -> impl IntoResponse {
+    ready_response(probe_ready(&state).await)
+}
+
+/// Map a probe result to its wire response.
+///
+/// Split out from `ready` so the 503 path is testable without standing up a
+/// broken database: `PgPool::connect` probes at construction and refuses to
+/// build against a dead host, so there is no way to hold a live
+/// `OrchestratorState` whose pool is down.
+///
+/// The body carries status only. This endpoint is unauthenticated, so it
+/// must not leak connection strings or driver errors — that detail lives
+/// behind `GET /api/admin/health`.
+pub fn ready_response(ok: bool) -> (StatusCode, Json<serde_json::Value>) {
+    if ok {
+        (
+            StatusCode::OK,
+            Json(serde_json::json!({ "status": "ready" })),
+        )
+    } else {
+        (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(serde_json::json!({ "status": "not_ready" })),
+        )
+    }
+}
+
+async fn probe_ready(state: &OrchestratorState) -> bool {
+    if let Some(cached) = state.readiness.get(READY_CACHE_TTL) {
+        return cached;
+    }
+    let probe = async {
+        let conn = state.storage.pool().acquire().await.ok()?;
+        conn.client().simple_query("SELECT 1").await.ok()?;
+        Some(())
+    };
+    let ok = matches!(
+        tokio::time::timeout(READY_PROBE_TIMEOUT, probe).await,
+        Ok(Some(()))
+    );
+    state.readiness.set(ok);
+    ok
 }
 
 async fn not_found() -> impl IntoResponse {
@@ -100,9 +162,9 @@ async fn not_found() -> impl IntoResponse {
 ///   external clients (CLI codegen, third-party integrations).
 /// - **`/api/...`** (deployment-internal) — load-bearing endpoints used by
 ///   `crates/big_brain_client` and the CLI's `bigBrainAPI` calls.
-/// - **`/api/dashboard/...`** — private dashboard API. The `_stubs` tag
-///   marks endpoints that intentionally return canned data because the
-///   underlying feature is Cloud-only (Orb billing, WorkOS, Vercel, etc.).
+/// - **`/api/dashboard/...`** — private dashboard API. The `_stubs` tag marks
+///   endpoints that intentionally return canned data because the underlying
+///   feature is Cloud-only (Orb billing, WorkOS, Vercel, etc.).
 /// - **`/api/internal/...`** — service-key-gated endpoints used only by
 ///   `dashboard-orchestrator`'s server side.
 ///
@@ -293,14 +355,14 @@ mod openapi_tests {
     /// reformatting the fixture) don't trip the test. To regenerate after
     /// intentional changes:
     /// `cargo run -p orchestrator --bin convex-orchestrator -- --print-openapi
-    ///   > crates/orchestrator/openapi.json && dprint fmt crates/orchestrator/openapi.json`
+    ///   > crates/orchestrator/openapi.json && dprint fmt
+    ///   > crates/orchestrator/openapi.json`
     #[test]
     fn openapi_fixture_matches() {
         let generated = super::openapi_spec().expect("openapi_spec()");
 
-        let fixture: serde_json::Value =
-            serde_json::from_str(include_str!("../openapi.json"))
-                .expect("openapi.json parses as JSON");
+        let fixture: serde_json::Value = serde_json::from_str(include_str!("../openapi.json"))
+            .expect("openapi.json parses as JSON");
 
         assert_eq!(
             generated, fixture,

--- a/crates/orchestrator/src/router.rs
+++ b/crates/orchestrator/src/router.rs
@@ -50,11 +50,14 @@ pub fn build_router(state: OrchestratorState) -> Router {
         .max_age(Duration::from_secs(3600));
 
     let api_router = routes::deployment_internal::router();
+    let admin_router = routes::admin::router();
     let dashboard_router = routes::dashboard::router();
     let internal_router = routes::internal::router();
     let management_router = routes::management::router();
 
     Router::new()
+        // Mounted before `/api` so the more specific prefix wins.
+        .nest("/api/admin", admin_router)
         .nest("/api/dashboard", dashboard_router)
         .nest("/api/internal", internal_router)
         .nest("/api", api_router)
@@ -309,6 +312,12 @@ async fn not_found() -> impl IntoResponse {
         // Service-key-gated internal endpoints (/api/internal/...)
         crate::routes::internal::exchange_session,
         crate::routes::internal::health,
+        // Instance-scoped operator API (/api/admin/...), SuperAdmin-gated
+        crate::routes::admin::health::admin_health,
+        crate::routes::admin::overview::overview,
+        crate::routes::admin::fleet::fleet,
+        crate::routes::admin::members::list_members,
+        crate::routes::admin::audit::instance_audit,
     ),
     tags(
         (name = "tokens", description = "/v1: personal access tokens"),
@@ -318,6 +327,7 @@ async fn not_found() -> impl IntoResponse {
         (name = "env_vars", description = "/v1: project-level default environment variables"),
         (name = "deployment_internal", description = "/api: load-bearing CLI / big_brain_client endpoints"),
         (name = "dashboard", description = "/api/dashboard: private dashboard API"),
+        (name = "admin", description = "/api/admin: instance-scoped operator API (super-admin only)"),
         (name = "dashboard_stubs", description = "/api/dashboard: stubbed Cloud-only endpoints (Orb, WorkOS, Vercel, Discord, cloud backups, usage analytics)"),
         (name = "internal", description = "/api/internal: service-key-gated endpoints used only by dashboard-orchestrator"),
     ),

--- a/crates/orchestrator/src/router.rs
+++ b/crates/orchestrator/src/router.rs
@@ -318,6 +318,11 @@ async fn not_found() -> impl IntoResponse {
         crate::routes::admin::fleet::fleet,
         crate::routes::admin::members::list_members,
         crate::routes::admin::audit::instance_audit,
+        crate::routes::admin::deployment_actions::pause,
+        crate::routes::admin::deployment_actions::resume,
+        crate::routes::admin::deployment_actions::restart,
+        crate::routes::admin::deployment_actions::set_tier,
+        crate::routes::admin::deployment_actions::delete,
     ),
     tags(
         (name = "tokens", description = "/v1: personal access tokens"),

--- a/crates/orchestrator/src/router.rs
+++ b/crates/orchestrator/src/router.rs
@@ -327,6 +327,7 @@ async fn not_found() -> impl IntoResponse {
         crate::routes::admin::member_actions::unsuspend,
         crate::routes::admin::member_actions::set_super_admin,
         crate::routes::admin::member_actions::delete,
+        crate::routes::admin::break_glass::grant_access,
     ),
     tags(
         (name = "tokens", description = "/v1: personal access tokens"),

--- a/crates/orchestrator/src/router.rs
+++ b/crates/orchestrator/src/router.rs
@@ -328,6 +328,10 @@ async fn not_found() -> impl IntoResponse {
         crate::routes::admin::member_actions::set_super_admin,
         crate::routes::admin::member_actions::delete,
         crate::routes::admin::break_glass::grant_access,
+        crate::routes::admin::team_actions::list_teams,
+        crate::routes::admin::team_actions::create_team,
+        crate::routes::admin::team_actions::rename_team,
+        crate::routes::admin::team_actions::delete_team,
     ),
     tags(
         (name = "tokens", description = "/v1: personal access tokens"),

--- a/crates/orchestrator/src/router.rs
+++ b/crates/orchestrator/src/router.rs
@@ -323,6 +323,10 @@ async fn not_found() -> impl IntoResponse {
         crate::routes::admin::deployment_actions::restart,
         crate::routes::admin::deployment_actions::set_tier,
         crate::routes::admin::deployment_actions::delete,
+        crate::routes::admin::member_actions::suspend,
+        crate::routes::admin::member_actions::unsuspend,
+        crate::routes::admin::member_actions::set_super_admin,
+        crate::routes::admin::member_actions::delete,
     ),
     tags(
         (name = "tokens", description = "/v1: personal access tokens"),

--- a/crates/orchestrator/src/routes/admin/audit.rs
+++ b/crates/orchestrator/src/routes/admin/audit.rs
@@ -46,6 +46,9 @@ pub struct InstanceAuditEvent {
     /// `None` for actions taken through the break-glass bootstrap
     /// credential, which has no human behind it.
     pub member_id: Option<i64>,
+    /// Resolved server-side. `None` when there is no member, or the member
+    /// has since been deleted.
+    pub member_email: Option<String>,
     pub action: String,
     pub metadata: serde_json::Value,
     pub creation_time: i64,
@@ -75,7 +78,7 @@ pub(crate) async fn instance_audit(
     let limit = q.limit.unwrap_or(DEFAULT_LIMIT).clamp(1, MAX_LIMIT);
     let records = state
         .storage
-        .list_instance_audit(limit)
+        .list_instance_audit_with_actors(limit)
         .await
         .map_err(ApiError::Internal)?;
     let events = records
@@ -83,6 +86,7 @@ pub(crate) async fn instance_audit(
         .map(|r| InstanceAuditEvent {
             id: r.id,
             member_id: r.member_id,
+            member_email: r.member_email,
             action: r.action,
             metadata: r.metadata,
             creation_time: r.creation_time,

--- a/crates/orchestrator/src/routes/admin/audit.rs
+++ b/crates/orchestrator/src/routes/admin/audit.rs
@@ -1,0 +1,92 @@
+//! GET /api/admin/audit
+//!
+//! The instance-scoped audit log — operator actions that belong to no single
+//! team. Team-scoped events stay on the per-team dashboard route.
+
+use axum::{
+    extract::{
+        Query,
+        State,
+    },
+    Json,
+};
+use serde::{
+    Deserialize,
+    Serialize,
+};
+
+use crate::{
+    auth::super_admin::SuperAdmin,
+    errors::{
+        ApiError,
+        ApiResult,
+    },
+    state::OrchestratorState,
+};
+
+/// Default page size, and a ceiling so a console that forgets to paginate
+/// cannot pull the whole table.
+const DEFAULT_LIMIT: i64 = 100;
+const MAX_LIMIT: i64 = 500;
+
+#[derive(Deserialize, utoipa::IntoParams)]
+#[serde(rename_all = "camelCase")]
+pub struct AuditFilters {
+    pub limit: Option<i64>,
+}
+
+/// One instance-scoped event on the wire.
+///
+/// Named distinctly from `storage::AuditEntry`, which is the team-scoped
+/// row type and carries a `team_id` this surface has no use for.
+#[derive(Serialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct InstanceAuditEvent {
+    pub id: i64,
+    /// `None` for actions taken through the break-glass bootstrap
+    /// credential, which has no human behind it.
+    pub member_id: Option<i64>,
+    pub action: String,
+    pub metadata: serde_json::Value,
+    pub creation_time: i64,
+}
+
+#[derive(Serialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct AdminAuditResponse {
+    pub events: Vec<InstanceAuditEvent>,
+}
+
+#[utoipa::path(
+    get,
+    path = "/api/admin/audit",
+    params(AuditFilters),
+    responses(
+        (status = 200, body = AdminAuditResponse),
+        (status = 403, description = "not a super-admin"),
+    ),
+    tag = "admin",
+)]
+pub(crate) async fn instance_audit(
+    _admin: SuperAdmin,
+    State(state): State<OrchestratorState>,
+    Query(q): Query<AuditFilters>,
+) -> ApiResult<Json<AdminAuditResponse>> {
+    let limit = q.limit.unwrap_or(DEFAULT_LIMIT).clamp(1, MAX_LIMIT);
+    let records = state
+        .storage
+        .list_instance_audit(limit)
+        .await
+        .map_err(ApiError::Internal)?;
+    let events = records
+        .into_iter()
+        .map(|r| InstanceAuditEvent {
+            id: r.id,
+            member_id: r.member_id,
+            action: r.action,
+            metadata: r.metadata,
+            creation_time: r.creation_time,
+        })
+        .collect();
+    Ok(Json(AdminAuditResponse { events }))
+}

--- a/crates/orchestrator/src/routes/admin/break_glass.rs
+++ b/crates/orchestrator/src/routes/admin/break_glass.rs
@@ -1,0 +1,205 @@
+//! Break-glass access to a tenant's deployment.
+//!
+//! Everything else in the admin console is metadata. This route hands over
+//! the ability to read and write a tenant's data, so it is deliberately
+//! ceremonious:
+//!
+//! - a reason is required, and recorded verbatim;
+//! - the key is minted fresh and short-lived, never the deployment's permanent
+//!   one;
+//! - the event is written to the **tenant's own audit log** as well as the
+//!   instance's.
+//!
+//! That last point is the one most likely to be dropped as redundant. It is
+//! not: an audit trail only the operator can read is not accountability. A
+//! tenant should be able to see that somebody opened their deployment, and
+//! why.
+
+use axum::{
+    extract::{
+        Path,
+        State,
+    },
+    Json,
+};
+use serde::{
+    Deserialize,
+    Serialize,
+};
+
+use crate::{
+    auth::{
+        super_admin::SuperAdmin,
+        tokens::{
+            encode_pat,
+            mint_token_secret,
+            sha256_hex,
+            suffix_of,
+        },
+    },
+    errors::{
+        ApiError,
+        ApiResult,
+    },
+    ids::random_id,
+    routes::admin::audit_admin,
+    state::OrchestratorState,
+    storage::{
+        access_tokens::NewAccessToken,
+        AccessTokenKind,
+        DeploymentType,
+    },
+};
+
+/// How long a break-glass key lives.
+///
+/// Short enough that a forgotten key is not a standing grant, long enough
+/// to actually diagnose something. Deliberately shorter than the one-hour
+/// TTL `ephemeral_admin_key` uses for the ordinary team-scoped path.
+const BREAK_GLASS_TTL_MS: i64 = 15 * 60_000;
+
+#[derive(Deserialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct AccessArgs {
+    /// Why this access is being taken. Recorded verbatim in both audit logs.
+    pub reason: String,
+}
+
+#[derive(Serialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct AccessResponse {
+    pub deployment: String,
+    pub url: String,
+    /// A freshly minted, short-lived admin key. Shown once.
+    pub admin_key: String,
+    /// Unix ms. The UI counts down to this so an operator with a dashboard
+    /// open is not surprised by everything failing at once.
+    pub expires_at: i64,
+    /// Restates, in the response, that this was recorded where the tenant
+    /// can see it — so it is visible even to an API caller who never saw
+    /// the modal.
+    pub tenant_notified: bool,
+}
+
+#[utoipa::path(
+    post,
+    path = "/api/admin/deployments/{deployment_id}/access",
+    params(("deployment_id" = i64, Path)),
+    request_body = AccessArgs,
+    responses(
+        (status = 200, body = AccessResponse),
+        (status = 400, description = "a reason is required"),
+        (status = 403, description = "not a super-admin"),
+    ),
+    tag = "admin",
+)]
+pub(crate) async fn grant_access(
+    admin: SuperAdmin,
+    State(state): State<OrchestratorState>,
+    Path(deployment_id): Path<i64>,
+    Json(args): Json<AccessArgs>,
+) -> ApiResult<Json<AccessResponse>> {
+    let reason = args.reason.trim();
+    if reason.is_empty() {
+        return Err(ApiError::BadRequest(
+            "a reason is required: it is recorded in the tenant's own audit log".into(),
+        ));
+    }
+
+    let deployment = state
+        .storage
+        .get_deployment(deployment_id)
+        .await
+        .map_err(ApiError::Internal)?
+        .ok_or_else(|| ApiError::NotFound(format!("deployment {deployment_id}")))?;
+    let project = state
+        .storage
+        .get_project(deployment.project_id)
+        .await
+        .map_err(ApiError::Internal)?
+        .ok_or_else(|| ApiError::NotFound("project".into()))?;
+
+    let expires_at = crate::time::now_unix_ms() + BREAK_GLASS_TTL_MS;
+
+    // Always mint. `ephemeral_admin_key` returns the deployment's stored
+    // permanent key when it has one, which would make the TTL above a
+    // fiction on every deployment that has ever been provisioned.
+    let secret = mint_token_secret(&deployment.name);
+    let admin_key = encode_pat(&secret);
+    let kind = match deployment.deployment_type {
+        DeploymentType::Prod => AccessTokenKind::DeployProd,
+        DeploymentType::Dev => AccessTokenKind::DeployDev,
+        DeploymentType::Preview => AccessTokenKind::DeployPreview,
+    };
+    state
+        .storage
+        .create_access_token(NewAccessToken {
+            public_id: &random_id(),
+            kind,
+            // No member: this credential is the access itself, not the
+            // operator's identity. The audit rows carry who took it.
+            member_id: None,
+            team_id: None,
+            project_id: Some(deployment.project_id),
+            deployment_id: Some(deployment.id),
+            name: "break-glass",
+            secret_hash: &sha256_hex(&secret.secret),
+            secret_suffix: &suffix_of(&secret.secret),
+            expiry: Some(expires_at),
+        })
+        .await
+        .map_err(ApiError::Internal)?;
+
+    let metadata = serde_json::json!({
+        "deployment": deployment.name,
+        "deploymentId": deployment.id,
+        "reason": reason,
+        "expiresAt": expires_at,
+        "ttlMinutes": BREAK_GLASS_TTL_MS / 60_000,
+    });
+
+    audit_admin(
+        &state,
+        &admin.actor,
+        "deploymentAccessGranted",
+        metadata.clone(),
+    )
+    .await;
+
+    // The tenant-visible copy. Written second and separately on purpose:
+    // if this fails the access still happened, and a silent failure here is
+    // exactly the accountability gap this route exists to avoid, so it is
+    // logged at error rather than swallowed.
+    if let Err(e) = state
+        .storage
+        .append_audit(
+            project.team_id,
+            admin.actor.member_id(),
+            "deploymentAccessGranted",
+            &metadata,
+        )
+        .await
+    {
+        tracing::error!(
+            deployment = %deployment.name,
+            team_id = project.team_id,
+            error = %e,
+            "break-glass: failed to write the tenant-visible audit event"
+        );
+    }
+
+    tracing::warn!(
+        deployment = %deployment.name,
+        actor = admin.actor.label(),
+        reason,
+        "break-glass access granted"
+    );
+
+    Ok(Json(AccessResponse {
+        deployment: deployment.name,
+        url: deployment.url,
+        admin_key,
+        expires_at,
+        tenant_notified: true,
+    }))
+}

--- a/crates/orchestrator/src/routes/admin/deployment_actions.rs
+++ b/crates/orchestrator/src/routes/admin/deployment_actions.rs
@@ -1,0 +1,380 @@
+//! Deployment lifecycle actions for the instance admin console.
+//!
+//! Two rules apply to every handler here.
+//!
+//! **The database row is the source of truth; container work is
+//! best-effort.** If `docker stop` fails after the row is marked paused, the
+//! action *did* take effect and the reconciler will converge — so the
+//! response is a success carrying `containerWarning`, not a failure. A pause
+//! that reports failure but did pause is worse than one that reports a
+//! warning, because the operator retries and gets more confused.
+//!
+//! **Delete is the exception.** It must not report success while an orphan
+//! container survives and the row is gone, because nothing will ever show
+//! that container again.
+
+use axum::{
+    extract::{
+        Path,
+        State,
+    },
+    Json,
+};
+use serde::{
+    Deserialize,
+    Serialize,
+};
+
+use crate::{
+    auth::super_admin::SuperAdmin,
+    config::ProvisionerMode,
+    errors::{
+        ApiError,
+        ApiResult,
+    },
+    provisioner::lifecycle,
+    routes::admin::audit_admin,
+    state::OrchestratorState,
+    storage::DeploymentRecord,
+};
+
+#[derive(Serialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ActionResponse {
+    pub deployment: String,
+    /// The row's state after the action.
+    pub state: String,
+    /// Set when the database changed but the container work did not fully
+    /// succeed. The action still took effect; the reconciler will converge.
+    pub container_warning: Option<String>,
+}
+
+#[derive(Deserialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct RestartArgs {
+    /// Bypass the host capacity check, as the management route does.
+    #[serde(default)]
+    pub force: Option<bool>,
+}
+
+#[derive(Deserialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct TierArgs {
+    pub tier: String,
+}
+
+async fn load(state: &OrchestratorState, id: i64) -> ApiResult<DeploymentRecord> {
+    state
+        .storage
+        .get_deployment(id)
+        .await
+        .map_err(ApiError::Internal)?
+        .ok_or_else(|| ApiError::NotFound(format!("deployment {id}")))
+}
+
+/// True when this provisioner actually owns containers. In `external` and
+/// `process` modes there is nothing to stop or start, and pretending
+/// otherwise would produce warnings about a daemon that was never involved.
+fn owns_containers(state: &OrchestratorState) -> bool {
+    matches!(state.config.provisioner_mode, ProvisionerMode::Docker)
+}
+
+#[utoipa::path(
+    post,
+    path = "/api/admin/deployments/{deployment_id}/pause",
+    params(("deployment_id" = i64, Path)),
+    responses(
+        (status = 200, body = ActionResponse),
+        (status = 403, description = "not a super-admin"),
+        (status = 409, description = "deployment is still provisioning"),
+    ),
+    tag = "admin",
+)]
+pub(crate) async fn pause(
+    admin: SuperAdmin,
+    State(state): State<OrchestratorState>,
+    Path(deployment_id): Path<i64>,
+) -> ApiResult<Json<ActionResponse>> {
+    let d = load(&state, deployment_id).await?;
+    state
+        .storage
+        .pause_deployment(d.id)
+        .await
+        .map_err(transition_error)?;
+
+    let container_warning = if owns_containers(&state) {
+        stop_all(&state, &d).await
+    } else {
+        None
+    };
+
+    audit_admin(
+        &state,
+        &admin.actor,
+        "deploymentPaused",
+        serde_json::json!({
+            "deployment": d.name,
+            "deploymentId": d.id,
+            "containerWarning": container_warning,
+        }),
+    )
+    .await;
+
+    Ok(Json(ActionResponse {
+        deployment: d.name,
+        state: "paused".into(),
+        container_warning,
+    }))
+}
+
+#[utoipa::path(
+    post,
+    path = "/api/admin/deployments/{deployment_id}/resume",
+    params(("deployment_id" = i64, Path)),
+    responses(
+        (status = 200, body = ActionResponse),
+        (status = 403, description = "not a super-admin"),
+        (status = 409, description = "deployment is still provisioning"),
+    ),
+    tag = "admin",
+)]
+pub(crate) async fn resume(
+    admin: SuperAdmin,
+    State(state): State<OrchestratorState>,
+    Path(deployment_id): Path<i64>,
+) -> ApiResult<Json<ActionResponse>> {
+    let d = load(&state, deployment_id).await?;
+    state
+        .storage
+        .resume_deployment(d.id)
+        .await
+        .map_err(transition_error)?;
+
+    let container_warning = if owns_containers(&state) {
+        start_all(&state, &d).await
+    } else {
+        None
+    };
+
+    audit_admin(
+        &state,
+        &admin.actor,
+        "deploymentResumed",
+        serde_json::json!({
+            "deployment": d.name,
+            "deploymentId": d.id,
+            "containerWarning": container_warning,
+        }),
+    )
+    .await;
+
+    Ok(Json(ActionResponse {
+        deployment: d.name,
+        state: "running".into(),
+        container_warning,
+    }))
+}
+
+#[utoipa::path(
+    post,
+    path = "/api/admin/deployments/{deployment_id}/restart",
+    params(("deployment_id" = i64, Path)),
+    request_body = RestartArgs,
+    responses(
+        (status = 200, body = ActionResponse),
+        (status = 403, description = "not a super-admin"),
+    ),
+    tag = "admin",
+)]
+pub(crate) async fn restart(
+    admin: SuperAdmin,
+    State(state): State<OrchestratorState>,
+    Path(deployment_id): Path<i64>,
+    // Optional: every field is optional, so a bare POST means "restart with
+    // defaults". Requiring a body would make callers send `{}` and get a 415
+    // if they forgot the content-type header.
+    args: Option<Json<RestartArgs>>,
+) -> ApiResult<Json<ActionResponse>> {
+    let args = args.map(|Json(a)| a).unwrap_or(RestartArgs { force: None });
+    let d = load(&state, deployment_id).await?;
+    // Delegates to the same routine the management API uses, so capacity
+    // checks, tier resolution, and sidecar credential reuse cannot drift
+    // between the two entry points.
+    let updated = crate::routes::management::deployments::respawn_deployment(
+        &state,
+        &d,
+        args.force.unwrap_or(false),
+    )
+    .await?;
+
+    audit_admin(
+        &state,
+        &admin.actor,
+        "deploymentRestarted",
+        serde_json::json!({
+            "deployment": updated.name,
+            "deploymentId": updated.id,
+            "force": args.force.unwrap_or(false),
+        }),
+    )
+    .await;
+
+    Ok(Json(ActionResponse {
+        deployment: updated.name,
+        state: updated.state.to_string(),
+        container_warning: None,
+    }))
+}
+
+#[utoipa::path(
+    post,
+    path = "/api/admin/deployments/{deployment_id}/tier",
+    params(("deployment_id" = i64, Path)),
+    request_body = TierArgs,
+    responses(
+        (status = 200, body = ActionResponse),
+        (status = 400, description = "unknown tier"),
+        (status = 403, description = "not a super-admin"),
+    ),
+    tag = "admin",
+)]
+pub(crate) async fn set_tier(
+    admin: SuperAdmin,
+    State(state): State<OrchestratorState>,
+    Path(deployment_id): Path<i64>,
+    Json(args): Json<TierArgs>,
+) -> ApiResult<Json<ActionResponse>> {
+    let d = load(&state, deployment_id).await?;
+    if crate::provisioner::tiers::resolve(&args.tier).is_none() {
+        return Err(ApiError::BadRequest(format!("unknown tier {}", args.tier)));
+    }
+
+    let previous = d.desired_tier.clone().unwrap_or_else(|| d.tier.clone());
+    state
+        .storage
+        .update_deployment_settings(d.id, Some(Some(args.tier.as_str())), None)
+        .await
+        .map_err(ApiError::Internal)?;
+
+    audit_admin(
+        &state,
+        &admin.actor,
+        "deploymentTierChanged",
+        serde_json::json!({
+            "deployment": d.name,
+            "deploymentId": d.id,
+            "from": previous,
+            "to": args.tier,
+        }),
+    )
+    .await;
+
+    Ok(Json(ActionResponse {
+        deployment: d.name,
+        state: d.state.to_string(),
+        // The tier is `desired` until the container is recreated, which is a
+        // separate deliberate action. Say so rather than implying it is live.
+        container_warning: Some(
+            "tier recorded as desired; restart the deployment to apply it".into(),
+        ),
+    }))
+}
+
+#[utoipa::path(
+    post,
+    path = "/api/admin/deployments/{deployment_id}/delete",
+    params(("deployment_id" = i64, Path)),
+    responses(
+        (status = 200, body = ActionResponse),
+        (status = 403, description = "not a super-admin"),
+        (status = 502, description = "teardown failed; the deployment was not removed"),
+    ),
+    tag = "admin",
+)]
+pub(crate) async fn delete(
+    admin: SuperAdmin,
+    State(state): State<OrchestratorState>,
+    Path(deployment_id): Path<i64>,
+) -> ApiResult<Json<ActionResponse>> {
+    let d = load(&state, deployment_id).await?;
+
+    // Unlike pause/resume, this one fails loudly. Removing the row while a
+    // container survives orphans it: nothing in the console lists it again,
+    // and it keeps holding its port and its volume.
+    if owns_containers(&state)
+        && let Err(e) = state.provisioner.teardown(&d.name, &d.storage_mode).await
+    {
+        tracing::error!(deployment = %d.name, error = %e, "admin: teardown failed; keeping the row");
+        return Err(ApiError::BadGateway(format!(
+            "teardown of {} failed, so the deployment was not removed: {e}",
+            d.name
+        )));
+    }
+
+    state
+        .storage
+        .delete_deployment(d.id)
+        .await
+        .map_err(ApiError::Internal)?;
+
+    audit_admin(
+        &state,
+        &admin.actor,
+        "deploymentDeleted",
+        serde_json::json!({ "deployment": d.name, "deploymentId": d.id }),
+    )
+    .await;
+
+    Ok(Json(ActionResponse {
+        deployment: d.name,
+        state: "deleted".into(),
+        container_warning: None,
+    }))
+}
+
+/// A refused transition is the caller's problem (the deployment is mid-
+/// provision), not an internal fault, so it must not surface as a 500.
+fn transition_error(e: anyhow::Error) -> ApiError {
+    let msg = e.to_string();
+    if msg.contains("provisioning") {
+        ApiError::Conflict(msg)
+    } else {
+        ApiError::Internal(e)
+    }
+}
+
+async fn stop_all(state: &OrchestratorState, d: &DeploymentRecord) -> Option<String> {
+    let mut failures = Vec::new();
+    for name in lifecycle::containers_for_pause(
+        &state.config.backend_container_prefix,
+        &d.name,
+        &d.storage_mode,
+    ) {
+        if let Err(e) = lifecycle::stop_container(&name).await {
+            failures.push(format!("{name}: {e}"));
+        }
+    }
+    warning(failures)
+}
+
+async fn start_all(state: &OrchestratorState, d: &DeploymentRecord) -> Option<String> {
+    let mut failures = Vec::new();
+    for name in lifecycle::containers_for_resume(
+        &state.config.backend_container_prefix,
+        &d.name,
+        &d.storage_mode,
+    ) {
+        if let Err(e) = crate::reconcile::start_container(&name).await {
+            failures.push(format!("{name}: {e}"));
+        }
+    }
+    warning(failures)
+}
+
+fn warning(failures: Vec<String>) -> Option<String> {
+    if failures.is_empty() {
+        None
+    } else {
+        Some(failures.join("; "))
+    }
+}

--- a/crates/orchestrator/src/routes/admin/fleet.rs
+++ b/crates/orchestrator/src/routes/admin/fleet.rs
@@ -1,0 +1,154 @@
+//! GET /api/admin/fleet
+//!
+//! Every deployment on the instance with intended state (from the database)
+//! next to actual state (from docker).
+//!
+//! Reuses `reconcile`'s primitives rather than shelling out to docker a
+//! second way, so the console and the reconciler can never disagree about
+//! what "drifted" means.
+
+use axum::{
+    extract::State,
+    Json,
+};
+use futures::stream::{
+    self,
+    StreamExt,
+};
+use serde::Serialize;
+
+use crate::{
+    auth::super_admin::SuperAdmin,
+    config::ProvisionerMode,
+    errors::{
+        ApiError,
+        ApiResult,
+    },
+    state::OrchestratorState,
+    storage::AdminDeploymentRow,
+};
+
+/// Matches `reconcile`'s concurrency: enough to keep the sweep fast, few
+/// enough not to storm the docker socket.
+const PROBE_CONCURRENCY: usize = 8;
+
+/// Reported when the provisioner does not own containers, or when the probe
+/// itself failed. Distinct from `stopped` on purpose.
+const STATE_UNKNOWN: &str = "unknown";
+
+#[derive(Serialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct FleetEntry {
+    #[serde(flatten)]
+    pub deployment: AdminDeploymentRow,
+    /// `running` / `stopped` / `missing`, or `unknown` when there was
+    /// nothing to inspect or the inspection failed.
+    pub actual_state: String,
+    /// True when the container is not doing what the database says it
+    /// should. Always false when `actual_state` is `unknown` — we do not
+    /// report drift we could not observe.
+    pub drifted: bool,
+}
+
+#[derive(Serialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct FleetResponse {
+    pub deployments: Vec<FleetEntry>,
+    pub drift_count: u32,
+    /// False when the provisioner does not manage containers, so the UI can
+    /// say "not applicable" rather than rendering a column of `unknown`.
+    pub container_states_available: bool,
+}
+
+/// Is the container doing something other than what the database intends?
+///
+/// Pure so it can be tested without a docker daemon. `unknown` is never
+/// drift: a probe we could not run is not evidence that anything is wrong,
+/// and reporting it as drift would light up the console every time the
+/// socket hiccuped.
+pub fn is_drifted(intended_state: &str, actual_state: &str) -> bool {
+    match actual_state {
+        STATE_UNKNOWN => false,
+        "running" => intended_state != "running",
+        // `stopped` or `missing`: drift only if it was supposed to be up. A
+        // paused deployment with no container is exactly correct.
+        _ => intended_state == "running",
+    }
+}
+
+#[utoipa::path(
+    get,
+    path = "/api/admin/fleet",
+    responses(
+        (status = 200, body = FleetResponse),
+        (status = 403, description = "not a super-admin"),
+    ),
+    tag = "admin",
+)]
+pub(crate) async fn fleet(
+    _admin: SuperAdmin,
+    State(state): State<OrchestratorState>,
+) -> ApiResult<Json<FleetResponse>> {
+    let rows = state
+        .storage
+        .list_all_deployments_with_owners()
+        .await
+        .map_err(ApiError::Internal)?;
+
+    let container_states_available =
+        matches!(state.config.provisioner_mode, ProvisionerMode::Docker);
+
+    if !container_states_available {
+        let deployments = rows
+            .into_iter()
+            .map(|deployment| FleetEntry {
+                deployment,
+                actual_state: STATE_UNKNOWN.to_string(),
+                drifted: false,
+            })
+            .collect();
+        return Ok(Json(FleetResponse {
+            deployments,
+            drift_count: 0,
+            container_states_available,
+        }));
+    }
+
+    let prefix = state.config.backend_container_prefix.clone();
+    let deployments: Vec<FleetEntry> = stream::iter(rows.into_iter().map(|row| {
+        let prefix = prefix.clone();
+        async move {
+            let container = format!("{prefix}{}", row.name);
+            let actual_state = match crate::reconcile::container_status(&container).await {
+                Ok(s) => format!("{s:?}").to_lowercase(),
+                // A probe that errored is not evidence of drift — say so
+                // rather than reporting a deployment as broken because the
+                // socket hiccuped.
+                Err(e) => {
+                    tracing::warn!(
+                        deployment = %row.name,
+                        error = %e,
+                        "admin fleet: container status probe failed"
+                    );
+                    STATE_UNKNOWN.to_string()
+                },
+            };
+            let drifted = is_drifted(&row.intended_state, &actual_state);
+            FleetEntry {
+                deployment: row,
+                actual_state,
+                drifted,
+            }
+        }
+    }))
+    .buffer_unordered(PROBE_CONCURRENCY)
+    .collect()
+    .await;
+
+    let drift_count = deployments.iter().filter(|d| d.drifted).count() as u32;
+    Ok(Json(FleetResponse {
+        deployments,
+        drift_count,
+        container_states_available,
+    }))
+}

--- a/crates/orchestrator/src/routes/admin/health.rs
+++ b/crates/orchestrator/src/routes/admin/health.rs
@@ -1,0 +1,143 @@
+//! GET /api/admin/health
+//!
+//! The detailed counterpart to `/ready`. `/ready` is unauthenticated and so
+//! reports status only; this route is behind `SuperAdmin` and can therefore
+//! name what is actually broken.
+
+use std::time::{
+    Duration,
+    Instant,
+};
+
+use axum::{
+    extract::State,
+    Json,
+};
+use serde::Serialize;
+
+use crate::{
+    auth::super_admin::SuperAdmin,
+    config::ProvisionerMode,
+    errors::ApiResult,
+    state::OrchestratorState,
+};
+
+#[derive(Serialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct DatabaseHealth {
+    pub reachable: bool,
+    pub ping_ms: Option<u64>,
+    pub error: Option<String>,
+}
+
+#[derive(Serialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ProvisionerHealth {
+    pub mode: String,
+    /// `None` when the mode does not own containers, so there is no socket
+    /// to check. Reporting `false` there would read as a fault when nothing
+    /// is wrong.
+    pub docker_reachable: Option<bool>,
+    pub error: Option<String>,
+}
+
+#[derive(Serialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct AdminHealthResponse {
+    pub version: String,
+    pub database: DatabaseHealth,
+    pub provisioner: ProvisionerHealth,
+    pub reconcile_interval_secs: u64,
+}
+
+const PROBE_TIMEOUT: Duration = Duration::from_secs(3);
+
+#[utoipa::path(
+    get,
+    path = "/api/admin/health",
+    responses(
+        (status = 200, body = AdminHealthResponse),
+        (status = 403, description = "not a super-admin"),
+    ),
+    tag = "admin",
+)]
+pub(crate) async fn admin_health(
+    _admin: SuperAdmin,
+    State(state): State<OrchestratorState>,
+) -> ApiResult<Json<AdminHealthResponse>> {
+    let database = probe_database(&state).await;
+    let provisioner = probe_provisioner(&state).await;
+    Ok(Json(AdminHealthResponse {
+        version: env!("CARGO_PKG_VERSION").to_string(),
+        database,
+        provisioner,
+        reconcile_interval_secs: state.config.reconcile_interval_secs,
+    }))
+}
+
+async fn probe_database(state: &OrchestratorState) -> DatabaseHealth {
+    let started = Instant::now();
+    let probe = async {
+        let conn = state.storage.pool().acquire().await?;
+        conn.client().simple_query("SELECT 1").await?;
+        Ok::<_, anyhow::Error>(())
+    };
+    match tokio::time::timeout(PROBE_TIMEOUT, probe).await {
+        Ok(Ok(())) => DatabaseHealth {
+            reachable: true,
+            ping_ms: Some(started.elapsed().as_millis() as u64),
+            error: None,
+        },
+        Ok(Err(e)) => DatabaseHealth {
+            reachable: false,
+            ping_ms: None,
+            error: Some(e.to_string()),
+        },
+        Err(_) => DatabaseHealth {
+            reachable: false,
+            ping_ms: None,
+            error: Some(format!("probe timed out after {PROBE_TIMEOUT:?}")),
+        },
+    }
+}
+
+/// A broken docker socket currently only surfaces as failed provisions, with
+/// nothing pointing at the cause. Check it directly so the console can say
+/// so.
+async fn probe_provisioner(state: &OrchestratorState) -> ProvisionerHealth {
+    let mode = format!("{:?}", state.config.provisioner_mode).to_lowercase();
+    if !matches!(state.config.provisioner_mode, ProvisionerMode::Docker) {
+        return ProvisionerHealth {
+            mode,
+            docker_reachable: None,
+            error: None,
+        };
+    }
+    let probe = tokio::process::Command::new("docker")
+        .arg("version")
+        .arg("--format")
+        .arg("{{.Server.Version}}")
+        .output();
+    match tokio::time::timeout(PROBE_TIMEOUT, probe).await {
+        Ok(Ok(out)) if out.status.success() => ProvisionerHealth {
+            mode,
+            docker_reachable: Some(true),
+            error: None,
+        },
+        Ok(Ok(out)) => ProvisionerHealth {
+            mode,
+            docker_reachable: Some(false),
+            error: Some(String::from_utf8_lossy(&out.stderr).trim().to_string()),
+        },
+        Ok(Err(e)) => ProvisionerHealth {
+            mode,
+            docker_reachable: Some(false),
+            error: Some(e.to_string()),
+        },
+        Err(_) => ProvisionerHealth {
+            mode,
+            docker_reachable: Some(false),
+            error: Some(format!("docker probe timed out after {PROBE_TIMEOUT:?}")),
+        },
+    }
+}

--- a/crates/orchestrator/src/routes/admin/member_actions.rs
+++ b/crates/orchestrator/src/routes/admin/member_actions.rs
@@ -1,0 +1,233 @@
+//! Member governance for the instance admin console.
+//!
+//! Suspension is reversible and preserves the member's teams, projects, and
+//! audit history; deletion is the permanent case. Both are audited, as is
+//! every change to who can operate the instance.
+
+use axum::{
+    extract::{
+        Path,
+        State,
+    },
+    Json,
+};
+use serde::{
+    Deserialize,
+    Serialize,
+};
+
+use crate::{
+    auth::super_admin::SuperAdmin,
+    errors::{
+        ApiError,
+        ApiResult,
+    },
+    routes::admin::audit_admin,
+    state::OrchestratorState,
+};
+
+#[derive(Serialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct MemberActionResponse {
+    pub member_id: i64,
+    pub email: String,
+    pub is_super_admin: bool,
+    pub suspended: bool,
+}
+
+#[derive(Deserialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct SuperAdminArgs {
+    pub grant: bool,
+}
+
+async fn reload(state: &OrchestratorState, id: i64) -> ApiResult<MemberActionResponse> {
+    let m = state
+        .storage
+        .get_member(id)
+        .await
+        .map_err(ApiError::Internal)?
+        .ok_or_else(|| ApiError::NotFound(format!("member {id}")))?;
+    Ok(MemberActionResponse {
+        member_id: m.id,
+        email: m.primary_email,
+        is_super_admin: m.is_super_admin,
+        suspended: m.suspended,
+    })
+}
+
+#[utoipa::path(
+    post,
+    path = "/api/admin/members/{member_id}/suspend",
+    params(("member_id" = i64, Path)),
+    responses(
+        (status = 200, body = MemberActionResponse),
+        (status = 403, description = "not a super-admin"),
+    ),
+    tag = "admin",
+)]
+pub(crate) async fn suspend(
+    admin: SuperAdmin,
+    State(state): State<OrchestratorState>,
+    Path(member_id): Path<i64>,
+) -> ApiResult<Json<MemberActionResponse>> {
+    set_suspended(admin, state, member_id, true).await
+}
+
+#[utoipa::path(
+    post,
+    path = "/api/admin/members/{member_id}/unsuspend",
+    params(("member_id" = i64, Path)),
+    responses(
+        (status = 200, body = MemberActionResponse),
+        (status = 403, description = "not a super-admin"),
+    ),
+    tag = "admin",
+)]
+pub(crate) async fn unsuspend(
+    admin: SuperAdmin,
+    State(state): State<OrchestratorState>,
+    Path(member_id): Path<i64>,
+) -> ApiResult<Json<MemberActionResponse>> {
+    set_suspended(admin, state, member_id, false).await
+}
+
+async fn set_suspended(
+    admin: SuperAdmin,
+    state: OrchestratorState,
+    member_id: i64,
+    value: bool,
+) -> ApiResult<Json<MemberActionResponse>> {
+    let before = reload(&state, member_id).await?;
+    state
+        .storage
+        .set_member_suspended(member_id, value)
+        .await
+        .map_err(ApiError::Internal)?;
+
+    audit_admin(
+        &state,
+        &admin.actor,
+        if value {
+            "memberSuspended"
+        } else {
+            "memberUnsuspended"
+        },
+        serde_json::json!({ "memberId": member_id, "email": before.email }),
+    )
+    .await;
+
+    Ok(Json(reload(&state, member_id).await?))
+}
+
+#[utoipa::path(
+    post,
+    path = "/api/admin/members/{member_id}/super_admin",
+    params(("member_id" = i64, Path)),
+    request_body = SuperAdminArgs,
+    responses(
+        (status = 200, body = MemberActionResponse),
+        (status = 403, description = "not a super-admin"),
+        (status = 409, description = "would revoke the last super-admin"),
+    ),
+    tag = "admin",
+)]
+pub(crate) async fn set_super_admin(
+    admin: SuperAdmin,
+    State(state): State<OrchestratorState>,
+    Path(member_id): Path<i64>,
+    Json(args): Json<SuperAdminArgs>,
+) -> ApiResult<Json<MemberActionResponse>> {
+    let before = reload(&state, member_id).await?;
+    state
+        .storage
+        .set_super_admin(member_id, args.grant)
+        .await
+        // The storage guard refuses to remove the last operator. That is the
+        // caller's problem, not an internal fault, and the message says what
+        // to do about it — so keep it and map to 409 rather than losing it
+        // inside a 500.
+        .map_err(|e| {
+            let msg = e.to_string();
+            if msg.contains("last super-admin") {
+                ApiError::Conflict(msg)
+            } else {
+                ApiError::Internal(e)
+            }
+        })?;
+
+    audit_admin(
+        &state,
+        &admin.actor,
+        if args.grant {
+            "superAdminGranted"
+        } else {
+            "superAdminRevoked"
+        },
+        serde_json::json!({ "memberId": member_id, "email": before.email }),
+    )
+    .await;
+
+    Ok(Json(reload(&state, member_id).await?))
+}
+
+#[utoipa::path(
+    post,
+    path = "/api/admin/members/{member_id}/delete",
+    params(("member_id" = i64, Path)),
+    responses(
+        (status = 200, body = MemberActionResponse),
+        (status = 403, description = "not a super-admin"),
+        (status = 409, description = "would remove the last super-admin"),
+    ),
+    tag = "admin",
+)]
+pub(crate) async fn delete(
+    admin: SuperAdmin,
+    State(state): State<OrchestratorState>,
+    Path(member_id): Path<i64>,
+) -> ApiResult<Json<MemberActionResponse>> {
+    let before = reload(&state, member_id).await?;
+
+    // Deleting an operator is a revoke with extra steps, so it has to clear
+    // the flag first and inherit the same last-operator guard. Without this
+    // the console would happily delete its way to an instance nobody can
+    // administer.
+    if before.is_super_admin {
+        state
+            .storage
+            .set_super_admin(member_id, false)
+            .await
+            .map_err(|e| {
+                let msg = e.to_string();
+                if msg.contains("last super-admin") {
+                    ApiError::Conflict(format!(
+                        "{msg} (deleting this member would leave the instance with no operator)"
+                    ))
+                } else {
+                    ApiError::Internal(e)
+                }
+            })?;
+    }
+
+    state
+        .storage
+        .delete_member(member_id)
+        .await
+        .map_err(ApiError::Internal)?;
+
+    audit_admin(
+        &state,
+        &admin.actor,
+        "memberDeleted",
+        serde_json::json!({ "memberId": member_id, "email": before.email }),
+    )
+    .await;
+
+    Ok(Json(MemberActionResponse {
+        member_id,
+        email: before.email,
+        is_super_admin: false,
+        suspended: before.suspended,
+    }))
+}

--- a/crates/orchestrator/src/routes/admin/members.rs
+++ b/crates/orchestrator/src/routes/admin/members.rs
@@ -1,0 +1,48 @@
+//! GET /api/admin/members
+//!
+//! Every member on the instance with their team memberships and flags.
+//! Read-only in Phase 1; the grant/revoke and suspend mutations land in
+//! Phase 2.
+
+use axum::{
+    extract::State,
+    Json,
+};
+use serde::Serialize;
+
+use crate::{
+    auth::super_admin::SuperAdmin,
+    errors::{
+        ApiError,
+        ApiResult,
+    },
+    state::OrchestratorState,
+    storage::AdminMemberRow,
+};
+
+#[derive(Serialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct AdminMembersResponse {
+    pub members: Vec<AdminMemberRow>,
+}
+
+#[utoipa::path(
+    get,
+    path = "/api/admin/members",
+    responses(
+        (status = 200, body = AdminMembersResponse),
+        (status = 403, description = "not a super-admin"),
+    ),
+    tag = "admin",
+)]
+pub(crate) async fn list_members(
+    _admin: SuperAdmin,
+    State(state): State<OrchestratorState>,
+) -> ApiResult<Json<AdminMembersResponse>> {
+    let members = state
+        .storage
+        .list_all_members()
+        .await
+        .map_err(ApiError::Internal)?;
+    Ok(Json(AdminMembersResponse { members }))
+}

--- a/crates/orchestrator/src/routes/admin/mod.rs
+++ b/crates/orchestrator/src/routes/admin/mod.rs
@@ -8,6 +8,7 @@ pub(crate) mod audit;
 pub(crate) mod deployment_actions;
 pub mod fleet;
 pub(crate) mod health;
+pub(crate) mod member_actions;
 pub(crate) mod members;
 pub(crate) mod overview;
 
@@ -71,6 +72,10 @@ pub const ADMIN_ROUTES: &[(&str, &str)] = &[
     ("POST", "/api/admin/deployments/{deployment_id}/restart"),
     ("POST", "/api/admin/deployments/{deployment_id}/tier"),
     ("POST", "/api/admin/deployments/{deployment_id}/delete"),
+    ("POST", "/api/admin/members/{member_id}/suspend"),
+    ("POST", "/api/admin/members/{member_id}/unsuspend"),
+    ("POST", "/api/admin/members/{member_id}/super_admin"),
+    ("POST", "/api/admin/members/{member_id}/delete"),
 ];
 
 pub fn router() -> Router<OrchestratorState> {
@@ -100,4 +105,17 @@ pub fn router() -> Router<OrchestratorState> {
             "/deployments/{deployment_id}/delete",
             post(deployment_actions::delete),
         )
+        .route(
+            "/members/{member_id}/suspend",
+            post(member_actions::suspend),
+        )
+        .route(
+            "/members/{member_id}/unsuspend",
+            post(member_actions::unsuspend),
+        )
+        .route(
+            "/members/{member_id}/super_admin",
+            post(member_actions::set_super_admin),
+        )
+        .route("/members/{member_id}/delete", post(member_actions::delete))
 }

--- a/crates/orchestrator/src/routes/admin/mod.rs
+++ b/crates/orchestrator/src/routes/admin/mod.rs
@@ -12,6 +12,7 @@ pub(crate) mod health;
 pub(crate) mod member_actions;
 pub(crate) mod members;
 pub(crate) mod overview;
+pub(crate) mod team_actions;
 
 use axum::{
     routing::{
@@ -78,6 +79,10 @@ pub const ADMIN_ROUTES: &[(&str, &str)] = &[
     ("POST", "/api/admin/members/{member_id}/super_admin"),
     ("POST", "/api/admin/members/{member_id}/delete"),
     ("POST", "/api/admin/deployments/{deployment_id}/access"),
+    ("GET", "/api/admin/teams"),
+    ("POST", "/api/admin/teams"),
+    ("POST", "/api/admin/teams/{team_id}"),
+    ("POST", "/api/admin/teams/{team_id}/delete"),
 ];
 
 pub fn router() -> Router<OrchestratorState> {
@@ -124,4 +129,10 @@ pub fn router() -> Router<OrchestratorState> {
             "/deployments/{deployment_id}/access",
             post(break_glass::grant_access),
         )
+        .route(
+            "/teams",
+            get(team_actions::list_teams).post(team_actions::create_team),
+        )
+        .route("/teams/{team_id}", post(team_actions::rename_team))
+        .route("/teams/{team_id}/delete", post(team_actions::delete_team))
 }

--- a/crates/orchestrator/src/routes/admin/mod.rs
+++ b/crates/orchestrator/src/routes/admin/mod.rs
@@ -5,17 +5,55 @@
 //! questions about the instance as a whole, which no other surface can.
 
 pub(crate) mod audit;
+pub(crate) mod deployment_actions;
 pub mod fleet;
 pub(crate) mod health;
 pub(crate) mod members;
 pub(crate) mod overview;
 
 use axum::{
-    routing::get,
+    routing::{
+        get,
+        post,
+    },
     Router,
 };
 
-use crate::state::OrchestratorState;
+use crate::{
+    auth::super_admin::Actor,
+    state::OrchestratorState,
+};
+
+/// Record an admin action on the instance audit log.
+///
+/// `actor.member_id()` is `None` for break-glass, so the metadata carries
+/// the actor label too — a row with no member should still say why it has
+/// no member.
+///
+/// Never fails the action it is recording. An admin action that succeeded
+/// but reported failure because its audit write failed would be worse than
+/// one that is unlogged, so the failure is logged loudly instead.
+pub(crate) async fn audit_admin(
+    state: &OrchestratorState,
+    actor: &Actor,
+    action: &str,
+    mut metadata: serde_json::Value,
+) {
+    if let Some(obj) = metadata.as_object_mut() {
+        obj.insert("actor".into(), serde_json::json!(actor.label()));
+    }
+    if let Err(e) = state
+        .storage
+        .append_instance_audit(actor.member_id(), action, &metadata)
+        .await
+    {
+        tracing::error!(
+            action,
+            error = %e,
+            "admin: failed to write instance audit event"
+        );
+    }
+}
 
 /// Every path this module serves, as `(method, absolute path)`.
 ///
@@ -28,6 +66,11 @@ pub const ADMIN_ROUTES: &[(&str, &str)] = &[
     ("GET", "/api/admin/fleet"),
     ("GET", "/api/admin/members"),
     ("GET", "/api/admin/audit"),
+    ("POST", "/api/admin/deployments/{deployment_id}/pause"),
+    ("POST", "/api/admin/deployments/{deployment_id}/resume"),
+    ("POST", "/api/admin/deployments/{deployment_id}/restart"),
+    ("POST", "/api/admin/deployments/{deployment_id}/tier"),
+    ("POST", "/api/admin/deployments/{deployment_id}/delete"),
 ];
 
 pub fn router() -> Router<OrchestratorState> {
@@ -37,4 +80,24 @@ pub fn router() -> Router<OrchestratorState> {
         .route("/fleet", get(fleet::fleet))
         .route("/members", get(members::list_members))
         .route("/audit", get(audit::instance_audit))
+        .route(
+            "/deployments/{deployment_id}/pause",
+            post(deployment_actions::pause),
+        )
+        .route(
+            "/deployments/{deployment_id}/resume",
+            post(deployment_actions::resume),
+        )
+        .route(
+            "/deployments/{deployment_id}/restart",
+            post(deployment_actions::restart),
+        )
+        .route(
+            "/deployments/{deployment_id}/tier",
+            post(deployment_actions::set_tier),
+        )
+        .route(
+            "/deployments/{deployment_id}/delete",
+            post(deployment_actions::delete),
+        )
 }

--- a/crates/orchestrator/src/routes/admin/mod.rs
+++ b/crates/orchestrator/src/routes/admin/mod.rs
@@ -1,0 +1,40 @@
+//! Instance-scoped operator API at `/api/admin/...`.
+//!
+//! Every handler in this module takes the `SuperAdmin` extractor rather than
+//! `AuthIdentity`. Nothing here is team-scoped — these routes exist to answer
+//! questions about the instance as a whole, which no other surface can.
+
+pub(crate) mod audit;
+pub mod fleet;
+pub(crate) mod health;
+pub(crate) mod members;
+pub(crate) mod overview;
+
+use axum::{
+    routing::get,
+    Router,
+};
+
+use crate::state::OrchestratorState;
+
+/// Every path this module serves, as `(method, absolute path)`.
+///
+/// The table-driven authorization test in `tests/integration.rs` iterates
+/// this, so a route added here without a `SuperAdmin` extractor fails CI
+/// rather than shipping open. Keep it in sync with `router()` below.
+pub const ADMIN_ROUTES: &[(&str, &str)] = &[
+    ("GET", "/api/admin/health"),
+    ("GET", "/api/admin/overview"),
+    ("GET", "/api/admin/fleet"),
+    ("GET", "/api/admin/members"),
+    ("GET", "/api/admin/audit"),
+];
+
+pub fn router() -> Router<OrchestratorState> {
+    Router::new()
+        .route("/health", get(health::admin_health))
+        .route("/overview", get(overview::overview))
+        .route("/fleet", get(fleet::fleet))
+        .route("/members", get(members::list_members))
+        .route("/audit", get(audit::instance_audit))
+}

--- a/crates/orchestrator/src/routes/admin/mod.rs
+++ b/crates/orchestrator/src/routes/admin/mod.rs
@@ -5,6 +5,7 @@
 //! questions about the instance as a whole, which no other surface can.
 
 pub(crate) mod audit;
+pub(crate) mod break_glass;
 pub(crate) mod deployment_actions;
 pub mod fleet;
 pub(crate) mod health;
@@ -76,6 +77,7 @@ pub const ADMIN_ROUTES: &[(&str, &str)] = &[
     ("POST", "/api/admin/members/{member_id}/unsuspend"),
     ("POST", "/api/admin/members/{member_id}/super_admin"),
     ("POST", "/api/admin/members/{member_id}/delete"),
+    ("POST", "/api/admin/deployments/{deployment_id}/access"),
 ];
 
 pub fn router() -> Router<OrchestratorState> {
@@ -118,4 +120,8 @@ pub fn router() -> Router<OrchestratorState> {
             post(member_actions::set_super_admin),
         )
         .route("/members/{member_id}/delete", post(member_actions::delete))
+        .route(
+            "/deployments/{deployment_id}/access",
+            post(break_glass::grant_access),
+        )
 }

--- a/crates/orchestrator/src/routes/admin/overview.rs
+++ b/crates/orchestrator/src/routes/admin/overview.rs
@@ -1,0 +1,111 @@
+//! GET /api/admin/overview
+//!
+//! Backs the admin overview cards: host capacity, deployment counts by
+//! state, team and member counts.
+//!
+//! The full host-capacity figures live here rather than on the dashboard
+//! route, which every authenticated user can reach. Fleet inventory is
+//! operator information.
+
+use std::collections::BTreeMap;
+
+use axum::{
+    extract::State,
+    Json,
+};
+use serde::Serialize;
+
+use crate::{
+    auth::super_admin::SuperAdmin,
+    errors::{
+        ApiError,
+        ApiResult,
+    },
+    state::OrchestratorState,
+};
+
+#[derive(Serialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct OverviewResponse {
+    pub total_memory_mb: u64,
+    pub total_cpus: u32,
+    pub allocated_memory_mb: u64,
+    pub allocated_cpus: f32,
+    pub deployment_count: u32,
+    /// Deployment counts keyed by the intended state recorded in the
+    /// database: `running`, `paused`, `disabled`, `provisioning`.
+    pub deployments_by_state: BTreeMap<String, u32>,
+    pub team_count: u32,
+    pub member_count: u32,
+}
+
+#[utoipa::path(
+    get,
+    path = "/api/admin/overview",
+    responses(
+        (status = 200, body = OverviewResponse),
+        (status = 403, description = "not a super-admin"),
+    ),
+    tag = "admin",
+)]
+pub(crate) async fn overview(
+    _admin: SuperAdmin,
+    State(state): State<OrchestratorState>,
+) -> ApiResult<Json<OverviewResponse>> {
+    let host = state.host_capacity.read();
+    let tiers = state
+        .storage
+        .list_deployment_tiers()
+        .await
+        .map_err(ApiError::Internal)?;
+
+    let mut allocated_memory: u64 = 0;
+    let mut allocated_cpus: f32 = 0.0;
+    for t in &tiers {
+        if let Some(tier) = crate::provisioner::tiers::resolve(t) {
+            // Unbounded tiers consume the entire host; reflect that so the
+            // overview shows "fully booked" when one exists.
+            if tier.unbounded {
+                allocated_memory += host.total_memory_mb;
+                allocated_cpus += host.total_cpus as f32;
+            } else {
+                allocated_memory += u64::from(tier.memory_mb);
+                allocated_cpus += tier.cpus;
+            }
+        }
+    }
+
+    let deployments = state
+        .storage
+        .list_all_deployments_with_owners()
+        .await
+        .map_err(ApiError::Internal)?;
+    let mut deployments_by_state: BTreeMap<String, u32> = BTreeMap::new();
+    for d in &deployments {
+        *deployments_by_state
+            .entry(d.intended_state.clone())
+            .or_insert(0) += 1;
+    }
+
+    let teams = state
+        .storage
+        .list_all_teams()
+        .await
+        .map_err(ApiError::Internal)?;
+    let member_count = state
+        .storage
+        .count_members()
+        .await
+        .map_err(ApiError::Internal)?;
+
+    Ok(Json(OverviewResponse {
+        total_memory_mb: host.total_memory_mb,
+        total_cpus: host.total_cpus,
+        allocated_memory_mb: allocated_memory,
+        allocated_cpus,
+        deployment_count: tiers.len() as u32,
+        deployments_by_state,
+        team_count: teams.len() as u32,
+        member_count: member_count as u32,
+    }))
+}

--- a/crates/orchestrator/src/routes/admin/team_actions.rs
+++ b/crates/orchestrator/src/routes/admin/team_actions.rs
@@ -1,0 +1,294 @@
+//! Team governance for the instance admin console.
+//!
+//! Deleting a team is the most destructive action here: it cascades to
+//! every project and every deployment underneath. The response reports how
+//! many deployments were torn down, and the count is available *before* the
+//! operator confirms, so "delete this team" is never a surprise.
+
+use axum::{
+    extract::{
+        Path,
+        State,
+    },
+    Json,
+};
+use serde::{
+    Deserialize,
+    Serialize,
+};
+
+use crate::{
+    auth::super_admin::SuperAdmin,
+    errors::{
+        ApiError,
+        ApiResult,
+    },
+    ids::slugify,
+    routes::admin::audit_admin,
+    state::OrchestratorState,
+};
+
+#[derive(Serialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct AdminTeamRow {
+    pub id: i64,
+    pub name: String,
+    pub slug: String,
+    pub creation_time: i64,
+    pub member_count: u32,
+    pub project_count: u32,
+    /// Shown in the delete confirmation, so the blast radius is visible
+    /// before the operator commits to it.
+    pub deployment_count: u32,
+}
+
+#[derive(Serialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct AdminTeamsResponse {
+    pub teams: Vec<AdminTeamRow>,
+}
+
+#[derive(Deserialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateTeamArgs {
+    pub name: String,
+    /// Derived from the name when omitted.
+    #[serde(default)]
+    pub slug: Option<String>,
+}
+
+#[derive(Deserialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct RenameTeamArgs {
+    pub name: String,
+}
+
+#[derive(Serialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct TeamActionResponse {
+    pub team_id: i64,
+    pub slug: String,
+    /// How many deployments the action tore down. Zero for anything but a
+    /// delete.
+    pub deployments_removed: u32,
+}
+
+#[utoipa::path(
+    get,
+    path = "/api/admin/teams",
+    responses(
+        (status = 200, body = AdminTeamsResponse),
+        (status = 403, description = "not a super-admin"),
+    ),
+    tag = "admin",
+)]
+pub(crate) async fn list_teams(
+    _admin: SuperAdmin,
+    State(state): State<OrchestratorState>,
+) -> ApiResult<Json<AdminTeamsResponse>> {
+    let teams = state
+        .storage
+        .list_all_teams_with_counts()
+        .await
+        .map_err(ApiError::Internal)?;
+    Ok(Json(AdminTeamsResponse {
+        teams: teams
+            .into_iter()
+            .map(|t| AdminTeamRow {
+                id: t.id,
+                name: t.name,
+                slug: t.slug,
+                creation_time: t.creation_time,
+                member_count: t.member_count as u32,
+                project_count: t.project_count as u32,
+                deployment_count: t.deployment_count as u32,
+            })
+            .collect(),
+    }))
+}
+
+#[utoipa::path(
+    post,
+    path = "/api/admin/teams",
+    request_body = CreateTeamArgs,
+    responses(
+        (status = 200, body = TeamActionResponse),
+        (status = 400, description = "invalid name or slug already taken"),
+        (status = 403, description = "not a super-admin"),
+    ),
+    tag = "admin",
+)]
+pub(crate) async fn create_team(
+    admin: SuperAdmin,
+    State(state): State<OrchestratorState>,
+    Json(args): Json<CreateTeamArgs>,
+) -> ApiResult<Json<TeamActionResponse>> {
+    let name = args.name.trim();
+    if name.is_empty() {
+        return Err(ApiError::BadRequest("a team name is required".into()));
+    }
+    let slug = args
+        .slug
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+        .unwrap_or_else(|| slugify(name));
+
+    let team = state
+        .storage
+        // The operator is not made a member: this is instance administration,
+        // not "give myself a team". Membership is granted separately.
+        .create_team(name, &slug, None)
+        .await
+        .map_err(|e| ApiError::BadRequest(format!("could not create team {slug}: {e}")))?;
+
+    audit_admin(
+        &state,
+        &admin.actor,
+        "teamCreated",
+        serde_json::json!({ "teamId": team.id, "slug": team.slug, "name": team.name }),
+    )
+    .await;
+
+    Ok(Json(TeamActionResponse {
+        team_id: team.id,
+        slug: team.slug,
+        deployments_removed: 0,
+    }))
+}
+
+#[utoipa::path(
+    post,
+    path = "/api/admin/teams/{team_id}",
+    params(("team_id" = i64, Path)),
+    request_body = RenameTeamArgs,
+    responses(
+        (status = 200, body = TeamActionResponse),
+        (status = 403, description = "not a super-admin"),
+    ),
+    tag = "admin",
+)]
+pub(crate) async fn rename_team(
+    admin: SuperAdmin,
+    State(state): State<OrchestratorState>,
+    Path(team_id): Path<i64>,
+    Json(args): Json<RenameTeamArgs>,
+) -> ApiResult<Json<TeamActionResponse>> {
+    let name = args.name.trim();
+    if name.is_empty() {
+        return Err(ApiError::BadRequest("a team name is required".into()));
+    }
+    let team = state
+        .storage
+        .get_team(team_id)
+        .await
+        .map_err(ApiError::Internal)?
+        .ok_or_else(|| ApiError::NotFound(format!("team {team_id}")))?;
+
+    // The slug is left alone deliberately: it is baked into deploy keys,
+    // CLI config, and bookmarked URLs, so renaming the display name must
+    // not silently break them.
+    state
+        .storage
+        .update_team(team_id, Some(name), None)
+        .await
+        .map_err(ApiError::Internal)?;
+
+    audit_admin(
+        &state,
+        &admin.actor,
+        "teamRenamed",
+        serde_json::json!({
+            "teamId": team_id,
+            "slug": team.slug,
+            "from": team.name,
+            "to": name,
+        }),
+    )
+    .await;
+
+    Ok(Json(TeamActionResponse {
+        team_id,
+        slug: team.slug,
+        deployments_removed: 0,
+    }))
+}
+
+#[utoipa::path(
+    post,
+    path = "/api/admin/teams/{team_id}/delete",
+    params(("team_id" = i64, Path)),
+    responses(
+        (status = 200, body = TeamActionResponse),
+        (status = 403, description = "not a super-admin"),
+        (status = 502, description = "a deployment could not be torn down"),
+    ),
+    tag = "admin",
+)]
+pub(crate) async fn delete_team(
+    admin: SuperAdmin,
+    State(state): State<OrchestratorState>,
+    Path(team_id): Path<i64>,
+) -> ApiResult<Json<TeamActionResponse>> {
+    let team = state
+        .storage
+        .get_team(team_id)
+        .await
+        .map_err(ApiError::Internal)?
+        .ok_or_else(|| ApiError::NotFound(format!("team {team_id}")))?;
+
+    let projects = state
+        .storage
+        .list_projects(team_id)
+        .await
+        .map_err(ApiError::Internal)?;
+
+    // Cascade explicitly rather than relying on the foreign keys. The rows
+    // would go either way, but the *containers* would not: deleting the team
+    // row alone orphans every backend it owned, still running and still
+    // holding its ports and volumes, with nothing left to list them.
+    let mut removed = 0u32;
+    for p in &projects {
+        let deployments = state
+            .storage
+            .list_deployments(p.id)
+            .await
+            .map_err(ApiError::Internal)?;
+        removed += deployments.len() as u32;
+        crate::routes::helpers::cascade_delete_project(&state, p.id)
+            .await
+            .map_err(|e| {
+                ApiError::BadGateway(format!(
+                    "tearing down project {} failed, so team {} was not deleted: {e}",
+                    p.slug, team.slug
+                ))
+            })?;
+    }
+
+    state
+        .storage
+        .delete_team(team_id)
+        .await
+        .map_err(ApiError::Internal)?;
+
+    audit_admin(
+        &state,
+        &admin.actor,
+        "teamDeleted",
+        serde_json::json!({
+            "teamId": team_id,
+            "slug": team.slug,
+            "name": team.name,
+            "projectsRemoved": projects.len(),
+            "deploymentsRemoved": removed,
+        }),
+    )
+    .await;
+
+    Ok(Json(TeamActionResponse {
+        team_id,
+        slug: team.slug,
+        deployments_removed: removed,
+    }))
+}

--- a/crates/orchestrator/src/routes/internal.rs
+++ b/crates/orchestrator/src/routes/internal.rs
@@ -66,6 +66,11 @@ pub struct ExchangeSessionResponse {
     pub member_id: u64,
     pub team_slug: String,
     pub role: String,
+    /// Instance-wide operator. The dashboard uses this only to decide
+    /// whether to render the admin nav; the server-side gate is the
+    /// `SuperAdmin` extractor, so a client that lies about it gains
+    /// nothing.
+    pub is_super_admin: bool,
 }
 
 #[utoipa::path(
@@ -109,6 +114,30 @@ pub(crate) async fn exchange_session(
         .upsert_member(&args.auth_user_id, &email, args.name.as_deref())
         .await
         .map_err(ApiError::Internal)?;
+
+    // ADMIN_EMAILS seeds the super-admin column on sign-in; from then on the
+    // column is the authority, so an operator can be revoked in the console
+    // without a redeploy. Seeding is deliberately one-way: dropping an
+    // address from ADMIN_EMAILS must not silently strip a live operator,
+    // because that would make a config edit a security action nobody
+    // reviewed as one.
+    if is_admin_email && !member.is_super_admin {
+        state
+            .storage
+            .set_super_admin(member.id, true)
+            .await
+            .map_err(ApiError::Internal)?;
+        state
+            .storage
+            .append_instance_audit(
+                Some(member.id),
+                "superAdminSeeded",
+                &serde_json::json!({ "email": email, "source": "ADMIN_EMAILS" }),
+            )
+            .await
+            .ok();
+    }
+    let is_super_admin = member.is_super_admin || is_admin_email;
 
     let existing_teams = state
         .storage
@@ -227,6 +256,7 @@ pub(crate) async fn exchange_session(
         member_id: member.id as u64,
         team_slug,
         role: role.to_string(),
+        is_super_admin,
     }))
 }
 
@@ -248,10 +278,7 @@ pub(crate) async fn health(
     Ok(StatusCode::OK)
 }
 
-fn require_service_key(
-    state: &OrchestratorState,
-    headers: &HeaderMap,
-) -> Result<(), ApiError> {
+fn require_service_key(state: &OrchestratorState, headers: &HeaderMap) -> Result<(), ApiError> {
     let configured = state.config.service_key.as_deref().ok_or_else(|| {
         ApiError::NotImplemented(
             "internal endpoints disabled: set CONVEX_ORCHESTRATOR_SERVICE_KEY".into(),

--- a/crates/orchestrator/src/routes/management/deployments.rs
+++ b/crates/orchestrator/src/routes/management/deployments.rs
@@ -796,6 +796,24 @@ pub(crate) async fn restart_deployment(
         .await
         .map_err(ApiError::Internal)?
         .ok_or_else(|| ApiError::NotFound("deployment".into()))?;
+    let updated = respawn_deployment(&state, &deployment, args.force.unwrap_or(false)).await?;
+    Ok(Json(crate::routes::helpers::deployment_to_platform(
+        &updated,
+    )))
+}
+
+/// Respawn a deployment's backend container.
+///
+/// Extracted from `restart_deployment` so the admin console can restart a
+/// deployment without duplicating capacity checks, effective-tier
+/// resolution, layered knob overrides, sidecar credential reuse, or
+/// canonical-URL application. Two copies of this would drift, and the ways
+/// they would drift are all silent.
+pub(crate) async fn respawn_deployment(
+    state: &OrchestratorState,
+    deployment: &crate::storage::DeploymentRecord,
+    force: bool,
+) -> ApiResult<crate::storage::DeploymentRecord> {
     let project = state
         .storage
         .get_project(deployment.project_id)
@@ -811,7 +829,6 @@ pub(crate) async fn restart_deployment(
 
     // Capacity check: exclude this deployment's own current tier from the sum
     // so a same-tier restart doesn't self-reject.
-    let force = args.force.unwrap_or(false);
     ensure_host_capacity_for_restart(&state, deployment.id, &effective_tier, force).await?;
 
     // Compose effective overrides: project layer then deployment layer.
@@ -850,7 +867,7 @@ pub(crate) async fn restart_deployment(
     let result = state
         .provisioner
         .respawn(crate::provisioner::ProvisionRequest {
-            deployment_name: deployment_name.clone(),
+            deployment_name: deployment.name.clone(),
             deployment_type: deployment.deployment_type,
             project_id: deployment.project_id,
             tier: effective_tier.clone(),
@@ -908,7 +925,7 @@ pub(crate) async fn restart_deployment(
     // trade than an unrecoverable dashboard.
     if deployment.instance_secret != result.instance_secret {
         tracing::info!(
-            deployment = %deployment_name,
+            deployment = %deployment.name,
             had_backend_instance_secret = deployment.backend_instance_secret.is_some(),
             "restart: refreshing the stored admin key to match the running container"
         );
@@ -942,13 +959,11 @@ pub(crate) async fn restart_deployment(
     // Re-read and return the fresh row.
     let updated = state
         .storage
-        .get_deployment_by_name(&deployment_name)
+        .get_deployment_by_name(&deployment.name)
         .await
         .map_err(ApiError::Internal)?
         .ok_or_else(|| ApiError::NotFound("deployment".into()))?;
-    Ok(Json(crate::routes::helpers::deployment_to_platform(
-        &updated,
-    )))
+    Ok(updated)
 }
 
 #[cfg(test)]

--- a/crates/orchestrator/src/routes/mod.rs
+++ b/crates/orchestrator/src/routes/mod.rs
@@ -1,6 +1,7 @@
 //! HTTP route handlers grouped by API surface.
 
 pub mod acme_challenge;
+pub mod admin;
 pub mod dashboard;
 pub mod deployment_internal;
 pub mod helpers;

--- a/crates/orchestrator/src/state.rs
+++ b/crates/orchestrator/src/state.rs
@@ -23,6 +23,28 @@ use crate::{
 /// with a BetterAuth-issued ID.
 pub const SYSTEM_AUTH_USER_ID: &str = "system:bootstrap";
 
+/// Time-boxed cache for the readiness probe result.
+///
+/// A load balancer polling `/ready` every few seconds across N targets would
+/// otherwise turn health checking into database load. The window is short
+/// enough that a real outage is still reported promptly.
+#[derive(Default)]
+pub struct ReadinessCache {
+    inner: parking_lot::Mutex<Option<(std::time::Instant, bool)>>,
+}
+
+impl ReadinessCache {
+    pub fn get(&self, ttl: std::time::Duration) -> Option<bool> {
+        let guard = self.inner.lock();
+        let (at, value) = (*guard)?;
+        (at.elapsed() < ttl).then_some(value)
+    }
+
+    pub fn set(&self, value: bool) {
+        *self.inner.lock() = Some((std::time::Instant::now(), value));
+    }
+}
+
 #[derive(Clone)]
 pub struct OrchestratorState {
     pub storage: Storage,
@@ -35,6 +57,9 @@ pub struct OrchestratorState {
     /// In-flight HTTP-01 challenge tokens, served by the orchestrator's
     /// `/.well-known/acme-challenge/` route.
     pub challenges: crate::acme::ChallengeStore,
+    /// Caches the last `/ready` probe so load-balancer polling does not
+    /// become database load.
+    pub readiness: Arc<ReadinessCache>,
 }
 
 impl OrchestratorState {
@@ -94,6 +119,7 @@ impl OrchestratorState {
             host_capacity: Arc::new(crate::host_capacity::HostCapacityReader::new()),
             secrets,
             challenges: crate::acme::ChallengeStore::new(),
+            readiness: Arc::new(ReadinessCache::default()),
         };
 
         state.bootstrap_if_empty().await?;

--- a/crates/orchestrator/src/storage/admin.rs
+++ b/crates/orchestrator/src/storage/admin.rs
@@ -1,0 +1,173 @@
+//! Cross-tenant reads for the instance admin console.
+//!
+//! Every other query module in `storage` scopes to a team, project, or
+//! deployment. These deliberately do not — they exist to answer "what is on
+//! this instance?" and are only ever reachable behind the `SuperAdmin`
+//! extractor.
+
+use serde::Serialize;
+
+use super::{
+    teams::{
+        map_team,
+        TeamRecord,
+    },
+    Storage,
+};
+
+/// One team membership, flattened for the admin member table.
+#[derive(Debug, Clone, Serialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct MemberTeamRef {
+    pub team_id: i64,
+    pub team_slug: String,
+    pub team_name: String,
+    pub role: String,
+}
+
+/// A member as the admin console sees them: identity, flags, and every team
+/// they belong to.
+#[derive(Debug, Clone, Serialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct AdminMemberRow {
+    pub id: i64,
+    pub primary_email: String,
+    pub name: Option<String>,
+    pub creation_time: i64,
+    pub is_super_admin: bool,
+    pub suspended: bool,
+    pub teams: Vec<MemberTeamRef>,
+}
+
+/// A deployment as the admin console sees it, with its owning team and
+/// project resolved.
+///
+/// `intended_state` is what the database says should be running. What is
+/// *actually* running is a docker question, filled in by the fleet route —
+/// this query cannot know it.
+#[derive(Debug, Clone, Serialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct AdminDeploymentRow {
+    pub id: i64,
+    pub name: String,
+    pub deployment_type: String,
+    pub intended_state: String,
+    pub tier: String,
+    pub url: String,
+    pub creation_time: i64,
+    pub team_id: i64,
+    pub team_slug: String,
+    pub project_id: i64,
+    pub project_slug: String,
+}
+
+impl Storage {
+    /// Every team on the instance, oldest first.
+    pub async fn list_all_teams(&self) -> anyhow::Result<Vec<TeamRecord>> {
+        let conn = self.pool().acquire().await?;
+        let rows = conn
+            .client()
+            .query(
+                "SELECT id, name, slug, creator_id, creation_time
+                   FROM teams
+                  ORDER BY creation_time ASC, id ASC",
+                &[],
+            )
+            .await?;
+        Ok(rows.into_iter().map(map_team).collect())
+    }
+
+    /// Every non-deleted member, with their team memberships attached.
+    ///
+    /// One LEFT JOIN rather than N+1: the console renders the whole table at
+    /// once and an instance can have hundreds of members.
+    ///
+    /// Ordered by `m.id`, not `m.creation_time`. Creation times are
+    /// millisecond-precision, so two members registered in the same
+    /// millisecond could interleave and the run-grouping below would split
+    /// one member across two rows. `id` is unique, so the grouping is exact.
+    pub async fn list_all_members(&self) -> anyhow::Result<Vec<AdminMemberRow>> {
+        let conn = self.pool().acquire().await?;
+        let rows = conn
+            .client()
+            .query(
+                "SELECT m.id, m.primary_email, m.name, m.creation_time,
+                        m.is_super_admin, m.suspended,
+                        t.id, t.slug, t.name, tm.role
+                   FROM members m
+                   LEFT JOIN team_members tm ON tm.member_id = m.id
+                   LEFT JOIN teams t ON t.id = tm.team_id
+                  WHERE m.deleted = FALSE
+                  ORDER BY m.id ASC, t.slug ASC",
+                &[],
+            )
+            .await?;
+
+        let mut out: Vec<AdminMemberRow> = Vec::new();
+        for row in rows {
+            let id: i64 = row.get(0);
+            if out.last().map(|m| m.id) != Some(id) {
+                out.push(AdminMemberRow {
+                    id,
+                    primary_email: row.get(1),
+                    name: row.get(2),
+                    creation_time: row.get(3),
+                    is_super_admin: row.get(4),
+                    suspended: row.get(5),
+                    teams: Vec::new(),
+                });
+            }
+            // NULL when the member belongs to no team, which the LEFT JOIN
+            // still emits one row for.
+            let team_id: Option<i64> = row.get(6);
+            if let Some(team_id) = team_id {
+                out.last_mut()
+                    .expect("a row was just pushed")
+                    .teams
+                    .push(MemberTeamRef {
+                        team_id,
+                        team_slug: row.get(7),
+                        team_name: row.get(8),
+                        role: row.get(9),
+                    });
+            }
+        }
+        Ok(out)
+    }
+
+    /// Every deployment on the instance with its owning team and project.
+    pub async fn list_all_deployments_with_owners(
+        &self,
+    ) -> anyhow::Result<Vec<AdminDeploymentRow>> {
+        let conn = self.pool().acquire().await?;
+        let rows = conn
+            .client()
+            .query(
+                "SELECT d.id, d.name, d.deployment_type, d.state, d.tier, d.url,
+                        d.creation_time,
+                        t.id, t.slug, p.id, p.slug
+                   FROM deployments d
+                   JOIN projects p ON p.id = d.project_id
+                   JOIN teams t ON t.id = p.team_id
+                  ORDER BY d.creation_time ASC, d.id ASC",
+                &[],
+            )
+            .await?;
+        Ok(rows
+            .into_iter()
+            .map(|row| AdminDeploymentRow {
+                id: row.get(0),
+                name: row.get(1),
+                deployment_type: row.get(2),
+                intended_state: row.get(3),
+                tier: row.get(4),
+                url: row.get(5),
+                creation_time: row.get(6),
+                team_id: row.get(7),
+                team_slug: row.get(8),
+                project_id: row.get(9),
+                project_slug: row.get(10),
+            })
+            .collect())
+    }
+}

--- a/crates/orchestrator/src/storage/admin.rs
+++ b/crates/orchestrator/src/storage/admin.rs
@@ -224,3 +224,55 @@ impl Storage {
             .collect())
     }
 }
+
+/// An instance audit event with the actor's email resolved.
+#[derive(Debug, Clone, Serialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct AdminAuditRow {
+    pub id: i64,
+    pub member_id: Option<i64>,
+    /// `None` for break-glass (no member) or a member since deleted.
+    pub member_email: Option<String>,
+    pub action: String,
+    pub metadata: serde_json::Value,
+    pub creation_time: i64,
+}
+
+impl Storage {
+    /// Instance audit events, newest first, with actor emails joined.
+    ///
+    /// Joined here rather than looked up per row by the client: an audit
+    /// page is exactly the place where N+1 requests show up as a visibly
+    /// slow table.
+    pub async fn list_instance_audit_with_actors(
+        &self,
+        limit: i64,
+    ) -> anyhow::Result<Vec<AdminAuditRow>> {
+        let limit = limit.clamp(1, 1000);
+        let conn = self.pool().acquire().await?;
+        let rows = conn
+            .client()
+            .query(
+                "SELECT a.id, a.member_id, m.primary_email, a.action, a.metadata,
+                        a.creation_time
+                   FROM audit_log_events a
+                   LEFT JOIN members m ON m.id = a.member_id
+                  WHERE a.scope = 'instance'
+                  ORDER BY a.creation_time DESC, a.id DESC
+                  LIMIT $1",
+                &[&limit],
+            )
+            .await?;
+        Ok(rows
+            .into_iter()
+            .map(|r| AdminAuditRow {
+                id: r.get(0),
+                member_id: r.get(1),
+                member_email: r.get(2),
+                action: r.get(3),
+                metadata: r.get(4),
+                creation_time: r.get(5),
+            })
+            .collect())
+    }
+}

--- a/crates/orchestrator/src/storage/admin.rs
+++ b/crates/orchestrator/src/storage/admin.rs
@@ -171,3 +171,56 @@ impl Storage {
             .collect())
     }
 }
+
+/// A team as the admin console lists it, with the counts the delete
+/// confirmation needs.
+#[derive(Debug, Clone, Serialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct AdminTeamCounts {
+    pub id: i64,
+    pub name: String,
+    pub slug: String,
+    pub creation_time: i64,
+    pub member_count: i64,
+    pub project_count: i64,
+    pub deployment_count: i64,
+}
+
+impl Storage {
+    /// Every team with its member, project, and deployment counts.
+    ///
+    /// Correlated subqueries rather than joins: a join across three
+    /// one-to-many relations multiplies rows, and getting three independent
+    /// counts out of that needs `count(DISTINCT ...)` on each, which is both
+    /// slower and easier to get subtly wrong.
+    pub async fn list_all_teams_with_counts(&self) -> anyhow::Result<Vec<AdminTeamCounts>> {
+        let conn = self.pool().acquire().await?;
+        let rows = conn
+            .client()
+            .query(
+                "SELECT t.id, t.name, t.slug, t.creation_time,
+                        (SELECT count(*) FROM team_members tm WHERE tm.team_id = t.id),
+                        (SELECT count(*) FROM projects p
+                          WHERE p.team_id = t.id AND p.deleted = FALSE),
+                        (SELECT count(*) FROM deployments d
+                           JOIN projects p2 ON p2.id = d.project_id
+                          WHERE p2.team_id = t.id AND p2.deleted = FALSE)
+                   FROM teams t
+                  ORDER BY t.creation_time ASC, t.id ASC",
+                &[],
+            )
+            .await?;
+        Ok(rows
+            .into_iter()
+            .map(|r| AdminTeamCounts {
+                id: r.get(0),
+                name: r.get(1),
+                slug: r.get(2),
+                creation_time: r.get(3),
+                member_count: r.get(4),
+                project_count: r.get(5),
+                deployment_count: r.get(6),
+            })
+            .collect())
+    }
+}

--- a/crates/orchestrator/src/storage/audit_log.rs
+++ b/crates/orchestrator/src/storage/audit_log.rs
@@ -90,10 +90,14 @@ impl Storage {
         let rows = conn
             .client()
             .query(
+                // Tie-break on `id`: creation_time is millisecond precision,
+                // so two events written in the same millisecond would
+                // otherwise come back in arbitrary order. `id` is a
+                // BIGSERIAL, so it is monotonic and makes the sort stable.
                 "SELECT id, member_id, action, metadata, creation_time
                    FROM audit_log_events
                   WHERE scope = 'instance'
-                  ORDER BY creation_time DESC
+                  ORDER BY creation_time DESC, id DESC
                   LIMIT $1",
                 &[&limit],
             )
@@ -137,10 +141,7 @@ impl Storage {
             params.push(Box::new(to));
             sql.push_str(&format!(" AND creation_time <= ${}", params.len()));
         }
-        // Tie-break on `id`: creation_time is millisecond precision, so two
-        // events written in the same millisecond would otherwise come back
-        // in arbitrary order. `id` is a BIGSERIAL, so it is monotonic and
-        // makes the sort stable.
+        // Same millisecond-collision tie-break as `list_instance_audit`.
         sql.push_str(" ORDER BY creation_time DESC, id DESC LIMIT ");
         sql.push_str(&limit.to_string());
 

--- a/crates/orchestrator/src/storage/audit_log.rs
+++ b/crates/orchestrator/src/storage/audit_log.rs
@@ -11,6 +11,24 @@ pub struct AuditEntry {
     pub creation_time: i64,
 }
 
+/// An instance-scoped audit event: an operator action that belongs to no
+/// single team.
+///
+/// Separate from `AuditEntry` rather than making that type's `team_id`
+/// nullable. Team-scoped rows can never have a NULL `team_id` — the query
+/// filters on it — so widening the shared type would push an `Option` into
+/// the dashboard's audit route for a case it can never see.
+#[derive(Debug, Clone)]
+pub struct InstanceAuditEntry {
+    pub id: i64,
+    /// `None` for actions taken through the break-glass bootstrap
+    /// credential, which has no human behind it.
+    pub member_id: Option<i64>,
+    pub action: String,
+    pub metadata: serde_json::Value,
+    pub creation_time: i64,
+}
+
 #[derive(Debug, Clone, Default)]
 pub struct AuditQuery {
     pub team_id: i64,
@@ -33,7 +51,8 @@ impl Storage {
         let conn = self.pool().acquire().await?;
         conn.client()
             .execute(
-                "INSERT INTO audit_log_events (team_id, member_id, action, metadata, creation_time)
+                "INSERT INTO audit_log_events (team_id, member_id, action, metadata, \
+                 creation_time)
                  VALUES ($1, $2, $3, $4, $5)",
                 &[&team_id, &member_id, &action, metadata, &now],
             )
@@ -41,11 +60,64 @@ impl Storage {
         Ok(())
     }
 
+    /// Append an instance-scoped audit event.
+    ///
+    /// `team_id` is NULL and `scope` is `'instance'`, so the per-team query
+    /// below never returns these.
+    pub async fn append_instance_audit(
+        &self,
+        member_id: Option<i64>,
+        action: &str,
+        metadata: &serde_json::Value,
+    ) -> anyhow::Result<()> {
+        let now = now_unix_ms();
+        let conn = self.pool().acquire().await?;
+        conn.client()
+            .execute(
+                "INSERT INTO audit_log_events (team_id, member_id, action, metadata, \
+                 creation_time, scope)
+                 VALUES (NULL, $1, $2, $3, $4, 'instance')",
+                &[&member_id, &action, metadata, &now],
+            )
+            .await?;
+        Ok(())
+    }
+
+    /// Most recent instance-scoped events, newest first.
+    pub async fn list_instance_audit(&self, limit: i64) -> anyhow::Result<Vec<InstanceAuditEntry>> {
+        let limit = limit.clamp(1, 1000);
+        let conn = self.pool().acquire().await?;
+        let rows = conn
+            .client()
+            .query(
+                "SELECT id, member_id, action, metadata, creation_time
+                   FROM audit_log_events
+                  WHERE scope = 'instance'
+                  ORDER BY creation_time DESC
+                  LIMIT $1",
+                &[&limit],
+            )
+            .await?;
+        Ok(rows
+            .into_iter()
+            .map(|r| InstanceAuditEntry {
+                id: r.get(0),
+                member_id: r.get(1),
+                action: r.get(2),
+                metadata: r.get(3),
+                creation_time: r.get(4),
+            })
+            .collect())
+    }
+
     pub async fn query_audit(&self, q: &AuditQuery) -> anyhow::Result<Vec<AuditEntry>> {
         let limit = q.limit.unwrap_or(100).min(1000);
+        // The `scope` filter is redundant against `team_id = $1` today
+        // (instance rows have a NULL team_id) but is stated explicitly so
+        // this query stays correct if the default ever changes.
         let mut sql = String::from(
-            "SELECT id, team_id, member_id, action, metadata, creation_time \
-             FROM audit_log_events WHERE team_id = $1",
+            "SELECT id, team_id, member_id, action, metadata, creation_time FROM audit_log_events \
+             WHERE team_id = $1 AND scope = 'team'",
         );
         let mut params: Vec<Box<dyn tokio_postgres::types::ToSql + Sync + Send>> =
             vec![Box::new(q.team_id)];

--- a/crates/orchestrator/src/storage/deployments.rs
+++ b/crates/orchestrator/src/storage/deployments.rs
@@ -208,10 +208,7 @@ impl Storage {
         Ok(row.try_get::<_, Option<i64>>(0).ok().flatten())
     }
 
-    pub async fn list_deployments(
-        &self,
-        project_id: i64,
-    ) -> anyhow::Result<Vec<DeploymentRecord>> {
+    pub async fn list_deployments(&self, project_id: i64) -> anyhow::Result<Vec<DeploymentRecord>> {
         let conn = self.pool().acquire().await?;
         let rows = conn
             .client()
@@ -266,6 +263,46 @@ impl Storage {
         Ok(row.map(map_deployment))
     }
 
+    /// Mark a deployment paused. Idempotent.
+    ///
+    /// Refuses while `provisioning`: `reconcile::plan` reads `paused` as
+    /// "not running by intent" and leaves the container alone, so pausing a
+    /// half-built deployment would strand it there permanently.
+    pub async fn pause_deployment(&self, deployment_id: i64) -> anyhow::Result<()> {
+        self.transition_state(deployment_id, DeploymentState::Paused)
+            .await
+    }
+
+    /// Mark a deployment running. Idempotent.
+    pub async fn resume_deployment(&self, deployment_id: i64) -> anyhow::Result<()> {
+        self.transition_state(deployment_id, DeploymentState::Running)
+            .await
+    }
+
+    /// Shared guard for operator-driven state changes.
+    ///
+    /// Deliberately narrower than `update_deployment_state`, which stays
+    /// unguarded because provisioning itself has to be able to write
+    /// `Provisioning` and then `Running`.
+    async fn transition_state(
+        &self,
+        deployment_id: i64,
+        target: DeploymentState,
+    ) -> anyhow::Result<()> {
+        let current = self
+            .get_deployment(deployment_id)
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("deployment {deployment_id} not found"))?;
+        if matches!(current.state, DeploymentState::Provisioning) {
+            anyhow::bail!(
+                "deployment {} is still provisioning; wait for it to finish before changing its \
+                 state",
+                current.name
+            );
+        }
+        self.update_deployment_state(deployment_id, target).await
+    }
+
     pub async fn update_deployment_state(
         &self,
         id: i64,
@@ -296,11 +333,7 @@ impl Storage {
         Ok(())
     }
 
-    pub async fn transfer_deployment(
-        &self,
-        id: i64,
-        new_project_id: i64,
-    ) -> anyhow::Result<()> {
+    pub async fn transfer_deployment(&self, id: i64, new_project_id: i64) -> anyhow::Result<()> {
         let conn = self.pool().acquire().await?;
         conn.client()
             .execute(
@@ -352,7 +385,8 @@ impl Storage {
     ///
     /// `desired_tier`:
     ///   - `None`        → leave the column unchanged
-    ///   - `Some(None)`  → set the column to SQL NULL (fall back to project tier)
+    ///   - `Some(None)`  → set the column to SQL NULL (fall back to project
+    ///     tier)
     ///   - `Some(Some("S32"))` → set the column to "S32"
     ///
     /// `desired_overrides`:
@@ -467,11 +501,38 @@ impl Storage {
     }
 }
 
-const SELECT_DEPLOYMENT_BY_ID: &str = "SELECT id, project_id, name, deployment_type, deployment_class, region, url, site_url, backend_pid, backend_port, creator_id, creation_time, state, preview_identifier, instance_secret, tier, knob_overrides, desired_tier, desired_overrides, storage_mode, pg_password, minio_root_user, minio_root_password, backend_instance_secret, desired_url, desired_site_url FROM deployments WHERE id = $1";
-const SELECT_DEPLOYMENT_BY_NAME: &str = "SELECT id, project_id, name, deployment_type, deployment_class, region, url, site_url, backend_pid, backend_port, creator_id, creation_time, state, preview_identifier, instance_secret, tier, knob_overrides, desired_tier, desired_overrides, storage_mode, pg_password, minio_root_user, minio_root_password, backend_instance_secret, desired_url, desired_site_url FROM deployments WHERE name = $1";
-const SELECT_DEPLOYMENTS_BY_PROJECT: &str = "SELECT id, project_id, name, deployment_type, deployment_class, region, url, site_url, backend_pid, backend_port, creator_id, creation_time, state, preview_identifier, instance_secret, tier, knob_overrides, desired_tier, desired_overrides, storage_mode, pg_password, minio_root_user, minio_root_password, backend_instance_secret, desired_url, desired_site_url FROM deployments WHERE project_id = $1 ORDER BY creation_time ASC";
-const SELECT_ALL_DEPLOYMENTS: &str = "SELECT id, project_id, name, deployment_type, deployment_class, region, url, site_url, backend_pid, backend_port, creator_id, creation_time, state, preview_identifier, instance_secret, tier, knob_overrides, desired_tier, desired_overrides, storage_mode, pg_password, minio_root_user, minio_root_password, backend_instance_secret, desired_url, desired_site_url FROM deployments ORDER BY creation_time ASC";
-const SELECT_DEPLOYMENTS_BY_TEAM: &str = "SELECT d.id, d.project_id, d.name, d.deployment_type, d.deployment_class, d.region, d.url, d.site_url, d.backend_pid, d.backend_port, d.creator_id, d.creation_time, d.state, d.preview_identifier, d.instance_secret, d.tier, d.knob_overrides, d.desired_tier, d.desired_overrides, d.storage_mode, d.pg_password, d.minio_root_user, d.minio_root_password, d.backend_instance_secret, d.desired_url, d.desired_site_url FROM deployments d INNER JOIN projects p ON p.id = d.project_id WHERE p.team_id = $1 ORDER BY d.creation_time ASC";
+const SELECT_DEPLOYMENT_BY_ID: &str =
+    "SELECT id, project_id, name, deployment_type, deployment_class, region, url, site_url, \
+     backend_pid, backend_port, creator_id, creation_time, state, preview_identifier, \
+     instance_secret, tier, knob_overrides, desired_tier, desired_overrides, storage_mode, \
+     pg_password, minio_root_user, minio_root_password, backend_instance_secret, desired_url, \
+     desired_site_url FROM deployments WHERE id = $1";
+const SELECT_DEPLOYMENT_BY_NAME: &str =
+    "SELECT id, project_id, name, deployment_type, deployment_class, region, url, site_url, \
+     backend_pid, backend_port, creator_id, creation_time, state, preview_identifier, \
+     instance_secret, tier, knob_overrides, desired_tier, desired_overrides, storage_mode, \
+     pg_password, minio_root_user, minio_root_password, backend_instance_secret, desired_url, \
+     desired_site_url FROM deployments WHERE name = $1";
+const SELECT_DEPLOYMENTS_BY_PROJECT: &str =
+    "SELECT id, project_id, name, deployment_type, deployment_class, region, url, site_url, \
+     backend_pid, backend_port, creator_id, creation_time, state, preview_identifier, \
+     instance_secret, tier, knob_overrides, desired_tier, desired_overrides, storage_mode, \
+     pg_password, minio_root_user, minio_root_password, backend_instance_secret, desired_url, \
+     desired_site_url FROM deployments WHERE project_id = $1 ORDER BY creation_time ASC";
+const SELECT_ALL_DEPLOYMENTS: &str =
+    "SELECT id, project_id, name, deployment_type, deployment_class, region, url, site_url, \
+     backend_pid, backend_port, creator_id, creation_time, state, preview_identifier, \
+     instance_secret, tier, knob_overrides, desired_tier, desired_overrides, storage_mode, \
+     pg_password, minio_root_user, minio_root_password, backend_instance_secret, desired_url, \
+     desired_site_url FROM deployments ORDER BY creation_time ASC";
+const SELECT_DEPLOYMENTS_BY_TEAM: &str =
+    "SELECT d.id, d.project_id, d.name, d.deployment_type, d.deployment_class, d.region, d.url, \
+     d.site_url, d.backend_pid, d.backend_port, d.creator_id, d.creation_time, d.state, \
+     d.preview_identifier, d.instance_secret, d.tier, d.knob_overrides, d.desired_tier, \
+     d.desired_overrides, d.storage_mode, d.pg_password, d.minio_root_user, \
+     d.minio_root_password, d.backend_instance_secret, d.desired_url, d.desired_site_url FROM \
+     deployments d INNER JOIN projects p ON p.id = d.project_id WHERE p.team_id = $1 ORDER BY \
+     d.creation_time ASC";
 
 fn map_deployment(row: Row) -> DeploymentRecord {
     DeploymentRecord {

--- a/crates/orchestrator/src/storage/members.rs
+++ b/crates/orchestrator/src/storage/members.rs
@@ -11,6 +11,10 @@ pub struct MemberRecord {
     pub name: Option<String>,
     pub creation_time: i64,
     pub deleted: bool,
+    /// Instance-wide operator. See `auth::super_admin`.
+    pub is_super_admin: bool,
+    /// Reversible authentication block. Distinct from `deleted`.
+    pub suspended: bool,
 }
 
 impl Storage {
@@ -32,7 +36,8 @@ impl Storage {
                  ON CONFLICT (auth_user_id) DO UPDATE SET
                      primary_email = EXCLUDED.primary_email,
                      name = COALESCE(EXCLUDED.name, members.name)
-                 RETURNING id, auth_user_id, primary_email, name, creation_time, deleted",
+                 RETURNING id, auth_user_id, primary_email, name, creation_time, deleted,
+                        is_super_admin, suspended",
                 &[&auth_user_id, &email, &name, &now],
             )
             .await?;
@@ -44,7 +49,8 @@ impl Storage {
         let row = conn
             .client()
             .query_opt(
-                "SELECT id, auth_user_id, primary_email, name, creation_time, deleted
+                "SELECT id, auth_user_id, primary_email, name, creation_time, deleted,
+                        is_super_admin, suspended
                  FROM members WHERE id = $1",
                 &[&id],
             )
@@ -60,7 +66,8 @@ impl Storage {
         let row = conn
             .client()
             .query_opt(
-                "SELECT id, auth_user_id, primary_email, name, creation_time, deleted
+                "SELECT id, auth_user_id, primary_email, name, creation_time, deleted,
+                        is_super_admin, suspended
                  FROM members WHERE auth_user_id = $1 AND deleted = FALSE",
                 &[&auth_user_id],
             )
@@ -68,15 +75,13 @@ impl Storage {
         Ok(row.map(map_member))
     }
 
-    pub async fn get_member_by_email(
-        &self,
-        email: &str,
-    ) -> anyhow::Result<Option<MemberRecord>> {
+    pub async fn get_member_by_email(&self, email: &str) -> anyhow::Result<Option<MemberRecord>> {
         let conn = self.pool().acquire().await?;
         let row = conn
             .client()
             .query_opt(
-                "SELECT id, auth_user_id, primary_email, name, creation_time, deleted
+                "SELECT id, auth_user_id, primary_email, name, creation_time, deleted,
+                        is_super_admin, suspended
                  FROM members WHERE primary_email = $1 AND deleted = FALSE",
                 &[&email],
             )
@@ -99,10 +104,7 @@ impl Storage {
     pub async fn update_member_name(&self, id: i64, name: &str) -> anyhow::Result<()> {
         let conn = self.pool().acquire().await?;
         conn.client()
-            .execute(
-                "UPDATE members SET name = $1 WHERE id = $2",
-                &[&name, &id],
-            )
+            .execute("UPDATE members SET name = $1 WHERE id = $2", &[&name, &id])
             .await?;
         Ok(())
     }
@@ -110,11 +112,65 @@ impl Storage {
     pub async fn delete_member(&self, id: i64) -> anyhow::Result<()> {
         let conn = self.pool().acquire().await?;
         conn.client()
+            .execute("UPDATE members SET deleted = TRUE WHERE id = $1", &[&id])
+            .await?;
+        Ok(())
+    }
+
+    /// Grant or revoke instance-wide operator rights.
+    ///
+    /// Revocation is guarded against removing the last remaining
+    /// super-admin. The guard is a subquery inside the same statement, not
+    /// a read-then-write, so two concurrent revokes cannot both observe a
+    /// count of 2 and both succeed.
+    pub async fn set_super_admin(&self, member_id: i64, value: bool) -> anyhow::Result<()> {
+        let conn = self.pool().acquire().await?;
+        let affected = if value {
+            conn.client()
+                .execute(
+                    "UPDATE members SET is_super_admin = TRUE
+                      WHERE id = $1 AND deleted = FALSE",
+                    &[&member_id],
+                )
+                .await?
+        } else {
+            conn.client()
+                .execute(
+                    "UPDATE members SET is_super_admin = FALSE
+                      WHERE id = $1
+                        AND deleted = FALSE
+                        AND (SELECT count(*) FROM members
+                              WHERE is_super_admin = TRUE AND deleted = FALSE) > 1",
+                    &[&member_id],
+                )
+                .await?
+        };
+        if affected == 0 {
+            if value {
+                anyhow::bail!("member {member_id} not found");
+            }
+            anyhow::bail!(
+                "refusing to revoke the last super-admin (member {member_id}); grant another \
+                 operator first"
+            );
+        }
+        Ok(())
+    }
+
+    /// Suspend or unsuspend a member. Suspension blocks authentication but
+    /// preserves team membership, projects, and audit history.
+    pub async fn set_member_suspended(&self, member_id: i64, value: bool) -> anyhow::Result<()> {
+        let conn = self.pool().acquire().await?;
+        let affected = conn
+            .client()
             .execute(
-                "UPDATE members SET deleted = TRUE WHERE id = $1",
-                &[&id],
+                "UPDATE members SET suspended = $2 WHERE id = $1 AND deleted = FALSE",
+                &[&member_id, &value],
             )
             .await?;
+        if affected == 0 {
+            anyhow::bail!("member {member_id} not found");
+        }
         Ok(())
     }
 }
@@ -127,5 +183,7 @@ fn map_member(row: Row) -> MemberRecord {
         name: row.get(3),
         creation_time: row.get(4),
         deleted: row.get(5),
+        is_super_admin: row.get(6),
+        suspended: row.get(7),
     }
 }

--- a/crates/orchestrator/src/storage/members.rs
+++ b/crates/orchestrator/src/storage/members.rs
@@ -124,6 +124,19 @@ impl Storage {
     /// a read-then-write, so two concurrent revokes cannot both observe a
     /// count of 2 and both succeed.
     pub async fn set_super_admin(&self, member_id: i64, value: bool) -> anyhow::Result<()> {
+        // Revoking from someone who is not an operator is a no-op, not a
+        // last-operator violation. Without this the guard below fires for
+        // any revoke while exactly one operator exists — even when the
+        // target is a different, non-operator member — and reports a reason
+        // that is simply untrue.
+        if !value {
+            let current = self.get_member(member_id).await?;
+            match current {
+                Some(m) if !m.is_super_admin => return Ok(()),
+                Some(_) => {},
+                None => anyhow::bail!("member {member_id} not found"),
+            }
+        }
         let conn = self.pool().acquire().await?;
         let affected = if value {
             conn.client()

--- a/crates/orchestrator/src/storage/migrations.rs
+++ b/crates/orchestrator/src/storage/migrations.rs
@@ -107,5 +107,32 @@ pub async fn run(pool: &PgPool) -> anyhow::Result<()> {
             "#,
         )
         .await?;
+    // P1 admin-console migration. `is_super_admin` is the runtime authority
+    // for instance-wide operators (ADMIN_EMAILS only seeds it at sign-in).
+    // `suspended` is a reversible block, distinct from the permanent
+    // `deleted`. Both default FALSE so every existing row is unaffected.
+    //
+    // The audit change makes `team_id` nullable so instance-scoped events
+    // have somewhere to live. Existing per-team queries filter on
+    // `team_id = $1` and so continue to exclude them without modification.
+    //
+    // The `CHECK (scope IN ('team','instance'))` in schema.rs applies only to
+    // fresh inits, matching the convention already used for `storage_mode`
+    // above; orchestrator-side code is what enforces the invariant on
+    // ALTERed databases.
+    conn.client()
+        .batch_execute(
+            r#"
+            ALTER TABLE members
+              ADD COLUMN IF NOT EXISTS is_super_admin BOOLEAN NOT NULL DEFAULT FALSE,
+              ADD COLUMN IF NOT EXISTS suspended BOOLEAN NOT NULL DEFAULT FALSE;
+            ALTER TABLE audit_log_events
+              ALTER COLUMN team_id DROP NOT NULL,
+              ADD COLUMN IF NOT EXISTS scope TEXT NOT NULL DEFAULT 'team';
+            CREATE INDEX IF NOT EXISTS audit_instance_time_idx
+              ON audit_log_events(creation_time) WHERE scope = 'instance';
+            "#,
+        )
+        .await?;
     Ok(())
 }

--- a/crates/orchestrator/src/storage/mod.rs
+++ b/crates/orchestrator/src/storage/mod.rs
@@ -8,9 +8,11 @@ pub mod deployments;
 mod env_vars;
 mod invitations;
 mod members;
-mod migrations;
+// `pub` so the integration suite can run migrations against a throwaway
+// database without going through `Storage::connect`.
+pub mod migrations;
 mod opt_ins;
-mod pool;
+pub mod pool;
 mod projects;
 mod schema;
 mod teams;
@@ -25,6 +27,7 @@ pub use self::{
     audit_log::{
         AuditEntry,
         AuditQuery,
+        InstanceAuditEntry,
     },
     acme::{
         AcmeAccountRecord,

--- a/crates/orchestrator/src/storage/mod.rs
+++ b/crates/orchestrator/src/storage/mod.rs
@@ -25,19 +25,20 @@ pub use self::{
         AccessToken,
         AccessTokenKind,
     },
+    acme::{
+        AcmeAccountRecord,
+        StoredCertificate,
+    },
     admin::{
         AdminDeploymentRow,
         AdminMemberRow,
+        AdminTeamCounts,
         MemberTeamRef,
     },
     audit_log::{
         AuditEntry,
         AuditQuery,
         InstanceAuditEntry,
-    },
-    acme::{
-        AcmeAccountRecord,
-        StoredCertificate,
     },
     custom_domains::{
         CustomDomainRecord,

--- a/crates/orchestrator/src/storage/mod.rs
+++ b/crates/orchestrator/src/storage/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod access_tokens;
 mod acme;
+mod admin;
 mod audit_log;
 mod custom_domains;
 pub mod deployments;
@@ -23,6 +24,11 @@ pub use self::{
     access_tokens::{
         AccessToken,
         AccessTokenKind,
+    },
+    admin::{
+        AdminDeploymentRow,
+        AdminMemberRow,
+        MemberTeamRef,
     },
     audit_log::{
         AuditEntry,

--- a/crates/orchestrator/src/storage/schema.rs
+++ b/crates/orchestrator/src/storage/schema.rs
@@ -14,7 +14,14 @@ CREATE TABLE IF NOT EXISTS members (
     primary_email TEXT NOT NULL,
     name TEXT,
     creation_time BIGINT NOT NULL,
-    deleted BOOLEAN NOT NULL DEFAULT FALSE
+    deleted BOOLEAN NOT NULL DEFAULT FALSE,
+    -- Instance-wide operator. Seeded from ADMIN_EMAILS at first sign-in;
+    -- after that this column is the authority, so revoking an operator
+    -- does not require a redeploy.
+    is_super_admin BOOLEAN NOT NULL DEFAULT FALSE,
+    -- Reversible block: the member cannot authenticate, but their teams,
+    -- projects, and audit history stay intact. Distinct from `deleted`.
+    suspended BOOLEAN NOT NULL DEFAULT FALSE
 );
 CREATE INDEX IF NOT EXISTS members_auth_user_idx ON members(auth_user_id);
 CREATE INDEX IF NOT EXISTS members_email_idx ON members(primary_email);
@@ -115,13 +122,17 @@ CREATE TABLE IF NOT EXISTS default_env_vars (
 
 CREATE TABLE IF NOT EXISTS audit_log_events (
     id BIGSERIAL PRIMARY KEY,
-    team_id BIGINT NOT NULL REFERENCES teams(id) ON DELETE CASCADE,
+    -- NULL for instance-scoped events, which belong to no single team.
+    team_id BIGINT REFERENCES teams(id) ON DELETE CASCADE,
     member_id BIGINT REFERENCES members(id) ON DELETE SET NULL,
     action TEXT NOT NULL,
     metadata JSONB NOT NULL,
-    creation_time BIGINT NOT NULL
+    creation_time BIGINT NOT NULL,
+    scope TEXT NOT NULL DEFAULT 'team' CHECK (scope IN ('team','instance'))
 );
 CREATE INDEX IF NOT EXISTS audit_team_time_idx ON audit_log_events(team_id, creation_time);
+CREATE INDEX IF NOT EXISTS audit_instance_time_idx
+    ON audit_log_events(creation_time) WHERE scope = 'instance';
 
 CREATE TABLE IF NOT EXISTS opt_ins (
     member_id BIGINT NOT NULL REFERENCES members(id) ON DELETE CASCADE,

--- a/crates/orchestrator/src/storage/teams.rs
+++ b/crates/orchestrator/src/storage/teams.rs
@@ -83,10 +83,7 @@ impl Storage {
         Ok(row.map(map_team))
     }
 
-    pub async fn get_team_by_slug(
-        &self,
-        slug: &str,
-    ) -> anyhow::Result<Option<TeamRecord>> {
+    pub async fn get_team_by_slug(&self, slug: &str) -> anyhow::Result<Option<TeamRecord>> {
         let conn = self.pool().acquire().await?;
         let row = conn
             .client()
@@ -99,10 +96,7 @@ impl Storage {
         Ok(row.map(map_team))
     }
 
-    pub async fn list_teams_for_member(
-        &self,
-        member_id: i64,
-    ) -> anyhow::Result<Vec<TeamRecord>> {
+    pub async fn list_teams_for_member(&self, member_id: i64) -> anyhow::Result<Vec<TeamRecord>> {
         let conn = self.pool().acquire().await?;
         let rows = conn
             .client()
@@ -127,18 +121,12 @@ impl Storage {
         let conn = self.pool().acquire().await?;
         if let Some(name) = name {
             conn.client()
-                .execute(
-                    "UPDATE teams SET name = $1 WHERE id = $2",
-                    &[&name, &id],
-                )
+                .execute("UPDATE teams SET name = $1 WHERE id = $2", &[&name, &id])
                 .await?;
         }
         if let Some(slug) = slug {
             conn.client()
-                .execute(
-                    "UPDATE teams SET slug = $1 WHERE id = $2",
-                    &[&slug, &id],
-                )
+                .execute("UPDATE teams SET slug = $1 WHERE id = $2", &[&slug, &id])
                 .await?;
         }
         Ok(())
@@ -152,10 +140,7 @@ impl Storage {
         Ok(())
     }
 
-    pub async fn list_team_members(
-        &self,
-        team_id: i64,
-    ) -> anyhow::Result<Vec<TeamMemberRecord>> {
+    pub async fn list_team_members(&self, team_id: i64) -> anyhow::Result<Vec<TeamMemberRecord>> {
         let conn = self.pool().acquire().await?;
         let rows = conn
             .client()
@@ -169,10 +154,7 @@ impl Storage {
             .map(|r| TeamMemberRecord {
                 team_id: r.get(0),
                 member_id: r.get(1),
-                role: r
-                    .get::<_, String>(2)
-                    .parse()
-                    .unwrap_or(TeamRole::Developer),
+                role: r.get::<_, String>(2).parse().unwrap_or(TeamRole::Developer),
             })
             .collect())
     }
@@ -194,11 +176,7 @@ impl Storage {
         Ok(())
     }
 
-    pub async fn remove_team_member(
-        &self,
-        team_id: i64,
-        member_id: i64,
-    ) -> anyhow::Result<()> {
+    pub async fn remove_team_member(&self, team_id: i64, member_id: i64) -> anyhow::Result<()> {
         let conn = self.pool().acquire().await?;
         conn.client()
             .execute(
@@ -222,12 +200,11 @@ impl Storage {
                 &[&team_id, &member_id],
             )
             .await?;
-        Ok(row
-            .and_then(|r| r.get::<_, String>(0).parse().ok()))
+        Ok(row.and_then(|r| r.get::<_, String>(0).parse().ok()))
     }
 }
 
-fn map_team(row: Row) -> TeamRecord {
+pub(super) fn map_team(row: Row) -> TeamRecord {
     TeamRecord {
         id: row.get(0),
         name: row.get(1),

--- a/crates/orchestrator/tests/cross_tenant.rs
+++ b/crates/orchestrator/tests/cross_tenant.rs
@@ -238,6 +238,7 @@ fn test_config(database_url: String, data_root: std::path::PathBuf) -> Orchestra
         traefik_cert_dir: "/dynamic".into(),
         acme_contact_email: None,
         acme_directory_url: None,
+        reconcile_interval_secs: 0,
     }
 }
 

--- a/crates/orchestrator/tests/integration.rs
+++ b/crates/orchestrator/tests/integration.rs
@@ -4,10 +4,10 @@
 //! `docs/superpowers/specs/2026-05-02-convex-orchestrator-plan.md`:
 //!
 //! 1. **Default-run, no DB.** Asserts that the public Management API surface
-//!    (`/v1/...`) advertised by `--print-openapi` matches the wire contract
-//!    the dashboard's typed clients and `crates/big_brain_client` already
-//!    expect, and round-trips the load-bearing deployment-internal DTOs
-//!    through `serde_json` against their upstream definitions in
+//!    (`/v1/...`) advertised by `--print-openapi` matches the wire contract the
+//!    dashboard's typed clients and `crates/big_brain_client` already expect,
+//!    and round-trips the load-bearing deployment-internal DTOs through
+//!    `serde_json` against their upstream definitions in
 //!    `big_brain_private_api_types`.
 //!
 //! 2. **`#[ignore]`-gated, requires `TEST_ORCHESTRATOR_DATABASE_URL`.** Spins
@@ -62,7 +62,10 @@ const EXPECTED_MANAGEMENT_OPERATIONS: &[(&str, &str)] = &[
     ("get", "/v1/projects/{project_id}/list_deployments"),
     ("post", "/v1/projects/{project_id}/create_deployment"),
     ("get", "/v1/projects/{project_id}/deployment"),
-    ("get", "/v1/teams/{team_id_or_slug}/projects/{project_slug}/deployment"),
+    (
+        "get",
+        "/v1/teams/{team_id_or_slug}/projects/{project_slug}/deployment",
+    ),
     ("get", "/v1/teams/{team_id}/list_deployments"),
     ("get", "/v1/teams/{team_id}/list_local_deployments"),
     ("get", "/v1/teams/{team_id}/list_deployment_classes"),
@@ -74,15 +77,21 @@ const EXPECTED_MANAGEMENT_OPERATIONS: &[(&str, &str)] = &[
     ("patch", "/v1/deployments/{deployment_name}/settings"),
     ("post", "/v1/deployments/{deployment_name}/restart"),
     // env vars
-    ("get", "/v1/projects/{project_id}/list_default_environment_variables"),
-    ("post", "/v1/projects/{project_id}/update_default_environment_variables"),
+    (
+        "get",
+        "/v1/projects/{project_id}/list_default_environment_variables",
+    ),
+    (
+        "post",
+        "/v1/projects/{project_id}/update_default_environment_variables",
+    ),
 ];
 
 #[test]
 fn openapi_exposes_all_management_endpoints() {
     use utoipa::OpenApi;
-    let spec = serde_json::to_value(OrchestratorOpenApi::openapi())
-        .expect("serialize openapi spec");
+    let spec =
+        serde_json::to_value(OrchestratorOpenApi::openapi()).expect("serialize openapi spec");
     let paths = spec
         .get("paths")
         .and_then(|p| p.as_object())
@@ -105,8 +114,8 @@ fn openapi_exposes_all_management_endpoints() {
 #[test]
 fn openapi_does_not_expose_undocumented_management_endpoints() {
     use utoipa::OpenApi;
-    let spec = serde_json::to_value(OrchestratorOpenApi::openapi())
-        .expect("serialize openapi spec");
+    let spec =
+        serde_json::to_value(OrchestratorOpenApi::openapi()).expect("serialize openapi spec");
     let paths = spec
         .get("paths")
         .and_then(|p| p.as_object())
@@ -140,8 +149,8 @@ fn openapi_does_not_expose_undocumented_management_endpoints() {
     }
     assert!(
         extra.is_empty(),
-        "OpenAPI spec advertises /v1 operations not in the documented contract \
-         (add them to EXPECTED_MANAGEMENT_OPERATIONS):\n  {}",
+        "OpenAPI spec advertises /v1 operations not in the documented contract (add them to \
+         EXPECTED_MANAGEMENT_OPERATIONS):\n  {}",
         extra.join("\n  ")
     );
 }
@@ -159,10 +168,7 @@ fn deployment_internal_dto_wire_format() {
         UrlForKeyResponse,
     };
 
-    let v = serde_json::to_value(HasProjectsResponse {
-        has_projects: true,
-    })
-    .unwrap();
+    let v = serde_json::to_value(HasProjectsResponse { has_projects: true }).unwrap();
     assert_eq!(v, serde_json::json!({"hasProjects": true}));
 
     let v = serde_json::to_value(TeamSummary {
@@ -206,7 +212,10 @@ fn deployment_internal_dto_wire_format() {
         deploy_key: "prod:happy-otter-1|secret".into(),
     })
     .unwrap();
-    assert_eq!(v, serde_json::json!({"deployKey": "prod:happy-otter-1|secret"}));
+    assert_eq!(
+        v,
+        serde_json::json!({"deployKey": "prod:happy-otter-1|secret"})
+    );
 
     let v = serde_json::to_value(UrlForKeyResponse {
         url: "http://happy-otter-1.localhost:9000".into(),
@@ -241,7 +250,10 @@ fn deployment_auth_response_is_byte_identical_to_upstream() {
 
     let a = serde_json::to_value(&via_upstream).unwrap();
     let b = serde_json::to_value(&via_exported).unwrap();
-    assert_eq!(a, b, "DeploymentAuthResponse re-export drifted from upstream");
+    assert_eq!(
+        a, b,
+        "DeploymentAuthResponse re-export drifted from upstream"
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -303,15 +315,17 @@ async fn deployment_internal_flow_against_real_db() {
         router::build_router,
         state::OrchestratorState,
     };
-    use orchestrator_api_types::dashboard::{
-        DeviceAuthorizeArgs,
-        DeviceAuthorizeResponse,
-    };
-    use orchestrator_api_types::deployment::{
-        CreateProjectArgs,
-        CreateProjectResponse,
-        HasProjectsResponse,
-        TeamSummary,
+    use orchestrator_api_types::{
+        dashboard::{
+            DeviceAuthorizeArgs,
+            DeviceAuthorizeResponse,
+        },
+        deployment::{
+            CreateProjectArgs,
+            CreateProjectResponse,
+            HasProjectsResponse,
+            TeamSummary,
+        },
     };
     use tower::ServiceExt;
 
@@ -354,7 +368,9 @@ async fn deployment_internal_flow_against_real_db() {
 
     // Construct OrchestratorState the public way, then swap in the stub
     // provisioner so we can exercise create_deployment without docker.
-    let mut state = OrchestratorState::new(config).await.expect("orchestrator state");
+    let mut state = OrchestratorState::new(config)
+        .await
+        .expect("orchestrator state");
     state.provisioner = Arc::new(StubProvisioner);
 
     let app = build_router(state.clone());
@@ -399,8 +415,7 @@ async fn deployment_internal_flow_against_real_db() {
         .expect("send /api/teams");
     assert_eq!(resp.status(), StatusCode::OK, "GET /api/teams");
     let body = resp.into_body().collect().await.unwrap().to_bytes();
-    let teams: Vec<TeamSummary> =
-        serde_json::from_slice(&body).expect("Vec<TeamSummary> shape");
+    let teams: Vec<TeamSummary> = serde_json::from_slice(&body).expect("Vec<TeamSummary> shape");
     assert!(!teams.is_empty(), "bootstrap team should be present");
     let team_slug = teams[0].slug.clone();
 
@@ -419,8 +434,7 @@ async fn deployment_internal_flow_against_real_db() {
         .expect("send /api/has_projects");
     assert_eq!(resp.status(), StatusCode::OK);
     let body = resp.into_body().collect().await.unwrap().to_bytes();
-    let _: HasProjectsResponse =
-        serde_json::from_slice(&body).expect("HasProjectsResponse shape");
+    let _: HasProjectsResponse = serde_json::from_slice(&body).expect("HasProjectsResponse shape");
 
     // 3. POST /api/create_project → CreateProjectResponse.
     let create_args = CreateProjectArgs {
@@ -467,7 +481,10 @@ async fn deployment_internal_flow_against_real_db() {
     assert_eq!(resp.status(), StatusCode::OK);
     let body = resp.into_body().collect().await.unwrap().to_bytes();
     let after: HasProjectsResponse = serde_json::from_slice(&body).unwrap();
-    assert!(after.has_projects, "has_projects should be true after create");
+    assert!(
+        after.has_projects,
+        "has_projects should be true after create"
+    );
 }
 
 #[tokio::test]
@@ -489,9 +506,7 @@ async fn allowlist_rejects_uninvited_non_admin_session_exchange() {
     .await;
     let app = orchestrator::router::build_router(state);
 
-    let resp = exchange_session(&app, "stranger@example.com", None)
-        .await
-        .0;
+    let resp = exchange_session(&app, "stranger@example.com", None).await.0;
 
     assert_eq!(resp, StatusCode::FORBIDDEN);
 }
@@ -615,10 +630,10 @@ async fn non_members_cannot_list_team_invite_codes() {
 // Authorization on the access-token routes.
 //
 // These routes used to take `_auth: AuthIdentity` and discard it, which
-// authenticated the caller but never authorized them. `create_team_access_token`
-// took no identity at all — and `team_id` is a sequential BIGSERIAL, so anyone
-// who could reach the API could mint a team-wide token by guessing a small
-// integer.
+// authenticated the caller but never authorized them.
+// `create_team_access_token` took no identity at all — and `team_id` is a
+// sequential BIGSERIAL, so anyone who could reach the API could mint a
+// team-wide token by guessing a small integer.
 // ---------------------------------------------------------------------------
 
 #[tokio::test]
@@ -788,7 +803,10 @@ async fn a_member_cannot_revoke_another_members_personal_access_token() {
         .await
         .expect("load token")
         .expect("token row exists");
-    assert!(revoked.revoked_time.is_some(), "own revoke must take effect");
+    assert!(
+        revoked.revoked_time.is_some(),
+        "own revoke must take effect"
+    );
 }
 
 #[tokio::test]
@@ -1042,11 +1060,7 @@ async fn post_without_auth(
 }
 
 #[cfg(test)]
-async fn get_with_bearer(
-    app: &axum::Router,
-    uri: &str,
-    token: &str,
-) -> axum::http::StatusCode {
+async fn get_with_bearer(app: &axum::Router, uri: &str, token: &str) -> axum::http::StatusCode {
     use axum::{
         body::Body,
         http::{
@@ -1088,4 +1102,317 @@ async fn reset_public_schema(database_url: &str) {
         .batch_execute("DROP SCHEMA IF EXISTS public CASCADE; CREATE SCHEMA public;")
         .await
         .expect("reset public schema");
+}
+
+// ---------------------------------------------------------------------------
+// Admin console, Phase 1
+// ---------------------------------------------------------------------------
+
+/// The P1 migration must add the super-admin/suspension columns and make
+/// audit events instance-scopable. Asserts against `information_schema` so
+/// it fails loudly if a later migration drops one.
+#[tokio::test]
+#[ignore = "needs TEST_ORCHESTRATOR_DATABASE_URL"]
+async fn p1_migration_adds_admin_columns() {
+    let database_url = std::env::var("TEST_ORCHESTRATOR_DATABASE_URL")
+        .expect("TEST_ORCHESTRATOR_DATABASE_URL not set (this test is `#[ignore]` by default)");
+    reset_public_schema(&database_url).await;
+
+    let pool = orchestrator::storage::pool::PgPool::connect(&database_url)
+        .await
+        .expect("connect test pool");
+    orchestrator::storage::migrations::run(&pool)
+        .await
+        .expect("run migrations");
+
+    let conn = pool.acquire().await.expect("acquire");
+    let rows = conn
+        .client()
+        .query(
+            "SELECT table_name, column_name, is_nullable
+               FROM information_schema.columns
+              WHERE table_schema = 'public'
+                AND (   (table_name = 'members' AND column_name IN ('is_super_admin','suspended'))
+                     OR (table_name = 'audit_log_events' AND column_name IN ('scope','team_id')))",
+            &[],
+        )
+        .await
+        .expect("query information_schema");
+
+    let found: Vec<(String, String, String)> = rows
+        .iter()
+        .map(|r| (r.get(0), r.get(1), r.get(2)))
+        .collect();
+
+    assert!(
+        found
+            .iter()
+            .any(|(t, c, _)| t == "members" && c == "is_super_admin"),
+        "members.is_super_admin missing: {found:?}"
+    );
+    assert!(
+        found
+            .iter()
+            .any(|(t, c, _)| t == "members" && c == "suspended"),
+        "members.suspended missing: {found:?}"
+    );
+    assert!(
+        found
+            .iter()
+            .any(|(t, c, _)| t == "audit_log_events" && c == "scope"),
+        "audit_log_events.scope missing: {found:?}"
+    );
+    assert!(
+        found
+            .iter()
+            .any(|(t, c, n)| t == "audit_log_events" && c == "team_id" && n == "YES"),
+        "audit_log_events.team_id must be nullable: {found:?}"
+    );
+
+    // Idempotence: running migrations twice must not error.
+    orchestrator::storage::migrations::run(&pool)
+        .await
+        .expect("migrations are idempotent");
+}
+
+/// `set_super_admin` must refuse to clear the last remaining super-admin,
+/// and must do so atomically rather than as a read-then-write.
+#[tokio::test]
+#[ignore = "needs TEST_ORCHESTRATOR_DATABASE_URL"]
+async fn cannot_revoke_last_super_admin() {
+    let database_url = std::env::var("TEST_ORCHESTRATOR_DATABASE_URL")
+        .expect("TEST_ORCHESTRATOR_DATABASE_URL not set (this test is `#[ignore]` by default)");
+    reset_public_schema(&database_url).await;
+
+    let storage = orchestrator::storage::Storage::connect(&database_url)
+        .await
+        .expect("connect storage");
+
+    let a = storage
+        .upsert_member("auth-a", "a@example.com", Some("A"))
+        .await
+        .expect("member a");
+    let b = storage
+        .upsert_member("auth-b", "b@example.com", Some("B"))
+        .await
+        .expect("member b");
+
+    storage.set_super_admin(a.id, true).await.expect("grant a");
+    storage.set_super_admin(b.id, true).await.expect("grant b");
+
+    // Two admins: revoking one is fine.
+    storage
+        .set_super_admin(b.id, false)
+        .await
+        .expect("revoke b");
+
+    // One admin left: revoking is refused.
+    let err = storage
+        .set_super_admin(a.id, false)
+        .await
+        .expect_err("revoking the last super-admin must fail");
+    assert!(
+        err.to_string().contains("last super-admin"),
+        "unexpected error: {err}"
+    );
+
+    let reloaded = storage
+        .get_member(a.id)
+        .await
+        .expect("get a")
+        .expect("a exists");
+    assert!(reloaded.is_super_admin, "a must still be a super-admin");
+    assert!(!reloaded.suspended, "suspension defaults to false");
+}
+
+/// Elevation must ride only `Session` and `Pat` tokens, and a suspended
+/// member must stop authenticating entirely.
+///
+/// The ineligible case is exercised with a `Team` token rather than a deploy
+/// key because both sit in the same `matches!` arm in `resolve_with_storage`
+/// and a team token needs no deployment row to construct. The deploy-key
+/// kinds are the reason the gate exists - a key checked into CI must not be
+/// an instance-wide credential - so a dedicated deploy-key case is still
+/// worth adding once the fixtures for one are cheap.
+#[tokio::test]
+#[ignore = "needs TEST_ORCHESTRATOR_DATABASE_URL"]
+async fn elevation_is_limited_to_session_and_pat_tokens() {
+    use orchestrator::storage::{
+        access_tokens::NewAccessToken,
+        AccessTokenKind,
+    };
+
+    let database_url = std::env::var("TEST_ORCHESTRATOR_DATABASE_URL")
+        .expect("TEST_ORCHESTRATOR_DATABASE_URL not set (this test is `#[ignore]` by default)");
+    reset_public_schema(&database_url).await;
+
+    let storage = orchestrator::storage::Storage::connect(&database_url)
+        .await
+        .expect("connect storage");
+    let member = storage
+        .upsert_member("auth-admin", "admin@example.com", Some("Admin"))
+        .await
+        .expect("member");
+    let team = storage
+        .create_team("Ops", "ops", Some(member.id))
+        .await
+        .expect("team");
+    storage
+        .set_super_admin(member.id, true)
+        .await
+        .expect("grant");
+
+    // A PAT for that member elevates.
+    let pat_secret = "pat-secret-for-test";
+    storage
+        .create_access_token(NewAccessToken {
+            public_id: "pat-public",
+            kind: AccessTokenKind::Pat,
+            member_id: Some(member.id),
+            team_id: None,
+            project_id: None,
+            deployment_id: None,
+            name: "test-pat",
+            secret_hash: &orchestrator::auth::tokens::sha256_hex(pat_secret),
+            secret_suffix: "test",
+            expiry: None,
+        })
+        .await
+        .expect("create pat");
+
+    let identity = orchestrator::auth::identity::resolve_for_test(
+        &storage,
+        &format!("pat:pat-public|{pat_secret}"),
+    )
+    .await
+    .expect("resolve pat");
+    assert!(
+        identity.is_super_admin,
+        "a PAT for a super-admin must elevate"
+    );
+    assert!(
+        !identity.is_bootstrap,
+        "an ordinary member is not the bootstrap identity"
+    );
+
+    // A team token for the same member does not.
+    let team_secret = "team-secret-for-test";
+    storage
+        .create_access_token(NewAccessToken {
+            public_id: "team-public",
+            kind: AccessTokenKind::Team,
+            member_id: Some(member.id),
+            team_id: Some(team.id),
+            project_id: None,
+            deployment_id: None,
+            name: "test-team-token",
+            secret_hash: &orchestrator::auth::tokens::sha256_hex(team_secret),
+            secret_suffix: "test",
+            expiry: None,
+        })
+        .await
+        .expect("create team token");
+
+    let identity = orchestrator::auth::identity::resolve_for_test(
+        &storage,
+        &format!("team:team-public|{team_secret}"),
+    )
+    .await
+    .expect("resolve team token");
+    assert!(
+        !identity.is_super_admin,
+        "a non-session/PAT token must never elevate, even for an operator"
+    );
+
+    // A suspended member's token stops resolving entirely.
+    storage
+        .set_member_suspended(member.id, true)
+        .await
+        .expect("suspend");
+    let err = orchestrator::auth::identity::resolve_for_test(
+        &storage,
+        &format!("pat:pat-public|{pat_secret}"),
+    )
+    .await
+    .expect_err("a suspended member must not authenticate");
+    assert!(
+        matches!(err, orchestrator::errors::ApiError::Unauthorized),
+        "expected Unauthorized, got {err:?}"
+    );
+}
+
+/// Instance-scoped audit events must not leak into per-team audit queries,
+/// and team-scoped queries must be unaffected by team_id becoming nullable.
+#[tokio::test]
+#[ignore = "needs TEST_ORCHESTRATOR_DATABASE_URL"]
+async fn instance_audit_events_are_isolated_from_team_queries() {
+    use orchestrator::storage::AuditQuery;
+
+    let database_url = std::env::var("TEST_ORCHESTRATOR_DATABASE_URL")
+        .expect("TEST_ORCHESTRATOR_DATABASE_URL not set (this test is `#[ignore]` by default)");
+    reset_public_schema(&database_url).await;
+
+    let storage = orchestrator::storage::Storage::connect(&database_url)
+        .await
+        .expect("connect storage");
+    let member = storage
+        .upsert_member("auth-op", "op@example.com", Some("Op"))
+        .await
+        .expect("member");
+    let team = storage
+        .create_team("Test Team", "test-team", Some(member.id))
+        .await
+        .expect("team");
+
+    storage
+        .append_audit(
+            team.id,
+            Some(member.id),
+            "teamThing",
+            &serde_json::json!({ "k": "v" }),
+        )
+        .await
+        .expect("team event");
+    storage
+        .append_instance_audit(
+            Some(member.id),
+            "instanceThing",
+            &serde_json::json!({ "k": "v" }),
+        )
+        .await
+        .expect("instance event");
+    // Break-glass events carry no member attribution.
+    storage
+        .append_instance_audit(None, "bootstrapThing", &serde_json::json!({}))
+        .await
+        .expect("bootstrap event");
+
+    let team_events = storage
+        .query_audit(&AuditQuery {
+            team_id: team.id,
+            ..Default::default()
+        })
+        .await
+        .expect("query team audit");
+    assert_eq!(
+        team_events.len(),
+        1,
+        "team query must see only its own event, got {team_events:?}"
+    );
+    assert_eq!(team_events[0].action, "teamThing");
+
+    let instance_events = storage
+        .list_instance_audit(100)
+        .await
+        .expect("list instance audit");
+    assert_eq!(
+        instance_events.len(),
+        2,
+        "instance query sees only instance events"
+    );
+    // Newest first.
+    assert_eq!(instance_events[0].action, "bootstrapThing");
+    assert_eq!(instance_events[0].member_id, None);
+    assert_eq!(instance_events[1].action, "instanceThing");
+    assert_eq!(instance_events[1].member_id, Some(member.id));
 }

--- a/crates/orchestrator/tests/integration.rs
+++ b/crates/orchestrator/tests/integration.rs
@@ -307,11 +307,6 @@ async fn deployment_internal_flow_against_real_db() {
     };
     use http_body_util::BodyExt;
     use orchestrator::{
-        config::{
-            OrchestratorConfig,
-            ProvisionerMode,
-            RegistrationMode,
-        },
         router::build_router,
         state::OrchestratorState,
     };
@@ -338,33 +333,8 @@ async fn deployment_internal_flow_against_real_db() {
     reset_public_schema(&database_url).await;
 
     let data_root = tempfile::tempdir().expect("tempdir for data root");
-    let config = OrchestratorConfig {
-        database_url,
-        data_root: data_root.path().to_path_buf(),
-        public_origin: "http://localhost".into(),
-        bootstrap_token: Some(bootstrap_token.clone()),
-        provisioner_mode: ProvisionerMode::External,
-        service_key: None,
-        admin_emails: Vec::new(),
-        default_team_name: "Self-Hosted".into(),
-        registration_mode: RegistrationMode::Allowlist,
-        backend_image: "irrelevant".into(),
-        backend_network: None,
-        backend_container_prefix: "test-".into(),
-        router_host: "localhost".into(),
-        site_router_host: None,
-        router_public_port: 9000,
-        router_public_scheme: "http".into(),
-        direct_backend_routing: true,
-        enable_sidecars: false,
-        postgres_image: "postgres:16-alpine".into(),
-        minio_image: "quay.io/minio/minio:latest".into(),
-        traefik_dynamic_dir: None,
-        orchestrator_upstream: "orchestrator:8050".into(),
-        traefik_cert_dir: "/dynamic".into(),
-        acme_contact_email: None,
-        acme_directory_url: None,
-    };
+    let mut config = test_config(database_url, data_root.path().to_path_buf());
+    config.bootstrap_token = Some(bootstrap_token.clone());
 
     // Construct OrchestratorState the public way, then swap in the stub
     // provisioner so we can exercise create_deployment without docker.
@@ -873,32 +843,36 @@ fn uuid_like() -> String {
     format!("{nanos:032x}")
 }
 
+/// Build a config for tests.
+///
+/// The single place a new `OrchestratorConfig` field has to be added, rather
+/// than every test growing its own struct literal. Callers that need a
+/// different value mutate the returned struct.
+///
+/// Defaults are deliberately inert: `External` provisioner so nothing tries
+/// to reach docker, and `reconcile_interval_secs: 0` so no test starts a
+/// background loop that outlives it.
 #[cfg(test)]
-async fn test_state(
+fn test_config(
     database_url: String,
-    registration_mode: orchestrator::config::RegistrationMode,
-    admin_emails: Vec<String>,
-    service_key: &str,
-) -> orchestrator::state::OrchestratorState {
-    use orchestrator::{
-        config::{
-            OrchestratorConfig,
-            ProvisionerMode,
-        },
-        state::OrchestratorState,
+    data_root: std::path::PathBuf,
+) -> orchestrator::config::OrchestratorConfig {
+    use orchestrator::config::{
+        OrchestratorConfig,
+        ProvisionerMode,
+        RegistrationMode,
     };
 
-    let data_root = tempfile::tempdir().expect("tempdir for data root");
-    let config = OrchestratorConfig {
+    OrchestratorConfig {
         database_url,
-        data_root: data_root.path().to_path_buf(),
+        data_root,
         public_origin: "http://localhost".into(),
         bootstrap_token: None,
         provisioner_mode: ProvisionerMode::External,
-        service_key: Some(service_key.into()),
-        admin_emails,
+        service_key: None,
+        admin_emails: Vec::new(),
         default_team_name: "Self-Hosted".into(),
-        registration_mode,
+        registration_mode: RegistrationMode::Allowlist,
         backend_image: "irrelevant".into(),
         backend_network: None,
         backend_container_prefix: "test-".into(),
@@ -915,7 +889,24 @@ async fn test_state(
         traefik_cert_dir: "/dynamic".into(),
         acme_contact_email: None,
         acme_directory_url: None,
-    };
+        reconcile_interval_secs: 0,
+    }
+}
+
+#[cfg(test)]
+async fn test_state(
+    database_url: String,
+    registration_mode: orchestrator::config::RegistrationMode,
+    admin_emails: Vec<String>,
+    service_key: &str,
+) -> orchestrator::state::OrchestratorState {
+    use orchestrator::state::OrchestratorState;
+
+    let data_root = tempfile::tempdir().expect("tempdir for data root");
+    let mut config = test_config(database_url, data_root.path().to_path_buf());
+    config.service_key = Some(service_key.into());
+    config.admin_emails = admin_emails;
+    config.registration_mode = registration_mode;
 
     OrchestratorState::new(config)
         .await
@@ -1415,4 +1406,87 @@ async fn instance_audit_events_are_isolated_from_team_queries() {
     assert_eq!(instance_events[0].member_id, None);
     assert_eq!(instance_events[1].action, "instanceThing");
     assert_eq!(instance_events[1].member_id, Some(member.id));
+}
+
+/// The readiness response must actually differ by probe result.
+///
+/// Asserts on the pure mapping rather than end to end, because a `PgPool`
+/// cannot be constructed against a dead host - `connect` probes and fails -
+/// so there is no way to hold a live state whose database is down.
+#[test]
+fn ready_response_maps_probe_result_to_status() {
+    use axum::http::StatusCode;
+
+    let (status, body) = orchestrator::router::ready_response(true);
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body.0["status"], "ready");
+
+    let (status, body) = orchestrator::router::ready_response(false);
+    assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+    assert_eq!(body.0["status"], "not_ready");
+    assert!(
+        body.0.get("error").is_none(),
+        "the unauthenticated readiness body must not carry error detail"
+    );
+}
+
+/// `0` means boot-only, anything positive means keep going.
+#[test]
+fn reconcile_interval_zero_disables_the_loop() {
+    assert!(
+        !orchestrator::reconcile::periodic_enabled(0),
+        "0 must disable the periodic loop"
+    );
+    assert!(
+        orchestrator::reconcile::periodic_enabled(60),
+        "a positive interval must enable it"
+    );
+}
+
+/// `/health` is liveness and must never depend on Postgres. `/ready` is
+/// readiness and must. Both answer 200 against a live database; the
+/// distinction between them is asserted by
+/// `ready_response_maps_probe_result_to_status`, which does not need one.
+#[tokio::test]
+#[ignore = "needs TEST_ORCHESTRATOR_DATABASE_URL"]
+async fn health_and_ready_both_answer_against_a_live_database() {
+    use std::sync::Arc;
+
+    use axum::{
+        body::Body,
+        http::{
+            Request,
+            StatusCode,
+        },
+    };
+    use orchestrator::{
+        router::build_router,
+        state::OrchestratorState,
+    };
+    use tower::ServiceExt;
+
+    let database_url = std::env::var("TEST_ORCHESTRATOR_DATABASE_URL")
+        .expect("TEST_ORCHESTRATOR_DATABASE_URL not set (this test is `#[ignore]` by default)");
+    reset_public_schema(&database_url).await;
+
+    let data_root = tempfile::tempdir().expect("tempdir for data root");
+    let config = test_config(database_url, data_root.path().to_path_buf());
+    let mut state = OrchestratorState::new(config).await.expect("state");
+    state.provisioner = Arc::new(StubProvisioner);
+    let app = build_router(state.clone());
+
+    for path in ["/health", "/ready"] {
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri(path)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap_or_else(|_| panic!("send GET {path}"));
+        assert_eq!(resp.status(), StatusCode::OK, "GET {path} with a live DB");
+    }
 }

--- a/crates/orchestrator/tests/integration.rs
+++ b/crates/orchestrator/tests/integration.rs
@@ -1490,3 +1490,302 @@ async fn health_and_ready_both_answer_against_a_live_database() {
         assert_eq!(resp.status(), StatusCode::OK, "GET {path} with a live DB");
     }
 }
+
+/// Drift is "the container is not doing what the database says". The
+/// load-bearing case is intended=running, actual=missing.
+#[test]
+fn drift_is_intended_versus_actual() {
+    use orchestrator::routes::admin::fleet::is_drifted;
+
+    // The case that matters: the DB says it should be up, it is gone.
+    assert!(is_drifted("running", "missing"));
+    assert!(is_drifted("running", "stopped"));
+
+    // Agreement in either direction is not drift.
+    assert!(!is_drifted("running", "running"));
+    assert!(!is_drifted("paused", "missing"));
+    assert!(!is_drifted("disabled", "stopped"));
+
+    // Should be down but is up is also drift.
+    assert!(is_drifted("paused", "running"));
+
+    // A probe we could not run is never drift.
+    assert!(!is_drifted("running", "unknown"));
+    assert!(!is_drifted("paused", "unknown"));
+}
+
+/// The admin surface must see across team boundaries - that is the entire
+/// point. Two teams with one member each; the admin queries return both.
+#[tokio::test]
+#[ignore = "needs TEST_ORCHESTRATOR_DATABASE_URL"]
+async fn admin_queries_span_all_teams() {
+    let database_url = std::env::var("TEST_ORCHESTRATOR_DATABASE_URL")
+        .expect("TEST_ORCHESTRATOR_DATABASE_URL not set (this test is `#[ignore]` by default)");
+    reset_public_schema(&database_url).await;
+
+    let storage = orchestrator::storage::Storage::connect(&database_url)
+        .await
+        .expect("connect storage");
+
+    let alice = storage
+        .upsert_member("auth-alice", "alice@example.com", Some("Alice"))
+        .await
+        .expect("alice");
+    let bob = storage
+        .upsert_member("auth-bob", "bob@example.com", Some("Bob"))
+        .await
+        .expect("bob");
+    // A member on no team at all: the LEFT JOIN still emits a row for them,
+    // and they must come back with an empty `teams` rather than being
+    // dropped or inheriting somebody else's.
+    let _carol = storage
+        .upsert_member("auth-carol", "carol@example.com", None)
+        .await
+        .expect("carol");
+
+    let t1 = storage
+        .create_team("One", "one", Some(alice.id))
+        .await
+        .expect("team one");
+    let t2 = storage
+        .create_team("Two", "two", Some(bob.id))
+        .await
+        .expect("team two");
+    storage
+        .add_team_member(t1.id, alice.id, orchestrator::storage::TeamRole::Admin)
+        .await
+        .expect("alice in one");
+    storage
+        .add_team_member(t2.id, bob.id, orchestrator::storage::TeamRole::Developer)
+        .await
+        .expect("bob in two");
+    // Alice is on both teams, so her row must carry two memberships.
+    storage
+        .add_team_member(t2.id, alice.id, orchestrator::storage::TeamRole::Developer)
+        .await
+        .expect("alice in two");
+
+    let teams = storage.list_all_teams().await.expect("all teams");
+    assert_eq!(teams.len(), 2, "must see both teams");
+
+    let members = storage.list_all_members().await.expect("all members");
+    assert_eq!(members.len(), 3, "must see all three members");
+
+    let alice_row = members
+        .iter()
+        .find(|m| m.primary_email == "alice@example.com")
+        .expect("alice present");
+    assert_eq!(alice_row.teams.len(), 2, "alice is on two teams");
+    assert_eq!(alice_row.teams[0].team_slug, "one");
+    assert_eq!(alice_row.teams[0].role, "admin");
+    assert_eq!(alice_row.teams[1].team_slug, "two");
+    assert_eq!(alice_row.teams[1].role, "developer");
+
+    let carol_row = members
+        .iter()
+        .find(|m| m.primary_email == "carol@example.com")
+        .expect("carol present");
+    assert!(
+        carol_row.teams.is_empty(),
+        "a member on no team must have no memberships, got {:?}",
+        carol_row.teams
+    );
+}
+
+/// Every `/api/admin` route must reject a non-super-admin identity.
+///
+/// Driven off `ADMIN_ROUTES` rather than a hand-maintained list here, so a
+/// route added without a `SuperAdmin` extractor fails this test instead of
+/// shipping open.
+#[tokio::test]
+#[ignore = "needs TEST_ORCHESTRATOR_DATABASE_URL"]
+async fn every_admin_route_rejects_non_super_admins() {
+    use std::sync::Arc;
+
+    use axum::{
+        body::Body,
+        http::{
+            header::AUTHORIZATION,
+            Request,
+            StatusCode,
+        },
+    };
+    use orchestrator::{
+        router::build_router,
+        routes::admin::ADMIN_ROUTES,
+        state::OrchestratorState,
+        storage::{
+            access_tokens::NewAccessToken,
+            AccessTokenKind,
+        },
+    };
+    use tower::ServiceExt;
+
+    let database_url = std::env::var("TEST_ORCHESTRATOR_DATABASE_URL")
+        .expect("TEST_ORCHESTRATOR_DATABASE_URL not set (this test is `#[ignore]` by default)");
+    reset_public_schema(&database_url).await;
+
+    let data_root = tempfile::tempdir().expect("tempdir for data root");
+    let config = test_config(database_url, data_root.path().to_path_buf());
+    let mut state = OrchestratorState::new(config).await.expect("state");
+    state.provisioner = Arc::new(StubProvisioner);
+    let app = build_router(state.clone());
+
+    // An ordinary member with an ordinary PAT.
+    let plain = state
+        .storage
+        .upsert_member("auth-plain", "plain@example.com", Some("Plain"))
+        .await
+        .expect("plain member");
+    let plain_secret = "plain-secret";
+    state
+        .storage
+        .create_access_token(NewAccessToken {
+            public_id: "plain-public",
+            kind: AccessTokenKind::Pat,
+            member_id: Some(plain.id),
+            team_id: None,
+            project_id: None,
+            deployment_id: None,
+            name: "plain-pat",
+            secret_hash: &orchestrator::auth::tokens::sha256_hex(plain_secret),
+            secret_suffix: "cret",
+            expiry: None,
+        })
+        .await
+        .expect("plain pat");
+    let plain_bearer = format!("Bearer pat:plain-public|{plain_secret}");
+
+    assert!(!ADMIN_ROUTES.is_empty(), "ADMIN_ROUTES must not be empty");
+
+    for (method, path) in ADMIN_ROUTES {
+        // Unauthenticated.
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method(*method)
+                    .uri(*path)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap_or_else(|_| panic!("send {method} {path}"));
+        assert_eq!(
+            resp.status(),
+            StatusCode::UNAUTHORIZED,
+            "{method} {path} must be 401 without a token"
+        );
+
+        // Authenticated but not a super-admin.
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method(*method)
+                    .uri(*path)
+                    .header(AUTHORIZATION, &plain_bearer)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap_or_else(|_| panic!("send {method} {path} as plain member"));
+        assert_eq!(
+            resp.status(),
+            StatusCode::FORBIDDEN,
+            "{method} {path} must be 403 for a non-super-admin"
+        );
+    }
+
+    // Granting the bit opens every route.
+    state
+        .storage
+        .set_super_admin(plain.id, true)
+        .await
+        .expect("grant");
+    for (method, path) in ADMIN_ROUTES {
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method(*method)
+                    .uri(*path)
+                    .header(AUTHORIZATION, &plain_bearer)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap_or_else(|_| panic!("send {method} {path} as super-admin"));
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "{method} {path} must be 200 for a super-admin"
+        );
+    }
+}
+
+/// The route table and the router must not drift apart. `ADMIN_ROUTES` is
+/// what the authorization test iterates, so a route present in one and not
+/// the other is a hole rather than a cosmetic mismatch.
+#[test]
+fn admin_route_table_matches_the_openapi_surface() {
+    use orchestrator::{
+        router::OrchestratorOpenApi,
+        routes::admin::ADMIN_ROUTES,
+    };
+    use utoipa::OpenApi;
+
+    let spec =
+        serde_json::to_value(OrchestratorOpenApi::openapi()).expect("serialize openapi spec");
+    let paths = spec
+        .get("paths")
+        .and_then(|p| p.as_object())
+        .expect("openapi spec has a `paths` object");
+
+    // Every documented /api/admin operation is in the table.
+    let mut undocumented_in_table = Vec::new();
+    for (path, item) in paths {
+        if !path.starts_with("/api/admin/") {
+            continue;
+        }
+        let item = item.as_object().expect("path item must be an object");
+        for method in item.keys() {
+            if !matches!(
+                method.as_str(),
+                "get" | "post" | "put" | "patch" | "delete" | "head" | "options" | "trace"
+            ) {
+                continue;
+            }
+            let wanted = (method.to_uppercase(), path.to_string());
+            if !ADMIN_ROUTES
+                .iter()
+                .any(|(m, p)| *m == wanted.0 && *p == wanted.1)
+            {
+                undocumented_in_table.push(format!("{} {}", wanted.0, wanted.1));
+            }
+        }
+    }
+    assert!(
+        undocumented_in_table.is_empty(),
+        "these /api/admin operations are routed but missing from ADMIN_ROUTES, so the \
+         authorization test does not cover them:\n  {}",
+        undocumented_in_table.join("\n  ")
+    );
+
+    // And every table entry is actually documented.
+    let mut missing_from_spec = Vec::new();
+    for (method, path) in ADMIN_ROUTES {
+        let found = paths
+            .get(*path)
+            .and_then(|item| item.get(method.to_lowercase()))
+            .is_some();
+        if !found {
+            missing_from_spec.push(format!("{method} {path}"));
+        }
+    }
+    assert!(
+        missing_from_spec.is_empty(),
+        "these ADMIN_ROUTES entries are not in the OpenAPI spec:\n  {}",
+        missing_from_spec.join("\n  ")
+    );
+}

--- a/crates/orchestrator/tests/integration.rs
+++ b/crates/orchestrator/tests/integration.rs
@@ -1789,3 +1789,174 @@ fn admin_route_table_matches_the_openapi_surface() {
         missing_from_spec.join("\n  ")
     );
 }
+
+/// The fleet response's wire shape must match what `adminApi.ts`'s zod
+/// schema parses.
+///
+/// `FleetEntry` puts `#[serde(flatten)]` on its `AdminDeploymentRow`, so the
+/// deployment's fields have to land as flat camelCase siblings of
+/// `actualState` and `drifted`. If serde nested them under a `deployment`
+/// key instead, every fleet request would fail zod parsing in the browser
+/// and no status-code assertion would notice.
+#[tokio::test]
+#[ignore = "needs TEST_ORCHESTRATOR_DATABASE_URL"]
+async fn fleet_response_wire_shape_is_flat_camel_case() {
+    use std::sync::Arc;
+
+    use axum::{
+        body::Body,
+        http::{
+            header::AUTHORIZATION,
+            Request,
+            StatusCode,
+        },
+    };
+    use http_body_util::BodyExt;
+    use orchestrator::{
+        router::build_router,
+        state::OrchestratorState,
+        storage::{
+            access_tokens::NewAccessToken,
+            AccessTokenKind,
+        },
+    };
+    use tower::ServiceExt;
+
+    let database_url = std::env::var("TEST_ORCHESTRATOR_DATABASE_URL")
+        .expect("TEST_ORCHESTRATOR_DATABASE_URL not set (this test is `#[ignore]` by default)");
+    reset_public_schema(&database_url).await;
+
+    let data_root = tempfile::tempdir().expect("tempdir for data root");
+    let config = test_config(database_url, data_root.path().to_path_buf());
+    let mut state = OrchestratorState::new(config).await.expect("state");
+    state.provisioner = Arc::new(StubProvisioner);
+    let app = build_router(state.clone());
+
+    let op = state
+        .storage
+        .upsert_member("auth-op", "op@example.com", Some("Op"))
+        .await
+        .expect("member");
+    state
+        .storage
+        .set_super_admin(op.id, true)
+        .await
+        .expect("grant");
+    let secret = "fleet-secret";
+    state
+        .storage
+        .create_access_token(NewAccessToken {
+            public_id: "fleet-public",
+            kind: AccessTokenKind::Pat,
+            member_id: Some(op.id),
+            team_id: None,
+            project_id: None,
+            deployment_id: None,
+            name: "fleet-pat",
+            secret_hash: &orchestrator::auth::tokens::sha256_hex(secret),
+            secret_suffix: "cret",
+            expiry: None,
+        })
+        .await
+        .expect("pat");
+
+    // A team, project, and deployment so the fleet has a row to serialize.
+    let team = state
+        .storage
+        .create_team("Ops", "ops", Some(op.id))
+        .await
+        .expect("team");
+    let project = state
+        .storage
+        .create_project(team.id, "Demo", "demo", false)
+        .await
+        .expect("project");
+    let empty_knobs = serde_json::json!({});
+    state
+        .storage
+        .create_deployment(orchestrator::storage::deployments::NewDeployment {
+            project_id: project.id,
+            name: "happy-otter-123",
+            deployment_type: orchestrator::storage::DeploymentType::Prod,
+            deployment_class: orchestrator::storage::DeploymentClass::Standard,
+            region: None,
+            url: "http://happy-otter-123.localhost",
+            site_url: "http://happy-otter-123-site.localhost",
+            backend_pid: None,
+            backend_port: 3210,
+            creator_id: Some(op.id),
+            preview_identifier: None,
+            instance_secret: "",
+            tier: "S16",
+            knob_overrides: &empty_knobs,
+            storage_mode: "volume-sqlite",
+            pg_password: None,
+            minio_root_user: None,
+            minio_root_password: None,
+            backend_instance_secret: None,
+        })
+        .await
+        .expect("deployment");
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/api/admin/fleet")
+                .header(AUTHORIZATION, format!("Bearer pat:fleet-public|{secret}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .expect("send GET /api/admin/fleet");
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let body = resp.into_body().collect().await.unwrap().to_bytes();
+    let v: serde_json::Value = serde_json::from_slice(&body).expect("fleet response is JSON");
+
+    assert!(
+        v.get("containerStatesAvailable").is_some(),
+        "top level must be camelCase, got {v}"
+    );
+    let entry = v
+        .get("deployments")
+        .and_then(|d| d.get(0))
+        .unwrap_or_else(|| panic!("expected one fleet entry, got {v}"));
+
+    assert!(
+        entry.get("deployment").is_none(),
+        "the deployment must be flattened, not nested under `deployment`: {entry}"
+    );
+
+    // Exactly the keys `fleetEntrySchema` in adminApi.ts declares.
+    for key in [
+        "id",
+        "name",
+        "deploymentType",
+        "intendedState",
+        "tier",
+        "url",
+        "creationTime",
+        "teamId",
+        "teamSlug",
+        "projectId",
+        "projectSlug",
+        "actualState",
+        "drifted",
+    ] {
+        assert!(
+            entry.get(key).is_some(),
+            "fleet entry is missing `{key}`, which adminApi.ts requires: {entry}"
+        );
+    }
+
+    assert_eq!(entry["name"], "happy-otter-123");
+    assert_eq!(entry["teamSlug"], "ops");
+    assert_eq!(entry["projectSlug"], "demo");
+    // External provisioner owns no containers, so state is unknown and
+    // nothing is reported as drifted.
+    assert_eq!(entry["actualState"], "unknown");
+    assert_eq!(entry["drifted"], false);
+    assert_eq!(v["containerStatesAvailable"], false);
+    assert_eq!(v["driftCount"], 0);
+}

--- a/crates/orchestrator/tests/integration.rs
+++ b/crates/orchestrator/tests/integration.rs
@@ -1599,10 +1599,21 @@ async fn admin_queries_span_all_teams() {
 /// super-admin pass must reach the handler rather than bouncing off a path
 /// parse error, or it proves nothing about the gate.
 #[cfg(test)]
-fn concrete_admin_route(template: &str, deployment_id: i64) -> (String, Option<serde_json::Value>) {
-    let path = template.replace("{deployment_id}", &deployment_id.to_string());
+fn concrete_admin_route(
+    template: &str,
+    deployment_id: i64,
+    member_id: i64,
+) -> (String, Option<serde_json::Value>) {
+    let path = template
+        .replace("{deployment_id}", &deployment_id.to_string())
+        .replace("{member_id}", &member_id.to_string());
     let body = if template.ends_with("/tier") {
         Some(serde_json::json!({ "tier": "S16" }))
+    } else if template.ends_with("/super_admin") {
+        // Grant rather than revoke: revoking would trip the
+        // last-super-admin guard against the very account this test
+        // authenticates as.
+        Some(serde_json::json!({ "grant": true }))
     } else {
         None
     };
@@ -1678,7 +1689,7 @@ async fn every_admin_route_rejects_non_super_admins() {
     for (method, path) in ADMIN_ROUTES {
         // Any id will do here: authorization is checked before the handler
         // ever looks the deployment up.
-        let (concrete, _) = concrete_admin_route(path, 1);
+        let (concrete, _) = concrete_admin_route(path, 1, 1);
         // Unauthenticated.
         let resp = app
             .clone()
@@ -1771,7 +1782,21 @@ async fn every_admin_route_rejects_non_super_admins() {
             .await
             .expect("fixture deployment");
 
-        let (concrete, body) = concrete_admin_route(path, d.id);
+        // A throwaway member per route, for the same reason as the
+        // deployment: `/members/{id}/delete` removes the one it is given.
+        // Never the authenticated operator — deleting them mid-loop would
+        // fail every later route with a 401.
+        let victim = state
+            .storage
+            .upsert_member(
+                &format!("auth-fixture-{i}"),
+                &format!("fixture{i}@example.com"),
+                Some("Fixture"),
+            )
+            .await
+            .expect("fixture member");
+
+        let (concrete, body) = concrete_admin_route(path, d.id, victim.id);
         let mut req = Request::builder()
             .method(*method)
             .uri(&concrete)
@@ -2174,5 +2199,152 @@ fn pause_and_resume_touch_containers_in_dependency_order() {
         up,
         down.iter().rev().cloned().collect::<Vec<_>>(),
         "resume must be the exact reverse of pause"
+    );
+}
+
+/// Revoking the last super-admin must be a 409 the console can explain, not
+/// a 500.
+///
+/// The storage guard already refuses; this asserts the route maps that
+/// refusal to something a human can act on. A 500 tells the operator
+/// nothing and reads as a bug in the console.
+#[tokio::test]
+#[ignore = "needs TEST_ORCHESTRATOR_DATABASE_URL"]
+async fn revoking_the_last_super_admin_is_a_client_error() {
+    use std::sync::Arc;
+
+    use axum::{
+        body::Body,
+        http::{
+            header::AUTHORIZATION,
+            Request,
+            StatusCode,
+        },
+    };
+    use http_body_util::BodyExt;
+    use orchestrator::{
+        router::build_router,
+        state::OrchestratorState,
+        storage::{
+            access_tokens::NewAccessToken,
+            AccessTokenKind,
+        },
+    };
+    use tower::ServiceExt;
+
+    let database_url = std::env::var("TEST_ORCHESTRATOR_DATABASE_URL")
+        .expect("TEST_ORCHESTRATOR_DATABASE_URL not set (this test is `#[ignore]` by default)");
+    reset_public_schema(&database_url).await;
+
+    let data_root = tempfile::tempdir().expect("tempdir");
+    let config = test_config(database_url, data_root.path().to_path_buf());
+    let mut state = OrchestratorState::new(config).await.expect("state");
+    state.provisioner = Arc::new(StubProvisioner);
+    let app = build_router(state.clone());
+
+    let op = state
+        .storage
+        .upsert_member("auth-op", "op@example.com", Some("Op"))
+        .await
+        .expect("member");
+    state
+        .storage
+        .set_super_admin(op.id, true)
+        .await
+        .expect("grant");
+
+    let secret = "op-secret";
+    state
+        .storage
+        .create_access_token(NewAccessToken {
+            public_id: "op-public",
+            kind: AccessTokenKind::Pat,
+            member_id: Some(op.id),
+            team_id: None,
+            project_id: None,
+            deployment_id: None,
+            name: "op-pat",
+            secret_hash: &orchestrator::auth::tokens::sha256_hex(secret),
+            secret_suffix: "cret",
+            expiry: None,
+        })
+        .await
+        .expect("pat");
+    let bearer = format!("Bearer pat:op-public|{secret}");
+
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/api/admin/members/{}/super_admin", op.id))
+                .header(AUTHORIZATION, &bearer)
+                .header("content-type", "application/json")
+                .body(Body::from(r#"{"grant":false}"#))
+                .unwrap(),
+        )
+        .await
+        .expect("send revoke");
+    assert_eq!(
+        resp.status(),
+        StatusCode::CONFLICT,
+        "revoking the last super-admin must be 409, not 500"
+    );
+    let body = resp.into_body().collect().await.unwrap().to_bytes();
+    let v: serde_json::Value = serde_json::from_slice(&body).expect("json body");
+    assert!(
+        v["message"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("last super-admin"),
+        "the error must say why, got {v}"
+    );
+
+    // The bit must survive the refused revoke.
+    let reloaded = state
+        .storage
+        .get_member(op.id)
+        .await
+        .expect("get")
+        .expect("exists");
+    assert!(reloaded.is_super_admin);
+
+    // With a second operator, the revoke succeeds.
+    let other = state
+        .storage
+        .upsert_member("auth-two", "two@example.com", Some("Two"))
+        .await
+        .expect("member two");
+    state
+        .storage
+        .set_super_admin(other.id, true)
+        .await
+        .expect("grant two");
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/api/admin/members/{}/super_admin", other.id))
+                .header(AUTHORIZATION, &bearer)
+                .header("content-type", "application/json")
+                .body(Body::from(r#"{"grant":false}"#))
+                .unwrap(),
+        )
+        .await
+        .expect("send second revoke");
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    // And it is recorded, because changing who can operate the instance is
+    // exactly the kind of thing an audit log exists for.
+    let events = state
+        .storage
+        .list_instance_audit(10)
+        .await
+        .expect("instance audit");
+    assert!(
+        events.iter().any(|e| e.action == "superAdminRevoked"),
+        "the revoke must be audited, got {:?}",
+        events.iter().map(|e| &e.action).collect::<Vec<_>>()
     );
 }

--- a/crates/orchestrator/tests/integration.rs
+++ b/crates/orchestrator/tests/integration.rs
@@ -1592,6 +1592,23 @@ async fn admin_queries_span_all_teams() {
     );
 }
 
+/// Turn an `ADMIN_ROUTES` template into a concrete path plus a body.
+///
+/// The lifecycle routes are `POST`s with `{deployment_id}` in the path and,
+/// for `tier`, a required body. The 401/403 assertions do not care, but the
+/// super-admin pass must reach the handler rather than bouncing off a path
+/// parse error, or it proves nothing about the gate.
+#[cfg(test)]
+fn concrete_admin_route(template: &str, deployment_id: i64) -> (String, Option<serde_json::Value>) {
+    let path = template.replace("{deployment_id}", &deployment_id.to_string());
+    let body = if template.ends_with("/tier") {
+        Some(serde_json::json!({ "tier": "S16" }))
+    } else {
+        None
+    };
+    (path, body)
+}
+
 /// Every `/api/admin` route must reject a non-super-admin identity.
 ///
 /// Driven off `ADMIN_ROUTES` rather than a hand-maintained list here, so a
@@ -1659,13 +1676,16 @@ async fn every_admin_route_rejects_non_super_admins() {
     assert!(!ADMIN_ROUTES.is_empty(), "ADMIN_ROUTES must not be empty");
 
     for (method, path) in ADMIN_ROUTES {
+        // Any id will do here: authorization is checked before the handler
+        // ever looks the deployment up.
+        let (concrete, _) = concrete_admin_route(path, 1);
         // Unauthenticated.
         let resp = app
             .clone()
             .oneshot(
                 Request::builder()
                     .method(*method)
-                    .uri(*path)
+                    .uri(&concrete)
                     .body(Body::empty())
                     .unwrap(),
             )
@@ -1683,7 +1703,7 @@ async fn every_admin_route_rejects_non_super_admins() {
             .oneshot(
                 Request::builder()
                     .method(*method)
-                    .uri(*path)
+                    .uri(&concrete)
                     .header(AUTHORIZATION, &plain_bearer)
                     .body(Body::empty())
                     .unwrap(),
@@ -1703,17 +1723,69 @@ async fn every_admin_route_rejects_non_super_admins() {
         .set_super_admin(plain.id, true)
         .await
         .expect("grant");
-    for (method, path) in ADMIN_ROUTES {
+    // A team and project to hang the per-route deployments off.
+    let team = state
+        .storage
+        .create_team("Fixture", "fixture", Some(plain.id))
+        .await
+        .expect("team");
+    state
+        .storage
+        .add_team_member(team.id, plain.id, orchestrator::storage::TeamRole::Admin)
+        .await
+        .expect("membership");
+    let project = state
+        .storage
+        .create_project(team.id, "Fixture", "fixture", false)
+        .await
+        .expect("project");
+
+    for (i, (method, path)) in ADMIN_ROUTES.iter().enumerate() {
+        // A fresh deployment per route: `delete` removes the one it is given,
+        // and every later route would then 404 and fail for the wrong reason.
+        let empty = serde_json::json!({});
+        let name = format!("fixture-deployment-{i}");
+        let d = state
+            .storage
+            .create_deployment(orchestrator::storage::deployments::NewDeployment {
+                project_id: project.id,
+                name: &name,
+                deployment_type: orchestrator::storage::DeploymentType::Prod,
+                deployment_class: orchestrator::storage::DeploymentClass::Standard,
+                region: None,
+                url: &format!("http://{name}.localhost"),
+                site_url: &format!("http://{name}-site.localhost"),
+                backend_pid: None,
+                backend_port: 3210 + i as i64,
+                creator_id: Some(plain.id),
+                preview_identifier: None,
+                instance_secret: "",
+                tier: "S16",
+                knob_overrides: &empty,
+                storage_mode: "volume-sqlite",
+                pg_password: None,
+                minio_root_user: None,
+                minio_root_password: None,
+                backend_instance_secret: None,
+            })
+            .await
+            .expect("fixture deployment");
+
+        let (concrete, body) = concrete_admin_route(path, d.id);
+        let mut req = Request::builder()
+            .method(*method)
+            .uri(&concrete)
+            .header(AUTHORIZATION, &plain_bearer);
+        let body = match body {
+            Some(v) => {
+                req = req.header("content-type", "application/json");
+                Body::from(serde_json::to_vec(&v).unwrap())
+            },
+            None => Body::empty(),
+        };
         let resp = app
             .clone()
-            .oneshot(
-                Request::builder()
-                    .method(*method)
-                    .uri(*path)
-                    .header(AUTHORIZATION, &plain_bearer)
-                    .body(Body::empty())
-                    .unwrap(),
-            )
+            .oneshot(req.body(body).unwrap())
             .await
             .unwrap_or_else(|_| panic!("send {method} {path} as super-admin"));
         assert_eq!(

--- a/crates/orchestrator/tests/integration.rs
+++ b/crates/orchestrator/tests/integration.rs
@@ -1609,6 +1609,8 @@ fn concrete_admin_route(
         .replace("{member_id}", &member_id.to_string());
     let body = if template.ends_with("/tier") {
         Some(serde_json::json!({ "tier": "S16" }))
+    } else if template.ends_with("/access") {
+        Some(serde_json::json!({ "reason": "route table coverage" }))
     } else if template.ends_with("/super_admin") {
         // Grant rather than revoke: revoking would trip the
         // last-super-admin guard against the very account this test
@@ -2346,5 +2348,206 @@ async fn revoking_the_last_super_admin_is_a_client_error() {
         events.iter().any(|e| e.action == "superAdminRevoked"),
         "the revoke must be audited, got {:?}",
         events.iter().map(|e| &e.action).collect::<Vec<_>>()
+    );
+}
+
+/// Break-glass must mint a fresh short-lived key and write the reason to
+/// BOTH audit logs — the instance's and the tenant's own.
+///
+/// The tenant-visible copy is the point of the whole design: an operator
+/// opening somebody's deployment should be visible to that somebody. An
+/// audit trail only the operator can read is not accountability.
+#[tokio::test]
+#[ignore = "needs TEST_ORCHESTRATOR_DATABASE_URL"]
+async fn break_glass_mints_a_fresh_key_and_writes_both_audit_logs() {
+    use std::sync::Arc;
+
+    use axum::{
+        body::Body,
+        http::{
+            header::AUTHORIZATION,
+            Request,
+            StatusCode,
+        },
+    };
+    use http_body_util::BodyExt;
+    use orchestrator::{
+        router::build_router,
+        state::OrchestratorState,
+        storage::{
+            access_tokens::NewAccessToken,
+            AccessTokenKind,
+            AuditQuery,
+        },
+    };
+    use tower::ServiceExt;
+
+    let database_url = std::env::var("TEST_ORCHESTRATOR_DATABASE_URL")
+        .expect("TEST_ORCHESTRATOR_DATABASE_URL not set (this test is `#[ignore]` by default)");
+    reset_public_schema(&database_url).await;
+
+    let data_root = tempfile::tempdir().expect("tempdir");
+    let config = test_config(database_url, data_root.path().to_path_buf());
+    let mut state = OrchestratorState::new(config).await.expect("state");
+    state.provisioner = Arc::new(StubProvisioner);
+    let app = build_router(state.clone());
+
+    // The operator.
+    let op = state
+        .storage
+        .upsert_member("auth-op", "op@example.com", Some("Op"))
+        .await
+        .expect("member");
+    state
+        .storage
+        .set_super_admin(op.id, true)
+        .await
+        .expect("grant");
+    let secret = "op-secret";
+    state
+        .storage
+        .create_access_token(NewAccessToken {
+            public_id: "op-public",
+            kind: AccessTokenKind::Pat,
+            member_id: Some(op.id),
+            team_id: None,
+            project_id: None,
+            deployment_id: None,
+            name: "op-pat",
+            secret_hash: &orchestrator::auth::tokens::sha256_hex(secret),
+            secret_suffix: "cret",
+            expiry: None,
+        })
+        .await
+        .expect("pat");
+    let bearer = format!("Bearer pat:op-public|{secret}");
+
+    // A tenant the operator has nothing to do with.
+    let tenant = state
+        .storage
+        .upsert_member("auth-tenant", "tenant@example.com", Some("Tenant"))
+        .await
+        .expect("tenant");
+    let team = state
+        .storage
+        .create_team("Tenant", "tenant", Some(tenant.id))
+        .await
+        .expect("team");
+    let project = state
+        .storage
+        .create_project(team.id, "App", "app", false)
+        .await
+        .expect("project");
+    let empty = serde_json::json!({});
+    let d = state
+        .storage
+        .create_deployment(orchestrator::storage::deployments::NewDeployment {
+            project_id: project.id,
+            name: "tenant-prod",
+            deployment_type: orchestrator::storage::DeploymentType::Prod,
+            deployment_class: orchestrator::storage::DeploymentClass::Standard,
+            region: None,
+            url: "http://tenant-prod.localhost",
+            site_url: "http://tenant-prod-site.localhost",
+            backend_pid: None,
+            backend_port: 3210,
+            creator_id: Some(tenant.id),
+            preview_identifier: None,
+            // A stored permanent admin key, which is what makes the
+            // "must not hand this back" assertion below meaningful.
+            instance_secret: "tenant-prod|permanent-admin-key",
+            tier: "S16",
+            knob_overrides: &empty,
+            storage_mode: "volume-sqlite",
+            pg_password: None,
+            minio_root_user: None,
+            minio_root_password: None,
+            backend_instance_secret: None,
+        })
+        .await
+        .expect("deployment");
+
+    // A blank reason is refused.
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/api/admin/deployments/{}/access", d.id))
+                .header(AUTHORIZATION, &bearer)
+                .header("content-type", "application/json")
+                .body(Body::from(r#"{"reason":"   "}"#))
+                .unwrap(),
+        )
+        .await
+        .expect("send blank reason");
+    assert_eq!(
+        resp.status(),
+        StatusCode::BAD_REQUEST,
+        "a whitespace-only reason must be refused"
+    );
+
+    // A real one succeeds.
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/api/admin/deployments/{}/access", d.id))
+                .header(AUTHORIZATION, &bearer)
+                .header("content-type", "application/json")
+                .body(Body::from(r#"{"reason":"investigating ticket 4711"}"#))
+                .unwrap(),
+        )
+        .await
+        .expect("send access");
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = resp.into_body().collect().await.unwrap().to_bytes();
+    let v: serde_json::Value = serde_json::from_slice(&body).expect("json");
+
+    let key = v["adminKey"].as_str().expect("adminKey");
+    assert_ne!(
+        key, "tenant-prod|permanent-admin-key",
+        "break-glass must not hand back the deployment's permanent admin key"
+    );
+    assert!(v["tenantNotified"].as_bool().unwrap_or(false));
+
+    // The TTL is real and short.
+    let expires_at = v["expiresAt"].as_i64().expect("expiresAt");
+    let ttl_ms = expires_at - orchestrator::time::now_unix_ms();
+    assert!(
+        ttl_ms > 0 && ttl_ms <= 15 * 60_000,
+        "break-glass TTL out of range: {ttl_ms}ms"
+    );
+
+    // Instance audit records it, with the reason verbatim.
+    let instance = state
+        .storage
+        .list_instance_audit(10)
+        .await
+        .expect("instance audit");
+    let granted = instance
+        .iter()
+        .find(|e| e.action == "deploymentAccessGranted")
+        .expect("instance audit records the access");
+    assert_eq!(granted.metadata["reason"], "investigating ticket 4711");
+    assert_eq!(granted.member_id, Some(op.id));
+
+    // ...and so does the tenant's own team audit log.
+    let team_events = state
+        .storage
+        .query_audit(&AuditQuery {
+            team_id: team.id,
+            ..Default::default()
+        })
+        .await
+        .expect("team audit");
+    let tenant_visible = team_events
+        .iter()
+        .find(|e| e.action == "deploymentAccessGranted")
+        .expect("the tenant must be able to see that an operator opened their deployment");
+    assert_eq!(
+        tenant_visible.metadata["reason"], "investigating ticket 4711",
+        "the tenant sees the reason too, not just that something happened"
     );
 }

--- a/crates/orchestrator/tests/integration.rs
+++ b/crates/orchestrator/tests/integration.rs
@@ -1603,12 +1603,21 @@ fn concrete_admin_route(
     template: &str,
     deployment_id: i64,
     member_id: i64,
+    team_id: i64,
+    unique: usize,
 ) -> (String, Option<serde_json::Value>) {
     let path = template
         .replace("{deployment_id}", &deployment_id.to_string())
-        .replace("{member_id}", &member_id.to_string());
+        .replace("{member_id}", &member_id.to_string())
+        .replace("{team_id}", &team_id.to_string());
     let body = if template.ends_with("/tier") {
         Some(serde_json::json!({ "tier": "S16" }))
+    } else if template == "/api/admin/teams" {
+        // Create needs a name; the slug must not collide with a team an
+        // earlier iteration already made.
+        Some(serde_json::json!({ "name": format!("Fixture {unique}") }))
+    } else if template.ends_with("/teams/{team_id}") {
+        Some(serde_json::json!({ "name": format!("Renamed {unique}") }))
     } else if template.ends_with("/access") {
         Some(serde_json::json!({ "reason": "route table coverage" }))
     } else if template.ends_with("/super_admin") {
@@ -1691,7 +1700,7 @@ async fn every_admin_route_rejects_non_super_admins() {
     for (method, path) in ADMIN_ROUTES {
         // Any id will do here: authorization is checked before the handler
         // ever looks the deployment up.
-        let (concrete, _) = concrete_admin_route(path, 1, 1);
+        let (concrete, _) = concrete_admin_route(path, 1, 1, 1, 0);
         // Unauthenticated.
         let resp = app
             .clone()
@@ -1798,7 +1807,15 @@ async fn every_admin_route_rejects_non_super_admins() {
             .await
             .expect("fixture member");
 
-        let (concrete, body) = concrete_admin_route(path, d.id, victim.id);
+        // A throwaway team per route as well: /teams/{id}/delete removes
+        // the one it is given, and it cascades to that team's projects.
+        let victim_team = state
+            .storage
+            .create_team(&format!("Victim {i}"), &format!("victim-team-{i}"), None)
+            .await
+            .expect("fixture team");
+
+        let (concrete, body) = concrete_admin_route(path, d.id, victim.id, victim_team.id, i);
         let mut req = Request::builder()
             .method(*method)
             .uri(&concrete)

--- a/crates/orchestrator/tests/integration.rs
+++ b/crates/orchestrator/tests/integration.rs
@@ -1960,3 +1960,147 @@ async fn fleet_response_wire_shape_is_flat_camel_case() {
     assert_eq!(v["containerStatesAvailable"], false);
     assert_eq!(v["driftCount"], 0);
 }
+
+/// Pausing and resuming must be idempotent, and must refuse a deployment
+/// that is still provisioning.
+///
+/// `reconcile::plan` treats `paused` as "not running by intent" and leaves
+/// it alone, so pausing a half-built deployment would strand it there
+/// permanently.
+#[tokio::test]
+#[ignore = "needs TEST_ORCHESTRATOR_DATABASE_URL"]
+async fn deployment_state_transitions_are_guarded() {
+    use orchestrator::storage::DeploymentState;
+
+    let database_url = std::env::var("TEST_ORCHESTRATOR_DATABASE_URL")
+        .expect("TEST_ORCHESTRATOR_DATABASE_URL not set (this test is `#[ignore]` by default)");
+    reset_public_schema(&database_url).await;
+    let storage = orchestrator::storage::Storage::connect(&database_url)
+        .await
+        .expect("connect storage");
+
+    let member = storage
+        .upsert_member("auth-op", "op@example.com", Some("Op"))
+        .await
+        .expect("member");
+    let team = storage
+        .create_team("Ops", "ops", Some(member.id))
+        .await
+        .expect("team");
+    let project = storage
+        .create_project(team.id, "Demo", "demo", false)
+        .await
+        .expect("project");
+    let empty = serde_json::json!({});
+    let d = storage
+        .create_deployment(orchestrator::storage::deployments::NewDeployment {
+            project_id: project.id,
+            name: "state-test",
+            deployment_type: orchestrator::storage::DeploymentType::Prod,
+            deployment_class: orchestrator::storage::DeploymentClass::Standard,
+            region: None,
+            url: "http://state-test.localhost",
+            site_url: "http://state-test-site.localhost",
+            backend_pid: None,
+            backend_port: 3210,
+            creator_id: Some(member.id),
+            preview_identifier: None,
+            instance_secret: "",
+            tier: "S16",
+            knob_overrides: &empty,
+            storage_mode: "volume-sqlite",
+            pg_password: None,
+            minio_root_user: None,
+            minio_root_password: None,
+            backend_instance_secret: None,
+        })
+        .await
+        .expect("deployment");
+
+    // running -> paused, and pausing again is a no-op rather than an error:
+    // an operator double-clicking Pause should not be shown a failure.
+    storage.pause_deployment(d.id).await.expect("pause");
+    storage
+        .pause_deployment(d.id)
+        .await
+        .expect("pause is idempotent");
+    let reloaded = storage
+        .get_deployment(d.id)
+        .await
+        .expect("get")
+        .expect("exists");
+    assert!(matches!(reloaded.state, DeploymentState::Paused));
+
+    storage.resume_deployment(d.id).await.expect("resume");
+    storage
+        .resume_deployment(d.id)
+        .await
+        .expect("resume is idempotent");
+    let reloaded = storage
+        .get_deployment(d.id)
+        .await
+        .expect("get")
+        .expect("exists");
+    assert!(matches!(reloaded.state, DeploymentState::Running));
+
+    // A deployment mid-provision must not be pausable.
+    storage
+        .update_deployment_state(d.id, DeploymentState::Provisioning)
+        .await
+        .expect("set provisioning");
+    let err = storage
+        .pause_deployment(d.id)
+        .await
+        .expect_err("pausing a provisioning deployment must fail");
+    assert!(
+        err.to_string().contains("provisioning"),
+        "the error must say why, got: {err}"
+    );
+
+    // A missing deployment is a clear error, not a silent no-op.
+    let err = storage
+        .pause_deployment(999_999)
+        .await
+        .expect_err("pausing a nonexistent deployment must fail");
+    assert!(
+        err.to_string().contains("not found"),
+        "unexpected error: {err}"
+    );
+}
+
+/// Which containers a pause has to touch, and in what order.
+///
+/// Pure so it is testable without a docker daemon — the shell-out around it
+/// is the only part this machine cannot exercise. Order matters: the backend
+/// stops before its sidecars so it never sees its database vanish
+/// mid-request, and starts after them so it never comes up without one.
+#[test]
+fn pause_and_resume_touch_containers_in_dependency_order() {
+    use orchestrator::provisioner::lifecycle::{
+        containers_for_pause,
+        containers_for_resume,
+    };
+
+    // volume-sqlite: the backend owns its own storage, so it is alone.
+    assert_eq!(
+        containers_for_pause("orch-", "happy-otter", "volume-sqlite"),
+        vec!["orch-happy-otter"]
+    );
+    assert_eq!(
+        containers_for_resume("orch-", "happy-otter", "volume-sqlite"),
+        vec!["orch-happy-otter"]
+    );
+
+    // sidecar: backend first on the way down, last on the way up.
+    let down = containers_for_pause("orch-", "happy-otter", "sidecar");
+    assert_eq!(down.first().map(String::as_str), Some("orch-happy-otter"));
+    assert_eq!(down.len(), 3, "backend + postgres + minio, got {down:?}");
+
+    let up = containers_for_resume("orch-", "happy-otter", "sidecar");
+    assert_eq!(up.last().map(String::as_str), Some("orch-happy-otter"));
+    assert_eq!(
+        up,
+        down.iter().rev().cloned().collect::<Vec<_>>(),
+        "resume must be the exact reverse of pause"
+    );
+}

--- a/npm-packages/dashboard-orchestrator/src/__tests__/adminAccess.test.tsx
+++ b/npm-packages/dashboard-orchestrator/src/__tests__/adminAccess.test.tsx
@@ -1,0 +1,74 @@
+import { render, screen } from "@testing-library/react";
+import { AdminLayout } from "../components/admin/AdminLayout";
+
+// `jest.spyOn` cannot redefine these exports — SWC compiles them to
+// non-configurable getters — so mock the module with a factory that reads
+// mutable state, matching the pattern in `loginSessionCache.test.tsx`.
+let mockIsSuperAdmin = false;
+let mockIsLoading = false;
+
+jest.mock("next/router", () => ({
+  useRouter: () => ({ pathname: "/admin", push: jest.fn() }),
+}));
+
+jest.mock("../lib/useOrchestratorToken", () => ({
+  useIsSuperAdmin: () => mockIsSuperAdmin,
+  useOrchestratorSession: () => ({ isLoading: mockIsLoading }),
+}));
+
+function mockSession({
+  isSuperAdmin,
+  isLoading,
+}: {
+  isSuperAdmin: boolean;
+  isLoading: boolean;
+}) {
+  mockIsSuperAdmin = isSuperAdmin;
+  mockIsLoading = isLoading;
+}
+
+describe("AdminLayout", () => {
+  afterEach(() => mockSession({ isSuperAdmin: false, isLoading: false }));
+
+  it("renders children for an operator", () => {
+    mockSession({ isSuperAdmin: true, isLoading: false });
+
+    render(
+      <AdminLayout title="Overview">
+        <p>admin content</p>
+      </AdminLayout>,
+    );
+    expect(screen.getByText("admin content")).toBeInTheDocument();
+    // The nav is what makes the section navigable; without it the layout is
+    // just a heading.
+    expect(
+      screen.getByRole("navigation", { name: /instance admin/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("refuses to render children for a non-operator", () => {
+    mockSession({ isSuperAdmin: false, isLoading: false });
+
+    render(
+      <AdminLayout title="Overview">
+        <p>admin content</p>
+      </AdminLayout>,
+    );
+    expect(screen.queryByText("admin content")).not.toBeInTheDocument();
+    expect(screen.getByText(/instance operators/i)).toBeInTheDocument();
+  });
+
+  it("shows nothing rather than a denial while the session loads", () => {
+    // The denial must not flash at an operator mid-navigation, so an
+    // unknown session renders neither branch.
+    mockSession({ isSuperAdmin: false, isLoading: true });
+
+    render(
+      <AdminLayout title="Overview">
+        <p>admin content</p>
+      </AdminLayout>,
+    );
+    expect(screen.queryByText("admin content")).not.toBeInTheDocument();
+    expect(screen.queryByText(/instance operators/i)).not.toBeInTheDocument();
+  });
+});

--- a/npm-packages/dashboard-orchestrator/src/__tests__/adminConfirm.test.tsx
+++ b/npm-packages/dashboard-orchestrator/src/__tests__/adminConfirm.test.tsx
@@ -1,0 +1,79 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { ConfirmByName } from "../components/admin/ConfirmByName";
+
+describe("ConfirmByName", () => {
+  function setup(overrides: Partial<Parameters<typeof ConfirmByName>[0]> = {}) {
+    const onConfirm = jest.fn();
+    const onCancel = jest.fn();
+    render(
+      <ConfirmByName
+        title="Delete deployment"
+        expected="happy-otter-123"
+        description="This is not recoverable."
+        confirmLabel="Delete permanently"
+        onConfirm={onConfirm}
+        onCancel={onCancel}
+        {...overrides}
+      />,
+    );
+    return {
+      onConfirm,
+      onCancel,
+      input: screen.getByLabelText(/type happy-otter-123 to confirm/i),
+      confirm: screen.getByRole("button", { name: /delete permanently/i }),
+    };
+  }
+
+  it("keeps confirm disabled until the name matches exactly", () => {
+    const { input, confirm, onConfirm } = setup();
+    expect(confirm).toBeDisabled();
+
+    fireEvent.change(input, { target: { value: "happy-otter" } });
+    expect(confirm).toBeDisabled();
+
+    fireEvent.change(input, { target: { value: "happy-otter-123" } });
+    expect(confirm).toBeEnabled();
+
+    fireEvent.click(confirm);
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not accept a near-miss", () => {
+    // Case and whitespace both count: the point of typing it is deliberate
+    // effort, and a fleet row's neighbours look almost identical.
+    const { input, confirm } = setup();
+    fireEvent.change(input, { target: { value: "Happy-Otter-123" } });
+    expect(confirm).toBeDisabled();
+    fireEvent.change(input, { target: { value: " happy-otter-123 " } });
+    expect(confirm).toBeDisabled();
+  });
+
+  it("stays disabled while an action is in flight", () => {
+    render(
+      <ConfirmByName
+        title="Delete deployment"
+        expected="happy-otter-123"
+        description="This is not recoverable."
+        confirmLabel="Delete permanently"
+        onConfirm={jest.fn()}
+        onCancel={jest.fn()}
+        busy
+      />,
+    );
+    // While busy the confirm button relabels itself, which is how the
+    // operator knows the click landed.
+    const confirm = screen.getByRole("button", { name: /working/i });
+    fireEvent.change(
+      screen.getByLabelText(/type happy-otter-123 to confirm/i),
+      { target: { value: "happy-otter-123" } },
+    );
+    expect(confirm).toBeDisabled();
+  });
+
+  it("cancels without confirming", () => {
+    const { onCancel, onConfirm } = setup();
+    fireEvent.click(screen.getByRole("button", { name: /cancel/i }));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+});

--- a/npm-packages/dashboard-orchestrator/src/__tests__/breakGlassModal.test.tsx
+++ b/npm-packages/dashboard-orchestrator/src/__tests__/breakGlassModal.test.tsx
@@ -1,0 +1,95 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { BreakGlassModal } from "../components/admin/BreakGlassModal";
+import type { BreakGlassGrant, FleetEntry } from "../lib/adminApi";
+
+const deployment: FleetEntry = {
+  id: 7,
+  name: "tenant-prod",
+  deploymentType: "prod",
+  intendedState: "running",
+  tier: "S16",
+  url: "http://tenant-prod.localhost",
+  creationTime: 0,
+  teamId: 1,
+  teamSlug: "acme",
+  projectId: 2,
+  projectSlug: "app",
+  actualState: "running",
+  drifted: false,
+};
+
+describe("BreakGlassModal", () => {
+  it("requires a reason before access can be granted", () => {
+    const onConfirm = jest.fn();
+    render(
+      <BreakGlassModal
+        deployment={deployment}
+        grant={null}
+        onConfirm={onConfirm}
+        onClose={jest.fn()}
+      />,
+    );
+
+    const grant = screen.getByRole("button", { name: /grant access/i });
+    expect(grant).toBeDisabled();
+
+    // Whitespace is not a reason.
+    fireEvent.change(screen.getByLabelText(/reason for access/i), {
+      target: { value: "   " },
+    });
+    expect(grant).toBeDisabled();
+
+    fireEvent.change(screen.getByLabelText(/reason for access/i), {
+      target: { value: "investigating ticket 4711" },
+    });
+    expect(grant).toBeEnabled();
+    fireEvent.click(grant);
+    expect(onConfirm).toHaveBeenCalledWith("investigating ticket 4711");
+  });
+
+  it("warns that the tenant will see this, before the operator commits", () => {
+    render(
+      <BreakGlassModal
+        deployment={deployment}
+        grant={null}
+        onConfirm={jest.fn()}
+        onClose={jest.fn()}
+      />,
+    );
+    // The whole accountability design rests on the operator knowing this
+    // going in rather than discovering it afterwards.
+    expect(
+      screen.getByText(/see this in their own audit log/i),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/acme/)).toBeInTheDocument();
+  });
+
+  it("shows the key once, with a countdown, after access is granted", () => {
+    const grant: BreakGlassGrant = {
+      deployment: "tenant-prod",
+      url: "http://tenant-prod.localhost",
+      adminKey: "prod:tenant-prod|secret-value",
+      expiresAt: Date.now() + 15 * 60_000,
+      tenantNotified: true,
+    };
+    render(
+      <BreakGlassModal
+        deployment={deployment}
+        grant={grant}
+        onConfirm={jest.fn()}
+        onClose={jest.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByText("prod:tenant-prod|secret-value"),
+    ).toBeInTheDocument();
+    // A countdown, so an operator with a dashboard open is not surprised
+    // when the key lapses mid-session.
+    expect(screen.getByText(/^1[0-5]:\d{2}$/)).toBeInTheDocument();
+    // The reason field is gone — this state is display-only.
+    expect(
+      screen.queryByLabelText(/reason for access/i),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/npm-packages/dashboard-orchestrator/src/components/OrchestratorHeader.tsx
+++ b/npm-packages/dashboard-orchestrator/src/components/OrchestratorHeader.tsx
@@ -31,7 +31,7 @@ import { Avatar } from "./Avatar";
 import { ConvexOrb } from "./ConvexOrb";
 import { CreateTeamModal } from "./CreateTeamModal";
 import { NavBar } from "./NavBar";
-import { useAccessToken } from "../lib/useOrchestratorToken";
+import { useAccessToken, useIsSuperAdmin } from "../lib/useOrchestratorToken";
 import { signOut, useSession } from "../lib/auth-client";
 import { orchestratorUrl } from "../lib/config";
 import {
@@ -695,6 +695,9 @@ function UserMenu({
   const user = session?.data?.user;
   const name = user?.name || user?.email || "?";
   const email = user?.email ?? "";
+  // Presentation only — /api/admin is gated server-side by the SuperAdmin
+  // extractor. This just avoids showing a link that would 403.
+  const isSuperAdmin = useIsSuperAdmin();
   return (
     <Menu
       buttonProps={{
@@ -765,6 +768,22 @@ function UserMenu({
               </MenuLink>
             </Tooltip>
           ) : null}
+        </>
+      ) : null}
+      {isSuperAdmin ? (
+        <>
+          <hr className="mx-4" />
+          <Tooltip
+            side="left"
+            tip="Instance-wide operator view: fleet health, all teams, all members."
+          >
+            <MenuLink href="/admin">
+              <div className="flex w-full items-center justify-between">
+                Instance Admin
+                <GearIcon className="text-content-secondary" />
+              </div>
+            </MenuLink>
+          </Tooltip>
         </>
       ) : null}
       <hr className="mx-4" />

--- a/npm-packages/dashboard-orchestrator/src/components/admin/AdminLayout.tsx
+++ b/npm-packages/dashboard-orchestrator/src/components/admin/AdminLayout.tsx
@@ -1,0 +1,78 @@
+// Shared chrome for the instance admin console.
+//
+// The guard here is presentation only. Every /api/admin route is gated by
+// the SuperAdmin extractor server-side; hiding the UI keeps a non-operator
+// from staring at a page of 403s, it is not the security boundary.
+
+import Link from "next/link";
+import { useRouter } from "next/router";
+import type { ReactNode } from "react";
+import {
+  useIsSuperAdmin,
+  useOrchestratorSession,
+} from "../../lib/useOrchestratorToken";
+
+const TABS = [
+  { href: "/admin", label: "Overview" },
+  { href: "/admin/deployments", label: "Deployments" },
+  { href: "/admin/members", label: "Members" },
+];
+
+export function AdminLayout({
+  title,
+  children,
+}: {
+  title: string;
+  children: ReactNode;
+}) {
+  const isSuperAdmin = useIsSuperAdmin();
+  const { isLoading } = useOrchestratorSession();
+  const router = useRouter();
+
+  // While the session is in flight we know nothing. Rendering the denial
+  // here would flash "not available" at operators on every hard navigation.
+  if (isLoading) return null;
+
+  if (!isSuperAdmin) {
+    return (
+      <div className="mx-auto max-w-2xl px-6 py-16 text-center">
+        <h1 className="text-xl font-semibold">Not available</h1>
+        <p className="mt-2 text-content-secondary">
+          This area is limited to instance operators. Ask an existing operator
+          to grant you access.
+        </p>
+        <Link href="/" className="mt-6 inline-block underline">
+          Back to your teams
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto w-full max-w-7xl px-6 py-8">
+      <header className="mb-6">
+        <p className="text-xs uppercase tracking-wide text-content-secondary">
+          Instance admin
+        </p>
+        <h1 className="text-2xl font-semibold">{title}</h1>
+      </header>
+      <nav className="mb-6 flex gap-4 border-b" aria-label="Instance admin">
+        {TABS.map((tab) => (
+          <Link
+            key={tab.href}
+            href={tab.href}
+            aria-current={router.pathname === tab.href ? "page" : undefined}
+            className={
+              router.pathname === tab.href
+                ? "border-b-2 border-content-primary pb-2 font-medium"
+                : "pb-2 text-content-secondary hover:text-content-primary"
+            }
+          >
+            {tab.label}
+          </Link>
+        ))}
+      </nav>
+      {children}
+    </div>
+  );
+}

--- a/npm-packages/dashboard-orchestrator/src/components/admin/AdminLayout.tsx
+++ b/npm-packages/dashboard-orchestrator/src/components/admin/AdminLayout.tsx
@@ -16,6 +16,8 @@ const TABS = [
   { href: "/admin", label: "Overview" },
   { href: "/admin/deployments", label: "Deployments" },
   { href: "/admin/members", label: "Members" },
+  { href: "/admin/teams", label: "Teams" },
+  { href: "/admin/audit", label: "Audit" },
 ];
 
 export function AdminLayout({

--- a/npm-packages/dashboard-orchestrator/src/components/admin/BreakGlassModal.tsx
+++ b/npm-packages/dashboard-orchestrator/src/components/admin/BreakGlassModal.tsx
@@ -1,0 +1,154 @@
+// Break-glass access to a tenant's deployment.
+//
+// The modal states, before the operator commits, that the tenant will see
+// this in their own audit log. An operator should know that going in rather
+// than discover it afterwards — that is what makes the audit trail a
+// deterrent rather than a trap.
+
+import { useEffect, useState } from "react";
+import type { BreakGlassGrant, FleetEntry } from "../../lib/adminApi";
+
+function Countdown({ expiresAt }: { expiresAt: number }) {
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    const t = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(t);
+  }, []);
+
+  const msLeft = expiresAt - now;
+  if (msLeft <= 0) {
+    return <span className="text-util-error">expired</span>;
+  }
+  const total = Math.floor(msLeft / 1000);
+  const mm = Math.floor(total / 60);
+  const ss = String(total % 60).padStart(2, "0");
+  return (
+    <span className={msLeft < 60_000 ? "text-util-error" : undefined}>
+      {mm}:{ss}
+    </span>
+  );
+}
+
+export function BreakGlassModal({
+  deployment,
+  grant,
+  busy,
+  error,
+  onConfirm,
+  onClose,
+}: {
+  deployment: FleetEntry;
+  /** Set once access has been granted; the modal then shows the key. */
+  grant: BreakGlassGrant | null;
+  busy?: boolean;
+  error?: string | null;
+  onConfirm: (reason: string) => void;
+  onClose: () => void;
+}) {
+  const [reason, setReason] = useState("");
+  const [copied, setCopied] = useState(false);
+  const canConfirm = reason.trim().length > 0 && !busy;
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="Break-glass access"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+    >
+      <div className="w-full max-w-lg rounded-lg border bg-background-primary p-6">
+        <h2 className="text-lg font-semibold">Open {deployment.name}</h2>
+
+        {grant ? (
+          <>
+            <p className="mt-2 text-sm text-content-secondary">
+              A temporary admin key for{" "}
+              <span className="font-mono">{deployment.name}</span>. It is shown
+              once and expires in{" "}
+              <strong>
+                <Countdown expiresAt={grant.expiresAt} />
+              </strong>
+              .
+            </p>
+            <div className="mt-4 flex items-center gap-2">
+              <code className="flex-1 overflow-x-auto rounded border bg-background-secondary p-2 font-mono text-xs">
+                {grant.adminKey}
+              </code>
+              <button
+                type="button"
+                onClick={() => {
+                  void navigator.clipboard?.writeText(grant.adminKey);
+                  setCopied(true);
+                }}
+                className="rounded border px-3 py-1.5 text-sm"
+              >
+                {copied ? "Copied" : "Copy"}
+              </button>
+            </div>
+            <p className="mt-4 text-xs text-content-secondary">
+              Recorded in the instance audit log and in{" "}
+              <span className="font-mono">{deployment.teamSlug}</span>&apos;s
+              own audit log.
+            </p>
+            <div className="mt-6 flex justify-end">
+              <button
+                type="button"
+                onClick={onClose}
+                className="rounded border px-3 py-1.5 text-sm"
+              >
+                Done
+              </button>
+            </div>
+          </>
+        ) : (
+          <>
+            <div className="mt-2 rounded border border-util-warning bg-util-warning/10 p-3 text-sm">
+              This grants read and write access to{" "}
+              <span className="font-mono">{deployment.teamSlug}</span>&apos;s
+              data. <strong>They will see this in their own audit log</strong>,
+              including the reason you give.
+            </div>
+
+            <label className="mt-4 block text-sm">
+              Reason
+              <input
+                autoFocus
+                value={reason}
+                onChange={(e) => setReason(e.target.value)}
+                disabled={busy}
+                placeholder="e.g. investigating ticket 4711"
+                aria-label="Reason for access"
+                className="mt-1 w-full rounded border px-2 py-1"
+              />
+            </label>
+
+            {error ? (
+              <p className="mt-3 rounded border border-util-error p-2 text-sm">
+                {error}
+              </p>
+            ) : null}
+
+            <div className="mt-6 flex justify-end gap-2">
+              <button
+                type="button"
+                onClick={onClose}
+                disabled={busy}
+                className="rounded border px-3 py-1.5 text-sm"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={() => onConfirm(reason.trim())}
+                disabled={!canConfirm}
+                className="rounded bg-util-warning px-3 py-1.5 text-sm disabled:opacity-40"
+              >
+                {busy ? "Opening…" : "Grant access"}
+              </button>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/npm-packages/dashboard-orchestrator/src/components/admin/ConfirmByName.tsx
+++ b/npm-packages/dashboard-orchestrator/src/components/admin/ConfirmByName.tsx
@@ -1,0 +1,76 @@
+// Type-the-name confirmation for destructive admin actions.
+//
+// A misclick on the wrong fleet row destroys a tenant's data, and the rows
+// are visually near-identical. Requiring the name typed exactly is the same
+// bar the rest of the dashboard uses for deletes.
+
+import { useState } from "react";
+
+export function ConfirmByName({
+  title,
+  expected,
+  description,
+  confirmLabel,
+  onConfirm,
+  onCancel,
+  busy,
+}: {
+  title: string;
+  /** The exact string the operator must type — usually the resource name. */
+  expected: string;
+  description: React.ReactNode;
+  confirmLabel: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+  busy?: boolean;
+}) {
+  const [typed, setTyped] = useState("");
+  // Exact match, not trimmed-or-lowercased: the point is deliberate effort.
+  const matches = typed === expected;
+
+  return (
+    <div
+      role="dialog"
+      aria-label={title}
+      aria-modal="true"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+    >
+      <div className="w-full max-w-md rounded-lg border bg-background-primary p-6">
+        <h2 className="text-lg font-semibold">{title}</h2>
+        <div className="mt-2 text-sm text-content-secondary">{description}</div>
+
+        <label className="mt-4 block text-sm">
+          Type <code className="font-mono font-semibold">{expected}</code> to
+          confirm
+          <input
+            autoFocus
+            value={typed}
+            onChange={(e) => setTyped(e.target.value)}
+            disabled={busy}
+            className="mt-1 w-full rounded border px-2 py-1 font-mono"
+            aria-label={`Type ${expected} to confirm`}
+          />
+        </label>
+
+        <div className="mt-6 flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={onCancel}
+            disabled={busy}
+            className="rounded border px-3 py-1.5 text-sm"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={onConfirm}
+            disabled={!matches || busy}
+            className="rounded bg-util-error px-3 py-1.5 text-sm text-white disabled:opacity-40"
+          >
+            {busy ? "Working…" : confirmLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/npm-packages/dashboard-orchestrator/src/hooks/useAdmin.ts
+++ b/npm-packages/dashboard-orchestrator/src/hooks/useAdmin.ts
@@ -1,0 +1,65 @@
+// SWR hooks over the instance-admin API.
+//
+// All keyed on the access token so a sign-out or session swap refetches
+// rather than serving the previous session's data from cache, matching
+// `useHostCapacity` and the other orchestrator hooks.
+
+import useSWR from "swr";
+import {
+  getAdminAudit,
+  getAdminFleet,
+  getAdminHealth,
+  getAdminMembers,
+  getAdminOverview,
+} from "../lib/adminApi";
+import { orchestratorUrl } from "../lib/config";
+import { useAccessToken } from "../lib/useOrchestratorToken";
+
+/**
+ * Fleet state changes without the user doing anything — containers stop,
+ * the reconciler starts them — so this one polls. The others are static
+ * enough to leave on SWR's default revalidation.
+ */
+const FLEET_REFRESH_MS = 15_000;
+
+export function useAdminOverview() {
+  const token = useAccessToken();
+  const url = orchestratorUrl();
+  return useSWR(token ? ["admin/overview", token] : null, () =>
+    getAdminOverview(url, token!),
+  );
+}
+
+export function useAdminHealth() {
+  const token = useAccessToken();
+  const url = orchestratorUrl();
+  return useSWR(token ? ["admin/health", token] : null, () =>
+    getAdminHealth(url, token!),
+  );
+}
+
+export function useAdminFleet() {
+  const token = useAccessToken();
+  const url = orchestratorUrl();
+  return useSWR(
+    token ? ["admin/fleet", token] : null,
+    () => getAdminFleet(url, token!),
+    { refreshInterval: FLEET_REFRESH_MS },
+  );
+}
+
+export function useAdminMembers() {
+  const token = useAccessToken();
+  const url = orchestratorUrl();
+  return useSWR(token ? ["admin/members", token] : null, () =>
+    getAdminMembers(url, token!),
+  );
+}
+
+export function useAdminAudit(limit = 100) {
+  const token = useAccessToken();
+  const url = orchestratorUrl();
+  return useSWR(token ? ["admin/audit", token, limit] : null, () =>
+    getAdminAudit(url, token!, limit),
+  );
+}

--- a/npm-packages/dashboard-orchestrator/src/hooks/useAdmin.ts
+++ b/npm-packages/dashboard-orchestrator/src/hooks/useAdmin.ts
@@ -7,6 +7,7 @@
 import useSWR from "swr";
 import {
   getAdminAudit,
+  getAdminTeams,
   getAdminFleet,
   getAdminHealth,
   getAdminMembers,
@@ -61,5 +62,13 @@ export function useAdminAudit(limit = 100) {
   const url = orchestratorUrl();
   return useSWR(token ? ["admin/audit", token, limit] : null, () =>
     getAdminAudit(url, token!, limit),
+  );
+}
+
+export function useAdminTeams() {
+  const token = useAccessToken();
+  const url = orchestratorUrl();
+  return useSWR(token ? ["admin/teams", token] : null, () =>
+    getAdminTeams(url, token!),
   );
 }

--- a/npm-packages/dashboard-orchestrator/src/lib/adminApi.ts
+++ b/npm-packages/dashboard-orchestrator/src/lib/adminApi.ts
@@ -96,6 +96,17 @@ export const instanceAuditEventSchema = z.object({
 });
 export type InstanceAuditEvent = z.infer<typeof instanceAuditEventSchema>;
 
+export const actionResponseSchema = z.object({
+  deployment: z.string(),
+  state: z.string(),
+  /**
+   * Set when the row changed but the container work did not fully succeed.
+   * The action still took effect — surface this, never swallow it.
+   */
+  containerWarning: z.string().nullable(),
+});
+export type ActionResponse = z.infer<typeof actionResponseSchema>;
+
 async function adminGet<T>(
   baseUrl: string,
   path: string,
@@ -105,6 +116,62 @@ async function adminGet<T>(
   const data = await request<unknown>(baseUrl, path, { token });
   return schema.parse(data);
 }
+
+async function adminPost<T>(
+  baseUrl: string,
+  path: string,
+  token: string,
+  schema: z.ZodType<T>,
+  body?: unknown,
+): Promise<T> {
+  const data = await request<unknown>(baseUrl, path, {
+    token,
+    method: "POST",
+    ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+  });
+  return schema.parse(data);
+}
+
+/** Deployment lifecycle actions. All audited server-side. */
+export const deploymentActions = {
+  pause: (baseUrl: string, token: string, id: number) =>
+    adminPost(
+      baseUrl,
+      `/api/admin/deployments/${id}/pause`,
+      token,
+      actionResponseSchema,
+    ),
+  resume: (baseUrl: string, token: string, id: number) =>
+    adminPost(
+      baseUrl,
+      `/api/admin/deployments/${id}/resume`,
+      token,
+      actionResponseSchema,
+    ),
+  restart: (baseUrl: string, token: string, id: number, force = false) =>
+    adminPost(
+      baseUrl,
+      `/api/admin/deployments/${id}/restart`,
+      token,
+      actionResponseSchema,
+      { force },
+    ),
+  setTier: (baseUrl: string, token: string, id: number, tier: string) =>
+    adminPost(
+      baseUrl,
+      `/api/admin/deployments/${id}/tier`,
+      token,
+      actionResponseSchema,
+      { tier },
+    ),
+  remove: (baseUrl: string, token: string, id: number) =>
+    adminPost(
+      baseUrl,
+      `/api/admin/deployments/${id}/delete`,
+      token,
+      actionResponseSchema,
+    ),
+};
 
 export function getAdminOverview(baseUrl: string, token: string) {
   return adminGet(baseUrl, "/api/admin/overview", token, overviewSchema);

--- a/npm-packages/dashboard-orchestrator/src/lib/adminApi.ts
+++ b/npm-packages/dashboard-orchestrator/src/lib/adminApi.ts
@@ -90,6 +90,8 @@ export type AdminHealth = z.infer<typeof adminHealthSchema>;
 export const instanceAuditEventSchema = z.object({
   id: z.number(),
   memberId: z.number().nullable(),
+  /** Resolved server-side; null for break-glass or a deleted member. */
+  memberEmail: z.string().nullable(),
   action: z.string(),
   metadata: z.unknown(),
   creationTime: z.number(),
@@ -200,5 +202,122 @@ export function getAdminAudit(baseUrl: string, token: string, limit = 100) {
     `/api/admin/audit?limit=${limit}`,
     token,
     z.object({ events: z.array(instanceAuditEventSchema) }),
+  );
+}
+
+export const adminTeamSchema = z.object({
+  id: z.number(),
+  name: z.string(),
+  slug: z.string(),
+  creationTime: z.number(),
+  memberCount: z.number(),
+  projectCount: z.number(),
+  /** Drives the delete confirmation's blast-radius warning. */
+  deploymentCount: z.number(),
+});
+export type AdminTeam = z.infer<typeof adminTeamSchema>;
+
+export const teamActionResponseSchema = z.object({
+  teamId: z.number(),
+  slug: z.string(),
+  deploymentsRemoved: z.number(),
+});
+
+export const memberActionResponseSchema = z.object({
+  memberId: z.number(),
+  email: z.string(),
+  isSuperAdmin: z.boolean(),
+  suspended: z.boolean(),
+});
+
+export const breakGlassResponseSchema = z.object({
+  deployment: z.string(),
+  url: z.string(),
+  /** Shown once. Never persisted. */
+  adminKey: z.string(),
+  expiresAt: z.number(),
+  tenantNotified: z.boolean(),
+});
+export type BreakGlassGrant = z.infer<typeof breakGlassResponseSchema>;
+
+export function getAdminTeams(baseUrl: string, token: string) {
+  return adminGet(
+    baseUrl,
+    "/api/admin/teams",
+    token,
+    z.object({ teams: z.array(adminTeamSchema) }),
+  );
+}
+
+export const teamActions = {
+  create: (baseUrl: string, token: string, name: string) =>
+    adminPost(baseUrl, "/api/admin/teams", token, teamActionResponseSchema, {
+      name,
+    }),
+  rename: (baseUrl: string, token: string, id: number, name: string) =>
+    adminPost(
+      baseUrl,
+      `/api/admin/teams/${id}`,
+      token,
+      teamActionResponseSchema,
+      { name },
+    ),
+  remove: (baseUrl: string, token: string, id: number) =>
+    adminPost(
+      baseUrl,
+      `/api/admin/teams/${id}/delete`,
+      token,
+      teamActionResponseSchema,
+    ),
+};
+
+export const memberActions = {
+  suspend: (baseUrl: string, token: string, id: number) =>
+    adminPost(
+      baseUrl,
+      `/api/admin/members/${id}/suspend`,
+      token,
+      memberActionResponseSchema,
+    ),
+  unsuspend: (baseUrl: string, token: string, id: number) =>
+    adminPost(
+      baseUrl,
+      `/api/admin/members/${id}/unsuspend`,
+      token,
+      memberActionResponseSchema,
+    ),
+  setSuperAdmin: (baseUrl: string, token: string, id: number, grant: boolean) =>
+    adminPost(
+      baseUrl,
+      `/api/admin/members/${id}/super_admin`,
+      token,
+      memberActionResponseSchema,
+      { grant },
+    ),
+  remove: (baseUrl: string, token: string, id: number) =>
+    adminPost(
+      baseUrl,
+      `/api/admin/members/${id}/delete`,
+      token,
+      memberActionResponseSchema,
+    ),
+};
+
+/**
+ * Break-glass access. The reason is recorded in the tenant's own audit log,
+ * so callers must have told the operator that before calling this.
+ */
+export function grantBreakGlassAccess(
+  baseUrl: string,
+  token: string,
+  deploymentId: number,
+  reason: string,
+) {
+  return adminPost(
+    baseUrl,
+    `/api/admin/deployments/${deploymentId}/access`,
+    token,
+    breakGlassResponseSchema,
+    { reason },
   );
 }

--- a/npm-packages/dashboard-orchestrator/src/lib/adminApi.ts
+++ b/npm-packages/dashboard-orchestrator/src/lib/adminApi.ts
@@ -1,0 +1,137 @@
+// Typed client for the orchestrator's instance-admin surface
+// (`crates/orchestrator/src/routes/admin`).
+//
+// Every route here is gated server-side by the SuperAdmin extractor; these
+// schemas mirror the serde-serialized response shapes. Requests go through
+// `orchestratorApi`'s shared `request` helper so retry behaviour and error
+// types match the rest of the dashboard.
+
+import { z } from "zod";
+import { request } from "./orchestratorApi";
+
+export const memberTeamRefSchema = z.object({
+  teamId: z.number(),
+  teamSlug: z.string(),
+  teamName: z.string(),
+  role: z.string(),
+});
+export type MemberTeamRef = z.infer<typeof memberTeamRefSchema>;
+
+export const adminMemberSchema = z.object({
+  id: z.number(),
+  primaryEmail: z.string(),
+  name: z.string().nullable(),
+  creationTime: z.number(),
+  isSuperAdmin: z.boolean(),
+  suspended: z.boolean(),
+  teams: z.array(memberTeamRefSchema),
+});
+export type AdminMember = z.infer<typeof adminMemberSchema>;
+
+/**
+ * The fleet row. `AdminDeploymentRow` is flattened into the entry
+ * server-side via `#[serde(flatten)]`, so these are all one object on the
+ * wire rather than a nested `deployment` key.
+ */
+export const fleetEntrySchema = z.object({
+  id: z.number(),
+  name: z.string(),
+  deploymentType: z.string(),
+  intendedState: z.string(),
+  tier: z.string(),
+  url: z.string(),
+  creationTime: z.number(),
+  teamId: z.number(),
+  teamSlug: z.string(),
+  projectId: z.number(),
+  projectSlug: z.string(),
+  actualState: z.string(),
+  drifted: z.boolean(),
+});
+export type FleetEntry = z.infer<typeof fleetEntrySchema>;
+
+export const fleetResponseSchema = z.object({
+  deployments: z.array(fleetEntrySchema),
+  driftCount: z.number(),
+  containerStatesAvailable: z.boolean(),
+});
+export type FleetResponse = z.infer<typeof fleetResponseSchema>;
+
+export const overviewSchema = z.object({
+  totalMemoryMb: z.number(),
+  totalCpus: z.number(),
+  allocatedMemoryMb: z.number(),
+  allocatedCpus: z.number(),
+  deploymentCount: z.number(),
+  deploymentsByState: z.record(z.string(), z.number()),
+  teamCount: z.number(),
+  memberCount: z.number(),
+});
+export type Overview = z.infer<typeof overviewSchema>;
+
+export const adminHealthSchema = z.object({
+  version: z.string(),
+  database: z.object({
+    reachable: z.boolean(),
+    pingMs: z.number().nullable(),
+    error: z.string().nullable(),
+  }),
+  provisioner: z.object({
+    mode: z.string(),
+    // null when the provisioner does not manage containers, which is not
+    // the same as "the socket is down".
+    dockerReachable: z.boolean().nullable(),
+    error: z.string().nullable(),
+  }),
+  reconcileIntervalSecs: z.number(),
+});
+export type AdminHealth = z.infer<typeof adminHealthSchema>;
+
+export const instanceAuditEventSchema = z.object({
+  id: z.number(),
+  memberId: z.number().nullable(),
+  action: z.string(),
+  metadata: z.unknown(),
+  creationTime: z.number(),
+});
+export type InstanceAuditEvent = z.infer<typeof instanceAuditEventSchema>;
+
+async function adminGet<T>(
+  baseUrl: string,
+  path: string,
+  token: string,
+  schema: z.ZodType<T>,
+): Promise<T> {
+  const data = await request<unknown>(baseUrl, path, { token });
+  return schema.parse(data);
+}
+
+export function getAdminOverview(baseUrl: string, token: string) {
+  return adminGet(baseUrl, "/api/admin/overview", token, overviewSchema);
+}
+
+export function getAdminHealth(baseUrl: string, token: string) {
+  return adminGet(baseUrl, "/api/admin/health", token, adminHealthSchema);
+}
+
+export function getAdminFleet(baseUrl: string, token: string) {
+  return adminGet(baseUrl, "/api/admin/fleet", token, fleetResponseSchema);
+}
+
+export function getAdminMembers(baseUrl: string, token: string) {
+  return adminGet(
+    baseUrl,
+    "/api/admin/members",
+    token,
+    z.object({ members: z.array(adminMemberSchema) }),
+  );
+}
+
+export function getAdminAudit(baseUrl: string, token: string, limit = 100) {
+  return adminGet(
+    baseUrl,
+    `/api/admin/audit?limit=${limit}`,
+    token,
+    z.object({ events: z.array(instanceAuditEventSchema) }),
+  );
+}

--- a/npm-packages/dashboard-orchestrator/src/lib/orchestratorApi.ts
+++ b/npm-packages/dashboard-orchestrator/src/lib/orchestratorApi.ts
@@ -115,7 +115,14 @@ async function fetchWithRetry(
   throw lastError;
 }
 
-async function request<T>(
+/**
+ * Shared request path for every orchestrator call: retry, bearer auth, and
+ * `OrchestratorApiError` on failure.
+ *
+ * Exported so `adminApi.ts` can keep the `/api/admin` surface in its own
+ * file without duplicating the retry and error handling.
+ */
+export async function request<T>(
   baseUrl: string,
   path: string,
   init: RequestInit & { auth?: boolean; token?: string | null } = {},

--- a/npm-packages/dashboard-orchestrator/src/lib/useOrchestratorToken.ts
+++ b/npm-packages/dashboard-orchestrator/src/lib/useOrchestratorToken.ts
@@ -9,6 +9,14 @@ export type OrchestratorSession = {
   memberId: number;
   teamSlug: string;
   role: string;
+  /**
+   * Instance-wide operator. Controls whether the admin nav renders.
+   *
+   * Presentation only: every /api/admin route is gated server-side by the
+   * SuperAdmin extractor, so a forged value here buys nothing but a page of
+   * 403s. Optional because an older orchestrator build won't send it.
+   */
+  isSuperAdmin?: boolean;
 };
 
 async function fetcher(url: string): Promise<OrchestratorSession | null> {
@@ -68,4 +76,17 @@ export function useOrchestratorSessionForInvite(
 export function useAccessToken(inviteCode?: string | null): string | null {
   const { data } = useOrchestratorSessionForInvite(inviteCode);
   return data?.accessToken ?? null;
+}
+
+/**
+ * Whether the current session is an instance operator.
+ *
+ * `false` while the session is still loading, so the admin nav never flashes
+ * in for a user who turns out not to have it. Callers that need to
+ * distinguish "not an operator" from "don't know yet" should read
+ * `isLoading` from `useOrchestratorSession` directly.
+ */
+export function useIsSuperAdmin(): boolean {
+  const { data } = useOrchestratorSession();
+  return data?.isSuperAdmin ?? false;
 }

--- a/npm-packages/dashboard-orchestrator/src/pages/admin/audit.tsx
+++ b/npm-packages/dashboard-orchestrator/src/pages/admin/audit.tsx
@@ -1,0 +1,99 @@
+// The instance audit log: operator actions that belong to no single team.
+//
+// Break-glass events are called out, because those are the rows an operator
+// reviews after the fact — "who opened a tenant's deployment, and why".
+
+import { AdminLayout } from "../../components/admin/AdminLayout";
+import { useAdminAudit } from "../../hooks/useAdmin";
+
+/** Actions that hand over access to a tenant's data. */
+const SENSITIVE = new Set(["deploymentAccessGranted"]);
+
+function reasonOf(metadata: unknown): string | null {
+  if (metadata && typeof metadata === "object" && "reason" in metadata) {
+    const r = (metadata as { reason?: unknown }).reason;
+    return typeof r === "string" ? r : null;
+  }
+  return null;
+}
+
+export default function AdminAuditPage() {
+  const { data, error, isLoading } = useAdminAudit(200);
+
+  return (
+    <AdminLayout title="Audit log">
+      {error ? (
+        <p className="mb-4 rounded border border-util-error p-4 text-sm">
+          Could not load the audit log: {String(error)}
+        </p>
+      ) : null}
+      {isLoading ? <p className="text-sm">Loading…</p> : null}
+
+      <div className="overflow-x-auto rounded-lg border">
+        <table className="w-full text-left text-sm">
+          <thead className="border-b bg-background-secondary">
+            <tr>
+              <th className="px-4 py-2">When</th>
+              <th className="px-4 py-2">Actor</th>
+              <th className="px-4 py-2">Action</th>
+              <th className="px-4 py-2">Detail</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y">
+            {(data?.events ?? []).map((e) => {
+              const sensitive = SENSITIVE.has(e.action);
+              const reason = reasonOf(e.metadata);
+              return (
+                <tr
+                  key={e.id}
+                  className={sensitive ? "bg-util-warning/10" : ""}
+                >
+                  <td className="px-4 py-2 whitespace-nowrap text-content-secondary">
+                    {new Date(e.creationTime).toLocaleString()}
+                  </td>
+                  <td className="px-4 py-2">
+                    {/* No member means the break-glass bootstrap credential,
+                        which has no human behind it — say so rather than
+                        rendering an empty cell. */}
+                    {e.memberEmail ?? (
+                      <span className="text-content-secondary">
+                        bootstrap credential
+                      </span>
+                    )}
+                  </td>
+                  <td className="px-4 py-2 font-mono">
+                    {e.action}
+                    {sensitive ? (
+                      <span className="ml-2 rounded bg-util-warning/20 px-1.5 py-0.5 text-xs">
+                        data access
+                      </span>
+                    ) : null}
+                  </td>
+                  <td className="px-4 py-2">
+                    {reason ? (
+                      <span title={reason}>{reason}</span>
+                    ) : (
+                      <code className="text-xs text-content-secondary">
+                        {JSON.stringify(e.metadata)}
+                      </code>
+                    )}
+                  </td>
+                </tr>
+              );
+            })}
+            {data && data.events.length === 0 && !isLoading ? (
+              <tr>
+                <td
+                  colSpan={4}
+                  className="px-4 py-6 text-center text-content-secondary"
+                >
+                  No instance-scoped events recorded yet.
+                </td>
+              </tr>
+            ) : null}
+          </tbody>
+        </table>
+      </div>
+    </AdminLayout>
+  );
+}

--- a/npm-packages/dashboard-orchestrator/src/pages/admin/deployments.tsx
+++ b/npm-packages/dashboard-orchestrator/src/pages/admin/deployments.tsx
@@ -1,15 +1,25 @@
 // Every deployment on the instance, with what the database intends next to
-// what docker is actually doing.
-//
-// Read-only in Phase 1 — the lifecycle actions land in Phase 2.
+// what docker is actually doing, plus the lifecycle actions.
 
 import { useMemo, useState } from "react";
+import { ConfirmByName } from "../../components/admin/ConfirmByName";
 import { AdminLayout } from "../../components/admin/AdminLayout";
 import { useAdminFleet } from "../../hooks/useAdmin";
+import { deploymentActions, type FleetEntry } from "../../lib/adminApi";
+import { orchestratorUrl } from "../../lib/config";
+import { useAccessToken } from "../../lib/useOrchestratorToken";
+
+type Notice = { kind: "ok" | "warn" | "error"; text: string };
 
 export default function AdminDeploymentsPage() {
-  const { data, error, isLoading } = useAdminFleet();
+  const { data, error, isLoading, mutate } = useAdminFleet();
+  const token = useAccessToken();
+  const url = orchestratorUrl();
+
   const [driftedOnly, setDriftedOnly] = useState(false);
+  const [busyId, setBusyId] = useState<number | null>(null);
+  const [notice, setNotice] = useState<Notice | null>(null);
+  const [pendingDelete, setPendingDelete] = useState<FleetEntry | null>(null);
 
   const rows = useMemo(() => {
     if (!data) return [];
@@ -18,11 +28,61 @@ export default function AdminDeploymentsPage() {
       : data.deployments;
   }, [data, driftedOnly]);
 
+  async function run(
+    entry: FleetEntry,
+    label: string,
+    fn: () => Promise<{ containerWarning: string | null }>,
+  ) {
+    if (!token) return;
+    setBusyId(entry.id);
+    setNotice(null);
+    try {
+      const res = await fn();
+      setNotice(
+        res.containerWarning
+          ? {
+              kind: "warn",
+              // Surfaced, never swallowed: "paused, but the container did not
+              // stop" is exactly what an operator needs to see.
+              text: `${entry.name}: ${label} recorded, but ${res.containerWarning}`,
+            }
+          : { kind: "ok", text: `${entry.name}: ${label}` },
+      );
+    } catch (e) {
+      setNotice({
+        kind: "error",
+        text: `${entry.name}: ${label} failed — ${e}`,
+      });
+    } finally {
+      setBusyId(null);
+      // Revalidate rather than mutating optimistically: this view exists to
+      // show real container state, so it must not display a state it merely
+      // hopes for.
+      await mutate();
+      setPendingDelete(null);
+    }
+  }
+
   return (
     <AdminLayout title="Deployments">
       {error ? (
         <p className="mb-4 rounded border border-util-error p-4 text-sm">
           Could not load the fleet: {String(error)}
+        </p>
+      ) : null}
+
+      {notice ? (
+        <p
+          role="status"
+          className={`mb-4 rounded border p-3 text-sm ${
+            notice.kind === "error"
+              ? "border-util-error"
+              : notice.kind === "warn"
+                ? "border-util-warning"
+                : "border-util-success"
+          }`}
+        >
+          {notice.text}
         </p>
       ) : null}
 
@@ -56,32 +116,76 @@ export default function AdminDeploymentsPage() {
             <tr>
               <th className="px-4 py-2">Deployment</th>
               <th className="px-4 py-2">Team / Project</th>
-              <th className="px-4 py-2">Type</th>
               <th className="px-4 py-2">Tier</th>
               <th className="px-4 py-2">Intended</th>
               <th className="px-4 py-2">Actual</th>
+              <th className="px-4 py-2">Actions</th>
             </tr>
           </thead>
           <tbody className="divide-y">
-            {rows.map((d) => (
-              <tr key={d.id} className={d.drifted ? "bg-util-warning/10" : ""}>
-                <td className="px-4 py-2 font-mono">{d.name}</td>
-                <td className="px-4 py-2">
-                  {d.teamSlug} / {d.projectSlug}
-                </td>
-                <td className="px-4 py-2">{d.deploymentType}</td>
-                <td className="px-4 py-2">{d.tier}</td>
-                <td className="px-4 py-2">{d.intendedState}</td>
-                <td className="px-4 py-2">
-                  {d.actualState}
-                  {d.drifted ? (
-                    <span className="ml-2 rounded bg-util-warning/20 px-1.5 py-0.5 text-xs">
-                      drifted
-                    </span>
-                  ) : null}
-                </td>
-              </tr>
-            ))}
+            {rows.map((d) => {
+              const busy = busyId === d.id;
+              const paused = d.intendedState === "paused";
+              return (
+                <tr
+                  key={d.id}
+                  className={d.drifted ? "bg-util-warning/10" : ""}
+                >
+                  <td className="px-4 py-2 font-mono">{d.name}</td>
+                  <td className="px-4 py-2">
+                    {d.teamSlug} / {d.projectSlug}
+                  </td>
+                  <td className="px-4 py-2">{d.tier}</td>
+                  <td className="px-4 py-2">{d.intendedState}</td>
+                  <td className="px-4 py-2">
+                    {d.actualState}
+                    {d.drifted ? (
+                      <span className="ml-2 rounded bg-util-warning/20 px-1.5 py-0.5 text-xs">
+                        drifted
+                      </span>
+                    ) : null}
+                  </td>
+                  <td className="px-4 py-2">
+                    <div className="flex gap-2">
+                      <button
+                        type="button"
+                        disabled={busy || !token}
+                        onClick={() =>
+                          run(d, paused ? "resumed" : "paused", () =>
+                            paused
+                              ? deploymentActions.resume(url, token!, d.id)
+                              : deploymentActions.pause(url, token!, d.id),
+                          )
+                        }
+                        className="rounded border px-2 py-1 text-xs disabled:opacity-40"
+                      >
+                        {paused ? "Resume" : "Pause"}
+                      </button>
+                      <button
+                        type="button"
+                        disabled={busy || !token}
+                        onClick={() =>
+                          run(d, "restarted", () =>
+                            deploymentActions.restart(url, token!, d.id),
+                          )
+                        }
+                        className="rounded border px-2 py-1 text-xs disabled:opacity-40"
+                      >
+                        Restart
+                      </button>
+                      <button
+                        type="button"
+                        disabled={busy || !token}
+                        onClick={() => setPendingDelete(d)}
+                        className="rounded border border-util-error px-2 py-1 text-xs disabled:opacity-40"
+                      >
+                        Delete
+                      </button>
+                    </div>
+                  </td>
+                </tr>
+              );
+            })}
             {rows.length === 0 && !isLoading ? (
               <tr>
                 <td
@@ -97,6 +201,31 @@ export default function AdminDeploymentsPage() {
           </tbody>
         </table>
       </div>
+
+      {pendingDelete ? (
+        <ConfirmByName
+          title="Delete deployment"
+          expected={pendingDelete.name}
+          confirmLabel="Delete permanently"
+          busy={busyId === pendingDelete.id}
+          onCancel={() => setPendingDelete(null)}
+          onConfirm={() =>
+            run(pendingDelete, "deleted", () =>
+              deploymentActions.remove(url, token!, pendingDelete.id),
+            )
+          }
+          description={
+            <>
+              This tears down the container and removes{" "}
+              <span className="font-mono">{pendingDelete.name}</span> from{" "}
+              <span className="font-mono">
+                {pendingDelete.teamSlug}/{pendingDelete.projectSlug}
+              </span>
+              . Its data is not recoverable from here.
+            </>
+          }
+        />
+      ) : null}
     </AdminLayout>
   );
 }

--- a/npm-packages/dashboard-orchestrator/src/pages/admin/deployments.tsx
+++ b/npm-packages/dashboard-orchestrator/src/pages/admin/deployments.tsx
@@ -2,10 +2,16 @@
 // what docker is actually doing, plus the lifecycle actions.
 
 import { useMemo, useState } from "react";
+import { BreakGlassModal } from "../../components/admin/BreakGlassModal";
 import { ConfirmByName } from "../../components/admin/ConfirmByName";
 import { AdminLayout } from "../../components/admin/AdminLayout";
 import { useAdminFleet } from "../../hooks/useAdmin";
-import { deploymentActions, type FleetEntry } from "../../lib/adminApi";
+import {
+  deploymentActions,
+  grantBreakGlassAccess,
+  type BreakGlassGrant,
+  type FleetEntry,
+} from "../../lib/adminApi";
 import { orchestratorUrl } from "../../lib/config";
 import { useAccessToken } from "../../lib/useOrchestratorToken";
 
@@ -20,6 +26,9 @@ export default function AdminDeploymentsPage() {
   const [busyId, setBusyId] = useState<number | null>(null);
   const [notice, setNotice] = useState<Notice | null>(null);
   const [pendingDelete, setPendingDelete] = useState<FleetEntry | null>(null);
+  const [breakGlassFor, setBreakGlassFor] = useState<FleetEntry | null>(null);
+  const [grant, setGrant] = useState<BreakGlassGrant | null>(null);
+  const [grantError, setGrantError] = useState<string | null>(null);
 
   const rows = useMemo(() => {
     if (!data) return [];
@@ -176,6 +185,18 @@ export default function AdminDeploymentsPage() {
                       <button
                         type="button"
                         disabled={busy || !token}
+                        onClick={() => {
+                          setGrant(null);
+                          setGrantError(null);
+                          setBreakGlassFor(d);
+                        }}
+                        className="rounded border border-util-warning px-2 py-1 text-xs disabled:opacity-40"
+                      >
+                        Open…
+                      </button>
+                      <button
+                        type="button"
+                        disabled={busy || !token}
                         onClick={() => setPendingDelete(d)}
                         className="rounded border border-util-error px-2 py-1 text-xs disabled:opacity-40"
                       >
@@ -224,6 +245,40 @@ export default function AdminDeploymentsPage() {
               . Its data is not recoverable from here.
             </>
           }
+        />
+      ) : null}
+
+      {breakGlassFor ? (
+        <BreakGlassModal
+          deployment={breakGlassFor}
+          grant={grant}
+          busy={busyId === breakGlassFor.id}
+          error={grantError}
+          onClose={() => {
+            setBreakGlassFor(null);
+            // Drop the key as soon as the modal closes: it is shown once and
+            // has no business living in component state afterwards.
+            setGrant(null);
+          }}
+          onConfirm={async (reason) => {
+            if (!token) return;
+            setBusyId(breakGlassFor.id);
+            setGrantError(null);
+            try {
+              setGrant(
+                await grantBreakGlassAccess(
+                  url,
+                  token,
+                  breakGlassFor.id,
+                  reason,
+                ),
+              );
+            } catch (e) {
+              setGrantError(String(e));
+            } finally {
+              setBusyId(null);
+            }
+          }}
         />
       ) : null}
     </AdminLayout>

--- a/npm-packages/dashboard-orchestrator/src/pages/admin/deployments.tsx
+++ b/npm-packages/dashboard-orchestrator/src/pages/admin/deployments.tsx
@@ -1,0 +1,102 @@
+// Every deployment on the instance, with what the database intends next to
+// what docker is actually doing.
+//
+// Read-only in Phase 1 — the lifecycle actions land in Phase 2.
+
+import { useMemo, useState } from "react";
+import { AdminLayout } from "../../components/admin/AdminLayout";
+import { useAdminFleet } from "../../hooks/useAdmin";
+
+export default function AdminDeploymentsPage() {
+  const { data, error, isLoading } = useAdminFleet();
+  const [driftedOnly, setDriftedOnly] = useState(false);
+
+  const rows = useMemo(() => {
+    if (!data) return [];
+    return driftedOnly
+      ? data.deployments.filter((d) => d.drifted)
+      : data.deployments;
+  }, [data, driftedOnly]);
+
+  return (
+    <AdminLayout title="Deployments">
+      {error ? (
+        <p className="mb-4 rounded border border-util-error p-4 text-sm">
+          Could not load the fleet: {String(error)}
+        </p>
+      ) : null}
+
+      <div className="mb-4 flex flex-wrap items-center gap-4 text-sm">
+        <label className="flex items-center gap-2">
+          <input
+            type="checkbox"
+            checked={driftedOnly}
+            onChange={(e) => setDriftedOnly(e.target.checked)}
+          />
+          Only drifted
+        </label>
+        {data ? (
+          <span className="text-content-secondary">
+            {data.deployments.length} deployments · {data.driftCount} drifted
+          </span>
+        ) : null}
+        {data && !data.containerStatesAvailable ? (
+          <span className="text-content-secondary">
+            Container state unavailable — this provisioner does not manage
+            containers.
+          </span>
+        ) : null}
+      </div>
+
+      {isLoading ? <p className="text-sm">Loading…</p> : null}
+
+      <div className="overflow-x-auto rounded-lg border">
+        <table className="w-full text-left text-sm">
+          <thead className="border-b bg-background-secondary">
+            <tr>
+              <th className="px-4 py-2">Deployment</th>
+              <th className="px-4 py-2">Team / Project</th>
+              <th className="px-4 py-2">Type</th>
+              <th className="px-4 py-2">Tier</th>
+              <th className="px-4 py-2">Intended</th>
+              <th className="px-4 py-2">Actual</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y">
+            {rows.map((d) => (
+              <tr key={d.id} className={d.drifted ? "bg-util-warning/10" : ""}>
+                <td className="px-4 py-2 font-mono">{d.name}</td>
+                <td className="px-4 py-2">
+                  {d.teamSlug} / {d.projectSlug}
+                </td>
+                <td className="px-4 py-2">{d.deploymentType}</td>
+                <td className="px-4 py-2">{d.tier}</td>
+                <td className="px-4 py-2">{d.intendedState}</td>
+                <td className="px-4 py-2">
+                  {d.actualState}
+                  {d.drifted ? (
+                    <span className="ml-2 rounded bg-util-warning/20 px-1.5 py-0.5 text-xs">
+                      drifted
+                    </span>
+                  ) : null}
+                </td>
+              </tr>
+            ))}
+            {rows.length === 0 && !isLoading ? (
+              <tr>
+                <td
+                  colSpan={6}
+                  className="px-4 py-6 text-center text-content-secondary"
+                >
+                  {driftedOnly
+                    ? "No drifted deployments."
+                    : "No deployments on this instance."}
+                </td>
+              </tr>
+            ) : null}
+          </tbody>
+        </table>
+      </div>
+    </AdminLayout>
+  );
+}

--- a/npm-packages/dashboard-orchestrator/src/pages/admin/index.tsx
+++ b/npm-packages/dashboard-orchestrator/src/pages/admin/index.tsx
@@ -1,0 +1,162 @@
+// Instance overview: capacity, deployment counts, subsystem health, and the
+// most recent operator actions.
+
+import { AdminLayout } from "../../components/admin/AdminLayout";
+import {
+  useAdminAudit,
+  useAdminHealth,
+  useAdminOverview,
+} from "../../hooks/useAdmin";
+
+function Card({
+  label,
+  value,
+  hint,
+}: {
+  label: string;
+  value: string;
+  hint?: string;
+}) {
+  return (
+    <div className="rounded-lg border p-4">
+      <p className="text-xs uppercase tracking-wide text-content-secondary">
+        {label}
+      </p>
+      <p className="mt-1 text-2xl font-semibold">{value}</p>
+      {hint ? (
+        <p className="mt-1 text-xs text-content-secondary">{hint}</p>
+      ) : null}
+    </div>
+  );
+}
+
+function StatusDot({ ok }: { ok: boolean }) {
+  return (
+    <span
+      aria-label={ok ? "healthy" : "unhealthy"}
+      className={`inline-block size-2 rounded-full ${
+        ok ? "bg-util-success" : "bg-util-error"
+      }`}
+    />
+  );
+}
+
+export default function AdminOverviewPage() {
+  const { data: overview, error: overviewError } = useAdminOverview();
+  const { data: health } = useAdminHealth();
+  const { data: audit } = useAdminAudit(10);
+
+  // Guard against a zero-memory reading rather than rendering NaN%.
+  const memoryPct =
+    overview && overview.totalMemoryMb > 0
+      ? `${Math.round(
+          (overview.allocatedMemoryMb / overview.totalMemoryMb) * 100,
+        )}%`
+      : "—";
+
+  return (
+    <AdminLayout title="Overview">
+      {overviewError ? (
+        <p className="mb-4 rounded border border-util-error p-4 text-sm">
+          Could not load the instance overview: {String(overviewError)}
+        </p>
+      ) : null}
+
+      <section className="grid grid-cols-2 gap-4 md:grid-cols-4">
+        <Card
+          label="Deployments"
+          value={overview ? String(overview.deploymentCount) : "—"}
+          hint={
+            overview
+              ? Object.entries(overview.deploymentsByState)
+                  .map(([state, n]) => `${n} ${state}`)
+                  .join(", ")
+              : undefined
+          }
+        />
+        <Card
+          label="Teams"
+          value={overview ? String(overview.teamCount) : "—"}
+        />
+        <Card
+          label="Members"
+          value={overview ? String(overview.memberCount) : "—"}
+        />
+        <Card
+          label="Memory allocated"
+          value={memoryPct}
+          hint={
+            overview
+              ? `${overview.allocatedMemoryMb} / ${overview.totalMemoryMb} MB`
+              : undefined
+          }
+        />
+      </section>
+
+      <section className="mt-8">
+        <h2 className="mb-3 text-lg font-medium">Subsystems</h2>
+        <div className="space-y-2 rounded-lg border p-4 text-sm">
+          <div className="flex items-center gap-2">
+            <StatusDot ok={health?.database.reachable ?? false} />
+            <span>
+              Postgres
+              {health?.database.pingMs != null
+                ? ` — ${health.database.pingMs} ms`
+                : ""}
+            </span>
+            {health?.database.error ? (
+              <span className="text-content-secondary">
+                {health.database.error}
+              </span>
+            ) : null}
+          </div>
+          <div className="flex items-center gap-2">
+            {/* `null` means this provisioner owns no containers, which is
+                not a fault — only an explicit `false` is unhealthy. */}
+            <StatusDot ok={health?.provisioner.dockerReachable !== false} />
+            <span>
+              Provisioner — {health?.provisioner.mode ?? "…"}
+              {health?.provisioner.dockerReachable === null
+                ? " (does not manage containers)"
+                : ""}
+            </span>
+            {health?.provisioner.error ? (
+              <span className="text-content-secondary">
+                {health.provisioner.error}
+              </span>
+            ) : null}
+          </div>
+          <div className="text-content-secondary">
+            Reconcile:{" "}
+            {health
+              ? health.reconcileIntervalSecs > 0
+                ? `every ${health.reconcileIntervalSecs}s`
+                : "boot only (periodic reconcile disabled)"
+              : "…"}
+            {health?.version ? ` · v${health.version}` : ""}
+          </div>
+        </div>
+      </section>
+
+      <section className="mt-8">
+        <h2 className="mb-3 text-lg font-medium">Recent operator actions</h2>
+        {audit && audit.events.length > 0 ? (
+          <ul className="divide-y rounded-lg border text-sm">
+            {audit.events.map((e) => (
+              <li key={e.id} className="flex justify-between px-4 py-2">
+                <span className="font-mono">{e.action}</span>
+                <span className="text-content-secondary">
+                  {new Date(e.creationTime).toLocaleString()}
+                </span>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p className="text-sm text-content-secondary">
+            No instance-scoped events recorded yet.
+          </p>
+        )}
+      </section>
+    </AdminLayout>
+  );
+}

--- a/npm-packages/dashboard-orchestrator/src/pages/admin/members.tsx
+++ b/npm-packages/dashboard-orchestrator/src/pages/admin/members.tsx
@@ -1,0 +1,77 @@
+// Every member on the instance with their team memberships and flags.
+//
+// Read-only in Phase 1 — grant/revoke and suspend land in Phase 2.
+
+import { AdminLayout } from "../../components/admin/AdminLayout";
+import { useAdminMembers } from "../../hooks/useAdmin";
+
+export default function AdminMembersPage() {
+  const { data, error, isLoading } = useAdminMembers();
+  const members = data?.members ?? [];
+
+  return (
+    <AdminLayout title="Members">
+      {error ? (
+        <p className="mb-4 rounded border border-util-error p-4 text-sm">
+          Could not load members: {String(error)}
+        </p>
+      ) : null}
+      {isLoading ? <p className="text-sm">Loading…</p> : null}
+
+      <div className="overflow-x-auto rounded-lg border">
+        <table className="w-full text-left text-sm">
+          <thead className="border-b bg-background-secondary">
+            <tr>
+              <th className="px-4 py-2">Email</th>
+              <th className="px-4 py-2">Name</th>
+              <th className="px-4 py-2">Teams</th>
+              <th className="px-4 py-2">Flags</th>
+              <th className="px-4 py-2">Joined</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y">
+            {members.map((m) => (
+              <tr key={m.id}>
+                <td className="px-4 py-2 font-mono">{m.primaryEmail}</td>
+                <td className="px-4 py-2">{m.name ?? "—"}</td>
+                <td className="px-4 py-2">
+                  {m.teams.length === 0
+                    ? "—"
+                    : m.teams
+                        .map((t) => `${t.teamSlug} (${t.role})`)
+                        .join(", ")}
+                </td>
+                <td className="px-4 py-2">
+                  {m.isSuperAdmin ? (
+                    <span className="mr-2 rounded bg-util-accent/20 px-1.5 py-0.5 text-xs">
+                      operator
+                    </span>
+                  ) : null}
+                  {m.suspended ? (
+                    <span className="rounded bg-util-error/20 px-1.5 py-0.5 text-xs">
+                      suspended
+                    </span>
+                  ) : null}
+                  {!m.isSuperAdmin && !m.suspended ? "—" : null}
+                </td>
+                <td className="px-4 py-2 text-content-secondary">
+                  {new Date(m.creationTime).toLocaleDateString()}
+                </td>
+              </tr>
+            ))}
+            {members.length === 0 && !isLoading ? (
+              <tr>
+                <td
+                  colSpan={5}
+                  className="px-4 py-6 text-center text-content-secondary"
+                >
+                  No members on this instance.
+                </td>
+              </tr>
+            ) : null}
+          </tbody>
+        </table>
+      </div>
+    </AdminLayout>
+  );
+}

--- a/npm-packages/dashboard-orchestrator/src/pages/admin/members.tsx
+++ b/npm-packages/dashboard-orchestrator/src/pages/admin/members.tsx
@@ -1,19 +1,63 @@
-// Every member on the instance with their team memberships and flags.
-//
-// Read-only in Phase 1 — grant/revoke and suspend land in Phase 2.
+// Every member on the instance, with their team memberships, flags, and
+// the governance actions.
 
+import { useState } from "react";
 import { AdminLayout } from "../../components/admin/AdminLayout";
 import { useAdminMembers } from "../../hooks/useAdmin";
+import { memberActions, type AdminMember } from "../../lib/adminApi";
+import { orchestratorUrl } from "../../lib/config";
+import {
+  useAccessToken,
+  useOrchestratorSession,
+} from "../../lib/useOrchestratorToken";
 
 export default function AdminMembersPage() {
-  const { data, error, isLoading } = useAdminMembers();
+  const { data, error, isLoading, mutate } = useAdminMembers();
+  const token = useAccessToken();
+  const url = orchestratorUrl();
+  const { data: session } = useOrchestratorSession();
+
+  const [busyId, setBusyId] = useState<number | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
   const members = data?.members ?? [];
+
+  async function run(m: AdminMember, fn: () => Promise<unknown>) {
+    if (!token) return;
+    setBusyId(m.id);
+    setNotice(null);
+    try {
+      await fn();
+    } catch (e) {
+      // The 409 from revoking the last operator carries a message that says
+      // what to do about it, so show it rather than a generic failure.
+      setNotice(String(e));
+    } finally {
+      setBusyId(null);
+      await mutate();
+    }
+  }
+
+  function confirmSelfSuspend(m: AdminMember): boolean {
+    if (session?.memberId !== m.id) return true;
+    return window.confirm(
+      "This suspends your own account and signs you out. You can recover by " +
+        "signing in with BOOTSTRAP_TOKEN. Continue?",
+    );
+  }
 
   return (
     <AdminLayout title="Members">
       {error ? (
         <p className="mb-4 rounded border border-util-error p-4 text-sm">
           Could not load members: {String(error)}
+        </p>
+      ) : null}
+      {notice ? (
+        <p
+          role="status"
+          className="mb-4 rounded border border-util-warning p-3 text-sm"
+        >
+          {notice}
         </p>
       ) : null}
       {isLoading ? <p className="text-sm">Loading…</p> : null}
@@ -26,39 +70,83 @@ export default function AdminMembersPage() {
               <th className="px-4 py-2">Name</th>
               <th className="px-4 py-2">Teams</th>
               <th className="px-4 py-2">Flags</th>
-              <th className="px-4 py-2">Joined</th>
+              <th className="px-4 py-2">Actions</th>
             </tr>
           </thead>
           <tbody className="divide-y">
-            {members.map((m) => (
-              <tr key={m.id}>
-                <td className="px-4 py-2 font-mono">{m.primaryEmail}</td>
-                <td className="px-4 py-2">{m.name ?? "—"}</td>
-                <td className="px-4 py-2">
-                  {m.teams.length === 0
-                    ? "—"
-                    : m.teams
-                        .map((t) => `${t.teamSlug} (${t.role})`)
-                        .join(", ")}
-                </td>
-                <td className="px-4 py-2">
-                  {m.isSuperAdmin ? (
-                    <span className="mr-2 rounded bg-util-accent/20 px-1.5 py-0.5 text-xs">
-                      operator
-                    </span>
-                  ) : null}
-                  {m.suspended ? (
-                    <span className="rounded bg-util-error/20 px-1.5 py-0.5 text-xs">
-                      suspended
-                    </span>
-                  ) : null}
-                  {!m.isSuperAdmin && !m.suspended ? "—" : null}
-                </td>
-                <td className="px-4 py-2 text-content-secondary">
-                  {new Date(m.creationTime).toLocaleDateString()}
-                </td>
-              </tr>
-            ))}
+            {members.map((m) => {
+              const busy = busyId === m.id;
+              const isSelf = session?.memberId === m.id;
+              return (
+                <tr key={m.id}>
+                  <td className="px-4 py-2 font-mono">
+                    {m.primaryEmail}
+                    {isSelf ? (
+                      <span className="ml-2 text-xs text-content-secondary">
+                        (you)
+                      </span>
+                    ) : null}
+                  </td>
+                  <td className="px-4 py-2">{m.name ?? "—"}</td>
+                  <td className="px-4 py-2">
+                    {m.teams.length === 0
+                      ? "—"
+                      : m.teams
+                          .map((t) => `${t.teamSlug} (${t.role})`)
+                          .join(", ")}
+                  </td>
+                  <td className="px-4 py-2">
+                    {m.isSuperAdmin ? (
+                      <span className="mr-2 rounded bg-util-accent/20 px-1.5 py-0.5 text-xs">
+                        operator
+                      </span>
+                    ) : null}
+                    {m.suspended ? (
+                      <span className="rounded bg-util-error/20 px-1.5 py-0.5 text-xs">
+                        suspended
+                      </span>
+                    ) : null}
+                    {!m.isSuperAdmin && !m.suspended ? "—" : null}
+                  </td>
+                  <td className="px-4 py-2">
+                    <div className="flex gap-2">
+                      <button
+                        type="button"
+                        disabled={busy || !token}
+                        onClick={() => {
+                          if (!m.suspended && !confirmSelfSuspend(m)) return;
+                          void run(m, () =>
+                            m.suspended
+                              ? memberActions.unsuspend(url, token!, m.id)
+                              : memberActions.suspend(url, token!, m.id),
+                          );
+                        }}
+                        className="rounded border px-2 py-1 text-xs disabled:opacity-40"
+                      >
+                        {m.suspended ? "Unsuspend" : "Suspend"}
+                      </button>
+                      <button
+                        type="button"
+                        disabled={busy || !token}
+                        onClick={() =>
+                          void run(m, () =>
+                            memberActions.setSuperAdmin(
+                              url,
+                              token!,
+                              m.id,
+                              !m.isSuperAdmin,
+                            ),
+                          )
+                        }
+                        className="rounded border px-2 py-1 text-xs disabled:opacity-40"
+                      >
+                        {m.isSuperAdmin ? "Revoke operator" : "Make operator"}
+                      </button>
+                    </div>
+                  </td>
+                </tr>
+              );
+            })}
             {members.length === 0 && !isLoading ? (
               <tr>
                 <td

--- a/npm-packages/dashboard-orchestrator/src/pages/admin/teams.tsx
+++ b/npm-packages/dashboard-orchestrator/src/pages/admin/teams.tsx
@@ -1,0 +1,154 @@
+// Every team on the instance, with the counts that make a delete legible.
+
+import { useState } from "react";
+import { AdminLayout } from "../../components/admin/AdminLayout";
+import { ConfirmByName } from "../../components/admin/ConfirmByName";
+import { useAdminTeams } from "../../hooks/useAdmin";
+import { teamActions, type AdminTeam } from "../../lib/adminApi";
+import { orchestratorUrl } from "../../lib/config";
+import { useAccessToken } from "../../lib/useOrchestratorToken";
+
+export default function AdminTeamsPage() {
+  const { data, error, isLoading, mutate } = useAdminTeams();
+  const token = useAccessToken();
+  const url = orchestratorUrl();
+
+  const [busy, setBusy] = useState(false);
+  const [notice, setNotice] = useState<string | null>(null);
+  const [pendingDelete, setPendingDelete] = useState<AdminTeam | null>(null);
+  const [newName, setNewName] = useState("");
+
+  async function withBusy(fn: () => Promise<string>) {
+    if (!token) return;
+    setBusy(true);
+    setNotice(null);
+    try {
+      setNotice(await fn());
+    } catch (e) {
+      setNotice(`Failed: ${e}`);
+    } finally {
+      setBusy(false);
+      await mutate();
+      setPendingDelete(null);
+    }
+  }
+
+  return (
+    <AdminLayout title="Teams">
+      {error ? (
+        <p className="mb-4 rounded border border-util-error p-4 text-sm">
+          Could not load teams: {String(error)}
+        </p>
+      ) : null}
+      {notice ? (
+        <p role="status" className="mb-4 rounded border p-3 text-sm">
+          {notice}
+        </p>
+      ) : null}
+
+      <form
+        className="mb-6 flex gap-2"
+        onSubmit={(e) => {
+          e.preventDefault();
+          const name = newName.trim();
+          if (!name) return;
+          void withBusy(async () => {
+            const r = await teamActions.create(url, token!, name);
+            setNewName("");
+            return `Created ${r.slug}`;
+          });
+        }}
+      >
+        <input
+          value={newName}
+          onChange={(e) => setNewName(e.target.value)}
+          placeholder="New team name"
+          aria-label="New team name"
+          className="rounded border px-2 py-1 text-sm"
+        />
+        <button
+          type="submit"
+          disabled={busy || !newName.trim()}
+          className="rounded border px-3 py-1 text-sm disabled:opacity-40"
+        >
+          Create team
+        </button>
+      </form>
+
+      {isLoading ? <p className="text-sm">Loading…</p> : null}
+
+      <div className="overflow-x-auto rounded-lg border">
+        <table className="w-full text-left text-sm">
+          <thead className="border-b bg-background-secondary">
+            <tr>
+              <th className="px-4 py-2">Team</th>
+              <th className="px-4 py-2">Slug</th>
+              <th className="px-4 py-2">Members</th>
+              <th className="px-4 py-2">Projects</th>
+              <th className="px-4 py-2">Deployments</th>
+              <th className="px-4 py-2">Actions</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y">
+            {(data?.teams ?? []).map((t) => (
+              <tr key={t.id}>
+                <td className="px-4 py-2">{t.name}</td>
+                <td className="px-4 py-2 font-mono">{t.slug}</td>
+                <td className="px-4 py-2">{t.memberCount}</td>
+                <td className="px-4 py-2">{t.projectCount}</td>
+                <td className="px-4 py-2">{t.deploymentCount}</td>
+                <td className="px-4 py-2">
+                  <button
+                    type="button"
+                    disabled={busy || !token}
+                    onClick={() => setPendingDelete(t)}
+                    className="rounded border border-util-error px-2 py-1 text-xs disabled:opacity-40"
+                  >
+                    Delete
+                  </button>
+                </td>
+              </tr>
+            ))}
+            {data && data.teams.length === 0 && !isLoading ? (
+              <tr>
+                <td
+                  colSpan={6}
+                  className="px-4 py-6 text-center text-content-secondary"
+                >
+                  No teams on this instance.
+                </td>
+              </tr>
+            ) : null}
+          </tbody>
+        </table>
+      </div>
+
+      {pendingDelete ? (
+        <ConfirmByName
+          title="Delete team"
+          // The slug, not the display name: it is the stable identifier and
+          // it is what the operator sees in URLs and deploy keys.
+          expected={pendingDelete.slug}
+          confirmLabel="Delete team and everything in it"
+          busy={busy}
+          onCancel={() => setPendingDelete(null)}
+          onConfirm={() =>
+            void withBusy(async () => {
+              const r = await teamActions.remove(url, token!, pendingDelete.id);
+              return `Deleted ${r.slug}, tearing down ${r.deploymentsRemoved} deployment(s)`;
+            })
+          }
+          description={
+            <>
+              This deletes{" "}
+              <span className="font-mono">{pendingDelete.slug}</span>, its{" "}
+              {pendingDelete.projectCount} project(s), and tears down{" "}
+              <strong>{pendingDelete.deploymentCount} deployment(s)</strong>.
+              Their data is not recoverable from here.
+            </>
+          }
+        />
+      ) : null}
+    </AdminLayout>
+  );
+}

--- a/npm-packages/dashboard-orchestrator/src/pages/api/orchestrator/token.ts
+++ b/npm-packages/dashboard-orchestrator/src/pages/api/orchestrator/token.ts
@@ -86,6 +86,9 @@ export default async function handler(
     memberId: number;
     teamSlug: string;
     role: string;
+    // Absent on orchestrator builds that pre-date the admin console; the
+    // client defaults it to false, which just hides the admin nav.
+    isSuperAdmin?: boolean;
   };
 
   // Headers to discourage caching of bearer tokens.

--- a/self-hosted/advanced/orchestrator.md
+++ b/self-hosted/advanced/orchestrator.md
@@ -416,6 +416,27 @@ one tenant's token against a second tenant's resources across the whole route
 table, and a source-level sweep fails the build if a new path-scoped handler is
 added without an authorization guard.
 
+### Deployment lifecycle
+
+The Deployments view carries per-row actions:
+
+| Action      | Effect                                                                                                                                                                    |
+| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Pause**   | Stops the container without removing it, and marks the row `paused`. Configuration, volumes, and data are preserved; reconcile leaves paused deployments alone by intent. |
+| **Resume**  | Starts the container again and marks the row `running`.                                                                                                                   |
+| **Restart** | Recreates the container, applying any pending tier or canonical-URL change. Same path the CLI and management API use.                                                     |
+| **Tier**    | Records a new _desired_ tier. It takes effect on the next restart, not immediately.                                                                                       |
+| **Delete**  | Tears the container down and removes the deployment. Not recoverable from here.                                                                                           |
+
+The database row is the source of truth and container work is best-effort: if a
+container operation fails after the row changed, the action still took effect
+and the reconciler converges, so the response carries a warning rather than
+reporting failure. **Delete is the exception** — if teardown fails the
+deployment is kept, because removing the row while a container survives orphans
+it where nothing will list it again.
+
+Every action is recorded in the instance audit log.
+
 ### Health endpoints
 
 | Path                | Auth     | Meaning                                                                       |

--- a/self-hosted/advanced/orchestrator.md
+++ b/self-hosted/advanced/orchestrator.md
@@ -397,6 +397,25 @@ Two things the flag deliberately does not do:
 - It is not a data-access grant. Phase 1 is read-only metadata; reaching into a
   tenant's deployment is a separate, audited action.
 
+### Authorization model
+
+Every route that names a team, project, or deployment in its path checks that
+the caller belongs to the owning team. Destructive and governance actions —
+deleting a team, removing a member, changing a role, granting project admin —
+additionally require the team `admin` role.
+
+Deploy keys are bound to the deployment they were minted for and are refused
+against any other, so a key committed to CI has the blast radius of its own
+deployment and nothing more. The one exception is
+`/api/deployment/authorize_within_current_project`, which exists to select among
+sibling deployments (dev, preview, prod) and is therefore scoped to the project
+rather than the single deployment.
+
+A cross-tenant test suite (`crates/orchestrator/tests/cross_tenant.rs`) drives
+one tenant's token against a second tenant's resources across the whole route
+table, and a source-level sweep fails the build if a new path-scoped handler is
+added without an authorization guard.
+
 ### Health endpoints
 
 | Path                | Auth     | Meaning                                                                       |

--- a/self-hosted/advanced/orchestrator.md
+++ b/self-hosted/advanced/orchestrator.md
@@ -61,6 +61,9 @@ own infrastructure and behave the same way.
 - Custom domains, end to end: managed entirely in the dashboard, routed via
   Traefik's file provider, with certificates the orchestrator issues itself over
   HTTP-01 and renews automatically. See [Custom domains](#custom-domains).
+- An instance admin console for operators: fleet health, every team, every
+  member, and an instance-scoped audit log. See
+  [Instance admin](#instance-admin).
 
 **Stubbed** (returns sensible empty / defaults so the dashboard renders without
 errors, but the cloud-only feature is not implemented):
@@ -257,6 +260,7 @@ instead.
 | `BETTER_AUTH_REQUIRE_EMAIL_VERIFICATION` / `BETTER_AUTH_SMTP_URL` / `BETTER_AUTH_SMTP_FROM`                          | `0` / unset / `no-reply@orchestrator`                                              | Optional SMTP for password reset / verification links.                                                                                                                     |
 | `ORCHESTRATOR_IMAGE` / `DASHBOARD_ORCHESTRATOR_IMAGE` / `DASHBOARD_IMAGE`                                            | `ghcr.io/defy-works/convex-{orchestrator,dashboard-orchestrator,dashboard}:latest` | Pin to a specific image tag.                                                                                                                                               |
 | `RUST_LOG`                                                                                                           | `orchestrator=info,tower_http=warn`                                                | Orchestrator log filter.                                                                                                                                                   |
+| `CONVEX_ORCHESTRATOR_RECONCILE_INTERVAL_SECS`                                                                        | `60`                                                                               | Seconds between reconcile passes over tenant containers. `0` restores boot-only behaviour. Docker provisioner mode only.                                                   |
 | `TRAEFIK_DYNAMIC_DIR`                                                                                                | `/convex/traefik-dynamic`                                                          | Directory the orchestrator renders custom-domain routers into, watched by Traefik's file provider. Unset to disable custom domains.                                        |
 | `CUSTOM_DOMAIN_CERT_RESOLVER`                                                                                        | `lehttp`                                                                           | ACME resolver for custom-domain certs. Must be HTTP-01 based — see Custom domains below.                                                                                   |
 
@@ -368,6 +372,52 @@ A cross-tenant test suite (`crates/orchestrator/tests/cross_tenant.rs`) drives
 one tenant's token against a second tenant's resources across the whole route
 table, and a source-level sweep fails the build if a new path-scoped handler is
 added without an authorization guard.
+
+## Instance admin
+
+Operators — members carrying the instance-wide super-admin flag — get an
+`/admin` section in the platform UI that covers the whole instance rather than
+one team: fleet health, every team, every member, and an instance-scoped audit
+log.
+
+The first operator is seeded from `ADMIN_EMAILS` at sign-in. After that the flag
+lives in the database, so operators are granted and revoked in the console
+without a redeploy. Seeding is one-way on purpose: removing an address from
+`ADMIN_EMAILS` does **not** revoke an existing operator, because a config edit
+should not silently become a security action.
+
+If every operator account is locked out, sign in with `BOOTSTRAP_TOKEN`. It is
+treated as an operator regardless of the database, so recovery never requires
+`psql`.
+
+Two things the flag deliberately does not do:
+
+- It never rides a deploy key. Only session and personal-access tokens can carry
+  it, so a prod key checked into CI is not an instance-wide credential.
+- It is not a data-access grant. Phase 1 is read-only metadata; reaching into a
+  tenant's deployment is a separate, audited action.
+
+### Health endpoints
+
+| Path                | Auth     | Meaning                                                                       |
+| ------------------- | -------- | ----------------------------------------------------------------------------- |
+| `/health`           | none     | Liveness. 200 whenever the process is up. Never checks dependencies.          |
+| `/ready`            | none     | Readiness. 200 only when Postgres is reachable. Status only, no error detail. |
+| `/api/admin/health` | operator | Subsystem detail: Postgres latency, docker socket, reconcile interval.        |
+
+Point container healthchecks and load-balancer target groups at **`/ready`**,
+not `/health`. A liveness probe that fails on a database blip gets the process
+killed, which does not fix a database problem and, behind a load balancer,
+cycles every target at once. `/ready` withholds error detail because it is
+unauthenticated; `/api/admin/health` is where the reason lives.
+
+### Reconcile interval
+
+The orchestrator reconciles tenant containers against the database on boot and
+every `CONVEX_ORCHESTRATOR_RECONCILE_INTERVAL_SECS` seconds thereafter (default
+`60`; `0` restores the previous boot-only behaviour). Docker provisioner mode
+only — the other modes do not own containers. Drift between what the database
+intends and what docker is running shows in the console's Deployments view.
 
 ## Running the orchestrator
 

--- a/self-hosted/advanced/orchestrator.md
+++ b/self-hosted/advanced/orchestrator.md
@@ -437,6 +437,34 @@ it where nothing will list it again.
 
 Every action is recorded in the instance audit log.
 
+### Governance
+
+Members and teams are managed from the console. Suspending a member blocks
+authentication while preserving their teams, projects, and audit history;
+deleting is the permanent case. Deleting a member who is an operator clears that
+flag first, so the console cannot delete its way to an instance nobody can
+administer — the same guard that refuses to revoke the last operator.
+
+Deleting a team cascades to its projects and tears down every deployment
+underneath. The confirmation states the deployment count before you commit, and
+asks for the team **slug** typed exactly.
+
+### Break-glass access
+
+Opening a tenant's deployment from the console is deliberately ceremonious:
+
+- a **reason is required**, and is recorded verbatim;
+- the admin key is **minted fresh with a 15-minute TTL** — never the
+  deployment's permanent key;
+- the event is written to the **tenant's own audit log** as well as the
+  instance's, so the team can see that an operator opened their deployment and
+  why.
+
+That last point is the design, not a nicety. An audit trail only the operator
+can read is not accountability. The modal says so before you confirm.
+
+Break-glass events are highlighted in the instance audit log.
+
 ### Health endpoints
 
 | Path                | Auth     | Meaning                                                                       |

--- a/self-hosted/docker/docker-compose.orchestrator.yml
+++ b/self-hosted/docker/docker-compose.orchestrator.yml
@@ -146,7 +146,10 @@ services:
       - CONVEX_ORCHESTRATOR_ACME_DIRECTORY_URL=${ACME_DIRECTORY_URL:-}
       - RUST_LOG=${RUST_LOG:-orchestrator=info,tower_http=warn}
     healthcheck:
-      test: curl -fsS http://localhost:8050/health || exit 1
+      # Readiness, not liveness: the container is only "healthy" once it can
+      # reach Postgres. `/health` returns 200 as long as the process is up,
+      # which would mark a database-less orchestrator healthy.
+      test: curl -fsS http://localhost:8050/ready || exit 1
       interval: 5s
       start_period: 30s
       retries: 10


### PR DESCRIPTION
An instance-scoped operator console for the orchestrator: fleet health,
deployment lifecycle, member and team governance, and audited break-glass
access to a tenant's deployment.

Before this, operating the whole instance meant SSH plus `docker ps` plus
`psql`. Every read path was team-scoped by construction — there was no "all
teams", "all members", or "all deployments" view anywhere, and `AuthIdentity`
had no platform-admin bit to hang one off.

Builds on #21 (tenant isolation), which had to land first: break-glass gating
is meaningless while `/api/dashboard/instances/{name}/auth` is open to every
authenticated user.

## Identity

`members.is_super_admin`, seeded from `ADMIN_EMAILS` at sign-in. After that
the column is the authority, so operators are granted and revoked in the
console without a redeploy. Seeding is one-way on purpose: dropping an
address from `ADMIN_EMAILS` must not silently strip a live operator, because
that would make a config edit a security action nobody reviewed as one.

Two deliberate limits:

- **The bit never rides a deploy key.** Only `Session` and `Pat` tokens carry
  it, so a prod key in CI is not an instance-wide credential.
- **Break-glass is keyed on the synthetic bootstrap member**, not on the
  token's name. Members can name their own PATs, so a name check would have
  let anyone mint themselves instance root. `exchange_session` already
  refuses the `system:` namespace, so the identity cannot be forged.

`members.suspended` is a reversible authentication block that preserves teams,
projects, and audit history — distinct from the permanent `deleted`.

## Two live bugs fixed on the way

**`/health` checked nothing** while `docker-compose.orchestrator.yml:149`
already used it as the container healthcheck, so the orchestrator reported
healthy with Postgres unreachable. `/health` stays dependency-free liveness;
a new `/ready` does the real check and the compose healthcheck points at it.
A liveness probe that fails on a database blip gets the process killed, which
does not fix a database problem and cycles every target at once behind a load
balancer.

**Reconcile ran once at boot and exited**, so container drift after startup
was neither detected nor corrected. It is now an interval loop, default 60s,
`0` to restore the old behaviour.

## What the console does

Read-only: fleet health with intended-vs-actual container state and drift,
capacity, all teams, all members, and an instance-scoped audit log.

Lifecycle: pause, resume, restart, tier, delete. The database row is the
source of truth and container work is best-effort — if `docker stop` fails
after the row is marked paused, the action took effect and the reconciler
converges, so the response carries a warning rather than reporting failure.
**Delete is the exception**: it fails and keeps the row if teardown fails,
because removing the row while a container survives orphans it where nothing
will list it again.

Governance: suspend, unsuspend, grant/revoke operator, delete. Revoking the
last operator is a 409 with a message that says what to do about it, not a
500. Deleting an operator inherits the same guard, so the console cannot
delete its way to an instance nobody can administer.

Teams: list with counts, create, rename, delete. Delete cascades explicitly
rather than leaning on the foreign keys — the rows would go either way, the
containers would not.

## Break-glass

Everything else here is metadata. This one hands over the ability to read and
write a tenant's data, so it is deliberately ceremonious:

- a reason is required and recorded verbatim;
- the key is minted fresh with a 15-minute TTL, never the deployment's
  permanent one;
- the event is written to the **tenant's own audit log** as well as the
  instance's.

The last point is the design rather than a nicety: an audit trail only the
operator can read is not accountability. The modal says so before the
operator confirms.

It could not reuse `ephemeral_admin_key`: that returns
`deployment.instance_secret` when it looks like an admin key, so on every
deployment ever provisioned it would have handed back the permanent
credential behind a TTL that was pure fiction. The test asserts the returned
key differs from a stored permanent one.

## Guard rails

`ADMIN_ROUTES` is the route table a test iterates: unauthenticated is 401,
authenticated-but-not-an-operator is 403, and an operator gets 200 on all 18.
A second test cross-checks that table against the OpenAPI surface in both
directions, so it cannot silently fall behind the router. The fixture builds
a fresh deployment, member, and team per route, because the delete routes
remove the one they are given and every later route would otherwise fail for
the wrong reason.

## Verification

113 lib + 3 cross-tenant + 27 integration tests against a real Postgres 16.4;
clippy clean. 20 jest suites / 82 tests; `tsc --noEmit` clean. No dprint
violations.

**Not verified:** no admin page has been rendered in a browser, and the
`docker stop` / `docker start` calls have never executed — the machine this
was built on has no hardware virtualization. The container *ordering*
decision is pure and unit-tested; only the shell-out is unexercised. Periodic
reconcile is in the same category.

## Open decision

Break-glass is built for the "mixed tenancy" assumption recorded in the
design doc. If this instance is settled as internal-only, the dual audit
write and the reason requirement are over-built and could be simplified. If
it is genuinely external, break-glass should additionally be rate-limited and
notify the team by email rather than only writing their audit log. Worth
settling before this merges, since either answer changes shipped code.

## Deliberately out of scope

- Phase 3: the `instance_config` table, live-vs-spawn-time knob
  classification, `/admin/settings`, respawn-on-save.
- `/api/dashboard/host_capacity` still reports fleet totals to every
  authenticated user. Narrowing it would break `advanced-knobs.tsx:231`,
  which renders `deploymentCount`, for a leak whose severity depends on the
  tenancy question above.
- `project_admins` exists in the schema with nothing enforcing it. Team
  membership is the boundary; project-level restriction is additive.
- Member impersonation. Break-glass covers the real support need.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an instance admin console with overview, health, fleet, audit, deployment, member, and team management.
  * Added deployment pause, resume, restart, deletion, tier updates, and break-glass access.
  * Added readiness monitoring and periodic container reconciliation.
  * Added super-admin status, suspension controls, audit logging, and protected administrative actions.
* **Bug Fixes**
  * Health checks now verify database readiness.
  * Improved handling and reporting of downstream container failures.
* **Documentation**
  * Documented the admin console, break-glass access, and reconciliation settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->