### PR TITLE
Fix orchestrator startup crash on existing databases

### DIFF
--- a/crates/orchestrator/src/storage/schema.rs
+++ b/crates/orchestrator/src/storage/schema.rs
@@ -131,8 +131,11 @@ CREATE TABLE IF NOT EXISTS audit_log_events (
     scope TEXT NOT NULL DEFAULT 'team' CHECK (scope IN ('team','instance'))
 );
 CREATE INDEX IF NOT EXISTS audit_team_time_idx ON audit_log_events(team_id, creation_time);
-CREATE INDEX IF NOT EXISTS audit_instance_time_idx
-    ON audit_log_events(creation_time) WHERE scope = 'instance';
+-- NOTE: the partial index on `scope` lives in `migrations.rs`, not here.
+-- SCHEMA_SQL runs first and `CREATE TABLE IF NOT EXISTS` is a no-op against
+-- an existing database, so an index referencing a column that migrations
+-- add would fail on every upgrade — before the migration that adds it ever
+-- runs. Only index columns that have existed since the table was created.
 
 CREATE TABLE IF NOT EXISTS opt_ins (
     member_id BIGINT NOT NULL REFERENCES members(id) ON DELETE CASCADE,

--- a/crates/orchestrator/tests/integration.rs
+++ b/crates/orchestrator/tests/integration.rs
@@ -2568,3 +2568,129 @@ async fn break_glass_mints_a_fresh_key_and_writes_both_audit_logs() {
         "the tenant sees the reason too, not just that something happened"
     );
 }
+
+/// Migrations must succeed against a database that already exists.
+///
+/// The rest of the DB-backed suite calls `reset_public_schema` first, so it
+/// only ever exercises the fresh-database path. That hid a startup crash:
+/// `SCHEMA_SQL` runs before the `ALTER TABLE`s, and `CREATE TABLE IF NOT
+/// EXISTS` is a no-op against an existing database — so an index in
+/// `SCHEMA_SQL` referencing a column that migrations add fails on every
+/// upgrade, before the migration that adds it can run.
+///
+/// This simulates a pre-upgrade instance by migrating, then stripping the
+/// columns this release adds, then migrating again.
+#[tokio::test]
+#[ignore = "needs TEST_ORCHESTRATOR_DATABASE_URL"]
+async fn migrations_succeed_against_a_pre_existing_database() {
+    let database_url = std::env::var("TEST_ORCHESTRATOR_DATABASE_URL")
+        .expect("TEST_ORCHESTRATOR_DATABASE_URL not set (this test is `#[ignore]` by default)");
+    reset_public_schema(&database_url).await;
+
+    let pool = orchestrator::storage::pool::PgPool::connect(&database_url)
+        .await
+        .expect("connect test pool");
+
+    // Bring the schema up to date the normal way.
+    orchestrator::storage::migrations::run(&pool)
+        .await
+        .expect("first migration run");
+
+    // Rewind to what an instance looked like before this release: the
+    // tables are present and populated, but without the new columns.
+    let conn = pool.acquire().await.expect("acquire");
+    conn.client()
+        .batch_execute(
+            r#"
+            DROP INDEX IF EXISTS audit_instance_time_idx;
+            ALTER TABLE audit_log_events
+              DROP COLUMN IF EXISTS scope,
+              ALTER COLUMN team_id SET NOT NULL;
+            ALTER TABLE members
+              DROP COLUMN IF EXISTS is_super_admin,
+              DROP COLUMN IF EXISTS suspended;
+            "#,
+        )
+        .await
+        .expect("rewind to the pre-upgrade shape");
+    drop(conn);
+
+    // The upgrade must work. Before the fix this failed with
+    // `column "scope" does not exist`, which crash-looped the orchestrator.
+    orchestrator::storage::migrations::run(&pool)
+        .await
+        .expect("migrating an existing database must succeed");
+
+    // And it must actually be upgraded, not merely not-crashed.
+    let conn = pool.acquire().await.expect("acquire");
+    let cols = conn
+        .client()
+        .query(
+            "SELECT table_name, column_name
+               FROM information_schema.columns
+              WHERE table_schema = 'public'
+                AND ((table_name = 'members'
+                      AND column_name IN ('is_super_admin','suspended'))
+                  OR (table_name = 'audit_log_events' AND column_name = 'scope'))",
+            &[],
+        )
+        .await
+        .expect("query information_schema");
+    assert_eq!(
+        cols.len(),
+        3,
+        "expected all three columns after upgrade, got {:?}",
+        cols.iter()
+            .map(|r| format!("{}.{}", r.get::<_, String>(0), r.get::<_, String>(1)))
+            .collect::<Vec<_>>()
+    );
+
+    // A third run must also be clean: startup runs this every time.
+    drop(conn);
+    orchestrator::storage::migrations::run(&pool)
+        .await
+        .expect("migrations must stay idempotent");
+}
+
+/// The manual unblock for an instance already crash-looping on the shipped
+/// image: add the column by hand, and startup recovers without a rollback.
+#[tokio::test]
+#[ignore = "needs TEST_ORCHESTRATOR_DATABASE_URL"]
+async fn adding_scope_by_hand_unblocks_a_crash_looping_instance() {
+    let database_url = std::env::var("TEST_ORCHESTRATOR_DATABASE_URL")
+        .expect("TEST_ORCHESTRATOR_DATABASE_URL not set (this test is `#[ignore]` by default)");
+    reset_public_schema(&database_url).await;
+    let pool = orchestrator::storage::pool::PgPool::connect(&database_url)
+        .await
+        .expect("connect");
+    orchestrator::storage::migrations::run(&pool)
+        .await
+        .expect("first run");
+
+    // Rewind to the pre-upgrade shape, i.e. what a stuck instance has.
+    let conn = pool.acquire().await.expect("acquire");
+    conn.client()
+        .batch_execute(
+            "DROP INDEX IF EXISTS audit_instance_time_idx;
+             ALTER TABLE audit_log_events DROP COLUMN IF EXISTS scope;
+             ALTER TABLE members
+               DROP COLUMN IF EXISTS is_super_admin,
+               DROP COLUMN IF EXISTS suspended;",
+        )
+        .await
+        .expect("rewind");
+
+    // The operator's one-liner.
+    conn.client()
+        .batch_execute(
+            "ALTER TABLE audit_log_events
+               ADD COLUMN IF NOT EXISTS scope TEXT NOT NULL DEFAULT 'team';",
+        )
+        .await
+        .expect("manual unblock");
+    drop(conn);
+
+    orchestrator::storage::migrations::run(&pool)
+        .await
+        .expect("startup must now succeed even on the shipped image");
+}


### PR DESCRIPTION
**The orchestrator crash-loops on startup against any pre-existing database.**
Regression from #22. Every real instance is affected; a fresh one is not,
which is why nothing caught it.

## What happens

`SCHEMA_SQL` carried a partial index referencing `scope` directly after the
audit table:

```sql
CREATE TABLE IF NOT EXISTS audit_log_events (... scope TEXT ...);
CREATE INDEX IF NOT EXISTS audit_instance_time_idx
  ON audit_log_events(creation_time) WHERE scope = 'instance';
```

On a fresh database `CREATE TABLE` creates it *with* `scope` and the index
builds. On an existing one `CREATE TABLE IF NOT EXISTS` is a no-op, the table
has no `scope`, and the index fails with `column "scope" does not exist`.
`migrations::run` executes `SCHEMA_SQL` **before** the `ALTER TABLE ... ADD
COLUMN scope`, so it dies before it can add the column — every startup.

It surfaced as `orchestrator token fetch 500` in the dashboard: with the
orchestrator unreachable the Next.js bridge's `fetch` throws unhandled.
Anything the orchestrator itself returned would have mapped to 401/403/502,
so a 500 there always means "could not reach it at all".

## The fix

The index already exists in `migrations.rs`, after the column is added, so
deleting it from `SCHEMA_SQL` is the whole change. It was the only index in
`SCHEMA_SQL` referencing a migration-added column — the rest are on columns
present since their table was created. A comment now records the rule.

## Why the tests missed it

Every DB-backed test calls `reset_public_schema` first, so the suite only
ever exercised the **fresh-database** path. The upgrade path — the only one
production takes — was never run once, across 143 tests.

The new test migrates, strips the columns this release adds, migrates again,
and asserts the columns exist afterwards. Reintroducing the bug makes it fail
with the exact production error. A second test documents the manual unblock
below.

## Unblocking an instance that is already stuck

No rollback and no wait for this to ship — run against the orchestrator's
database:

```sql
ALTER TABLE audit_log_events
  ADD COLUMN IF NOT EXISTS scope TEXT NOT NULL DEFAULT 'team';
```

Then restart the orchestrator. With the column present the index succeeds and
migrations complete normally. Verified in a test against the *shipped* buggy
code, not just reasoned about.

## Verification

113 lib + 3 cross-tenant + 29 integration against a real Postgres 16.4;
clippy clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database schema initialization and migration handling for existing installations.
  * Prevented startup failures when upgrading schemas with newly introduced audit log fields.
  * Ensured repeated migration runs remain safe and reliable.

* **Tests**
  * Added coverage for recovering from incomplete migrations and crash-loop scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->