### PR TITLE
Authorize handlers that name their resource in the request body

### DIFF
--- a/crates/orchestrator/openapi.json
+++ b/crates/orchestrator/openapi.json
@@ -1075,7 +1075,7 @@
     "/api/authorize": {
       "post": {
         "tags": ["deployment_internal"],
-        "summary": "CLI auth endpoint. Accepts only a bootstrap token in v1. Human users\nauthenticate through the dashboard (BetterAuth → /api/internal/exchange_session).",
+        "summary": "CLI auth endpoint. Accepts only a bootstrap token in v1. Human users\nauthenticate through the dashboard (BetterAuth →\n/api/internal/exchange_session).",
         "operationId": "authorize",
         "requestBody": {
           "content": {

--- a/crates/orchestrator/src/routes/dashboard/projects.rs
+++ b/crates/orchestrator/src/routes/dashboard/projects.rs
@@ -142,10 +142,20 @@ pub(crate) async fn update_project(
     tag = "dashboard",
 )]
 pub(crate) async fn delete_projects(
-    _auth: AuthIdentity,
+    auth: AuthIdentity,
     State(state): State<OrchestratorState>,
     Json(ids): Json<Vec<i64>>,
 ) -> ApiResult<StatusCode> {
+    // Authorize every id before destroying anything. This discarded the
+    // identity entirely, so any signed-in user could delete every project on
+    // the instance by posting a list of ids.
+    //
+    // Checked in a first pass rather than inside the loop: a partial delete
+    // that stops halfway through because id 7 was not theirs still destroyed
+    // ids 1 through 6.
+    for id in &ids {
+        require_project_member(&state, &auth, *id).await?;
+    }
     for id in ids {
         crate::routes::helpers::cascade_delete_project(&state, id)
             .await

--- a/crates/orchestrator/src/routes/deployment_internal.rs
+++ b/crates/orchestrator/src/routes/deployment_internal.rs
@@ -5,32 +5,70 @@
 //! and the CLI's `bigBrainAPI` calls.
 
 use axum::{
-    extract::{Path, State},
+    extract::{
+        Path,
+        State,
+    },
     http::StatusCode,
     response::IntoResponse,
-    routing::{get, post},
-    Json, Router,
+    routing::{
+        get,
+        post,
+    },
+    Json,
+    Router,
 };
 use orchestrator_api_types::{
-    dashboard::{DeviceAuthorizeArgs, DeviceAuthorizeResponse, OptIn},
+    dashboard::{
+        DeviceAuthorizeArgs,
+        DeviceAuthorizeResponse,
+        OptIn,
+    },
     deployment::{
-        ClaimPreviewDeploymentArgs, ClaimPreviewDeploymentResponse, CreateProjectArgs,
-        CreateProjectResponse, DeploymentAuthResponse, DeploymentAuthWithinCurrentProjectArgs,
-        HasProjectsResponse, ProjectSelectionArgs, ProvisionAndAuthorizeArgs,
-        TeamAndProjectForDeploymentResponse, TeamSummary,
+        ClaimPreviewDeploymentArgs,
+        ClaimPreviewDeploymentResponse,
+        CreateProjectArgs,
+        CreateProjectResponse,
+        DeploymentAuthResponse,
+        DeploymentAuthWithinCurrentProjectArgs,
+        HasProjectsResponse,
+        ProjectSelectionArgs,
+        ProvisionAndAuthorizeArgs,
+        TeamAndProjectForDeploymentResponse,
+        TeamSummary,
     },
 };
 
 use crate::{
     auth::{
-        identity::{AuthIdentity, OptionalAuth},
-        tokens::{encode_pat, mint_token_secret, parse_token, sha256_hex, suffix_of},
+        identity::{
+            AuthIdentity,
+            OptionalAuth,
+        },
+        tokens::{
+            encode_pat,
+            mint_token_secret,
+            parse_token,
+            sha256_hex,
+            suffix_of,
+        },
     },
-    errors::{ApiError, ApiResult},
+    errors::{
+        ApiError,
+        ApiResult,
+    },
     ids::random_id,
-    routes::helpers::{deployment_to_response, require_deployment_scope},
+    routes::helpers::{
+        deployment_to_response,
+        require_deployment_scope,
+    },
     state::OrchestratorState,
-    storage::{access_tokens::NewAccessToken, AccessTokenKind, DeploymentClass, DeploymentType},
+    storage::{
+        access_tokens::NewAccessToken,
+        AccessTokenKind,
+        DeploymentClass,
+        DeploymentType,
+    },
 };
 
 pub fn router() -> Router<OrchestratorState> {
@@ -78,7 +116,8 @@ pub(crate) async fn orchestrator_version() -> impl IntoResponse {
 }
 
 /// CLI auth endpoint. Accepts only a bootstrap token in v1. Human users
-/// authenticate through the dashboard (BetterAuth → /api/internal/exchange_session).
+/// authenticate through the dashboard (BetterAuth →
+/// /api/internal/exchange_session).
 #[utoipa::path(
     post,
     path = "/api/authorize",
@@ -605,6 +644,10 @@ pub(crate) async fn provision_and_authorize(
         .await
         .map_err(ApiError::Internal)?
         .ok_or_else(|| ApiError::NotFound(format!("project {project_slug}")))?;
+    // require_member above only authenticates. Without this, any signed-in
+    // user could name another tenant's team and project slugs and be handed
+    // that project's existing admin key below.
+    require_same_project(&state, &auth, project.id).await?;
     let dt: DeploymentType = args.deployment_type.parse().map_err(|_| {
         ApiError::BadRequest(format!("unknown deployment type {}", args.deployment_type))
     })?;
@@ -744,6 +787,11 @@ pub(crate) async fn claim_preview_deployment(
 ) -> ApiResult<Json<ClaimPreviewDeploymentResponse>> {
     let member_id = auth.require_member()?;
     let project = resolve_project_for_selection(&state, &args.project_selection).await?;
+    // The project comes from the request body and resolve_* does not
+    // authorize, so without this any signed-in user could provision a
+    // preview deployment inside another tenant's project — spending host
+    // capacity and receiving its admin key.
+    require_same_project(&state, &auth, project.id).await?;
     // Reuse existing preview if identifier matches; otherwise create.
     let existing = state
         .storage

--- a/crates/orchestrator/src/routes/internal.rs
+++ b/crates/orchestrator/src/routes/internal.rs
@@ -115,6 +115,22 @@ pub(crate) async fn exchange_session(
         .await
         .map_err(ApiError::Internal)?;
 
+    // Stop here for a blocked account, before anything else happens.
+    //
+    // `resolve()` already refuses the tokens this would mint, so nothing
+    // below grants access — but without this a suspended member still mints
+    // a token row on every attempt, still learns their team and role, and,
+    // if their address is in ADMIN_EMAILS, still triggers the super-admin
+    // grant below. Suspension should mean "cannot transact", not "tokens do
+    // not work".
+    if member.suspended || member.deleted {
+        tracing::debug!(
+            member_id = member.id,
+            "internal: refusing session exchange for a suspended or deleted member"
+        );
+        return Err(ApiError::Forbidden);
+    }
+
     // ADMIN_EMAILS seeds the super-admin column on sign-in; from then on the
     // column is the authority, so an operator can be revoked in the console
     // without a redeploy. Seeding is deliberately one-way: dropping an

--- a/crates/orchestrator/tests/cross_tenant.rs
+++ b/crates/orchestrator/tests/cross_tenant.rs
@@ -294,6 +294,21 @@ const CROSS_TENANT_ROUTES: &[(&str, &str, Option<&str>)] = &[
     ),
     ("GET", "/api/dashboard/teams/{team}/get_project_roles", None),
     ("GET", "/api/dashboard/teams/{team}/projects", None),
+    // --- body-scoped: the resource is named in the request body, not the
+    //     path. This class was invisible to the sweep until it learned to
+    //     look at `Json(` as well as `Path(`.
+    (
+        "POST",
+        "/api/dashboard/delete_projects",
+        Some(r#"[{project}]"#),
+    ),
+    (
+        "POST",
+        "/api/deployment/provision_and_authorize",
+        Some(
+            r#"{"teamSlug":"{team_slug}","projectSlug":"{project_slug}","deploymentType":"prod"}"#,
+        ),
+    ),
     // --- dashboard: projects ---
     ("GET", "/api/dashboard/projects/{project}", None),
     (
@@ -387,7 +402,17 @@ async fn one_tenant_cannot_touch_another() {
             .replace("{deployment_name}", &victim.deployment_name)
             .replace("{deployment}", &victim.deployment_id.to_string())
             .replace("{member}", &victim.member_id.to_string());
-        let body = body.map(|b| serde_json::from_str(b).expect("table body is valid JSON"));
+        // Bodies carry resource identifiers too, so they need the same
+        // substitution the path does.
+        let body = body.map(|b| {
+            let filled = b
+                .replace("{team_slug}", &victim.team_slug)
+                .replace("{project_slug}", &victim.project_slug)
+                .replace("{project}", &victim.project_id.to_string())
+                .replace("{deployment}", &victim.deployment_id.to_string());
+            serde_json::from_str::<serde_json::Value>(&filled)
+                .unwrap_or_else(|e| panic!("table body is valid JSON: {filled} ({e})"))
+        });
 
         let status = send(&app, method, &path, &attacker.bearer, body).await;
         match status {
@@ -546,6 +571,19 @@ fn every_path_scoped_handler_references_a_guard() {
         // project transfer is actually implemented, and whoever implements
         // it will have to guard both the source and destination team.
         ("projects.rs", "transfer_project"),
+        // Self-scoped: these act on the caller's own member row, taken from
+        // the identity, never on a resource id supplied by the request.
+        ("profile.rs", "create_profile_email"),
+        ("profile.rs", "delete_profile_email"),
+        ("profile.rs", "update_primary_email"),
+        ("profile.rs", "resend_verification"),
+        ("profile.rs", "update_profile_name"),
+        ("profile.rs", "accept_opt_ins"),
+        ("deployment_internal.rs", "accept_opt_ins"),
+        ("mgmt_tokens.rs", "create_personal_access_token"),
+        // Create a NEW team; there is no existing resource to own yet.
+        ("teams.rs", "create_team"),
+        ("mgmt_teams.rs", "create_team"),
     ];
 
     /// The route files that hold tenant state.
@@ -597,6 +635,10 @@ fn every_path_scoped_handler_references_a_guard() {
             include_str!("../src/routes/management/teams.rs"),
         ),
         (
+            "mgmt_tokens.rs",
+            include_str!("../src/routes/management/tokens.rs"),
+        ),
+        (
             "deployment_internal.rs",
             include_str!("../src/routes/deployment_internal.rs"),
         ),
@@ -639,7 +681,17 @@ fn every_path_scoped_handler_references_a_guard() {
             let (sig, body) = part.split_at(sig_end);
             let takes_identity = sig.contains("AuthIdentity") || sig.contains("SuperAdmin");
             // `SuperAdmin` is itself the guard.
-            if !takes_identity || sig.contains("SuperAdmin") || !sig.contains("Path(") {
+            if !takes_identity || sig.contains("SuperAdmin") {
+                continue;
+            }
+            // A handler is resource-scoped if it names a resource in the
+            // path OR takes one in the body. The body case is not
+            // hypothetical: `delete_projects` took a Vec<i64> of project ids
+            // that way and let any signed-in user destroy every project on
+            // the instance, and `provision_and_authorize` took team and
+            // project slugs the same way and handed back an admin key. Both
+            // were invisible while this only inspected `Path(`.
+            if !sig.contains("Path(") && !sig.contains("Json(") {
                 continue;
             }
             if !GUARDS.iter().any(|g| body.contains(g)) {

--- a/crates/orchestrator/tests/integration.rs
+++ b/crates/orchestrator/tests/integration.rs
@@ -2694,3 +2694,137 @@ async fn adding_scope_by_hand_unblocks_a_crash_looping_instance() {
         .await
         .expect("startup must now succeed even on the shipped image");
 }
+
+/// A suspended member must not be able to transact with the orchestrator at
+/// all, not merely hold tokens that fail later.
+///
+/// Before this, a suspended account with a live BetterAuth login still
+/// minted a token row on every attempt, still learned its team and role,
+/// and — if its address was in ADMIN_EMAILS — still triggered the
+/// super-admin grant.
+#[tokio::test]
+#[ignore = "needs TEST_ORCHESTRATOR_DATABASE_URL"]
+async fn a_suspended_member_cannot_exchange_a_session() {
+    use std::sync::Arc;
+
+    use axum::{
+        body::Body,
+        http::{
+            Request,
+            StatusCode,
+        },
+    };
+    use orchestrator::{
+        config::RegistrationMode,
+        router::build_router,
+        state::OrchestratorState,
+    };
+    use tower::ServiceExt;
+
+    let database_url = std::env::var("TEST_ORCHESTRATOR_DATABASE_URL")
+        .expect("TEST_ORCHESTRATOR_DATABASE_URL not set (this test is `#[ignore]` by default)");
+    reset_public_schema(&database_url).await;
+
+    let data_root = tempfile::tempdir().expect("tempdir");
+    let mut config = test_config(database_url, data_root.path().to_path_buf());
+    config.service_key = Some("test-service-key".into());
+    // The address is in ADMIN_EMAILS, so a successful exchange would grant
+    // operator rights. It must not get that far.
+    config.admin_emails = vec!["blocked@example.com".into()];
+    config.registration_mode = RegistrationMode::Open;
+
+    let mut state = OrchestratorState::new(config).await.expect("state");
+    state.provisioner = Arc::new(StubProvisioner);
+    let app = build_router(state.clone());
+
+    let body = serde_json::json!({
+        "authUserId": "auth-blocked",
+        "email": "blocked@example.com",
+        "name": "Blocked",
+    });
+
+    let send = |app: axum::Router, body: serde_json::Value| async move {
+        app.oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/internal/exchange_session")
+                .header("content-type", "application/json")
+                .header("x-service-key", "test-service-key")
+                .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .expect("send exchange_session")
+    };
+
+    // First sign-in creates the member and succeeds.
+    let resp = send(app.clone(), body.clone()).await;
+    assert_eq!(resp.status(), StatusCode::OK, "first sign-in should work");
+
+    let member = state
+        .storage
+        .get_member_by_auth_user_id("auth-blocked")
+        .await
+        .expect("lookup")
+        .expect("member exists");
+    let tokens_before = state
+        .storage
+        .list_access_tokens_by_member(member.id)
+        .await
+        .map(|t| t.len())
+        .unwrap_or(0);
+
+    // A second operator, so revoking the first does not trip the
+    // last-super-admin guard.
+    let other = state
+        .storage
+        .upsert_member("auth-other-op", "other@example.com", Some("Other"))
+        .await
+        .expect("other member");
+    state
+        .storage
+        .set_super_admin(other.id, true)
+        .await
+        .expect("grant other");
+
+    // Now suspend them and strip the operator bit, so a re-grant is visible.
+    state
+        .storage
+        .set_member_suspended(member.id, true)
+        .await
+        .expect("suspend");
+    state
+        .storage
+        .set_super_admin(member.id, false)
+        .await
+        .expect("revoke");
+
+    let resp = send(app.clone(), body.clone()).await;
+    assert_eq!(
+        resp.status(),
+        StatusCode::FORBIDDEN,
+        "a suspended member must be refused outright"
+    );
+
+    // No new token rows, and no operator re-grant.
+    let tokens_after = state
+        .storage
+        .list_access_tokens_by_member(member.id)
+        .await
+        .map(|t| t.len())
+        .unwrap_or(0);
+    assert_eq!(
+        tokens_after, tokens_before,
+        "a refused exchange must not mint a token row"
+    );
+    let reloaded = state
+        .storage
+        .get_member(member.id)
+        .await
+        .expect("get")
+        .expect("exists");
+    assert!(
+        !reloaded.is_super_admin,
+        "a suspended member must not be re-granted operator by ADMIN_EMAILS"
+    );
+}


### PR DESCRIPTION
Three critical authorization holes, found by auditing the orchestrator after
the admin console shipped. All exploitable by **any authenticated user**.

They are all one class, and it is the class #21's sweep was blind to: that
sweep covered handlers naming a resource in the **path**, and the guard test
was written to match. Anything taking a resource identifier from the
**request body** was invisible to it.

## What was reachable

| Handler | Impact |
| --- | --- |
| `POST /api/dashboard/delete_projects` | Discarded the identity and took a `Vec<i64>` of project ids. **Any signed-in user could destroy every project on the instance in one request** — cascading to every deployment underneath. |
| `POST /api/deployment/provision_and_authorize` | Resolved team and project from body slugs with no membership check, then returned the existing deployment's **admin key**. Full read/write on any tenant's production data by guessing two slugs. |
| `POST /api/deployment/claim_preview_deployment` | Resolved a project from the body and provisioned into it — spending host capacity and returning an admin key. |

`provision_and_authorize` is the sibling of `authorize_within_current_project`,
which #21 fixed. One was caught and one was missed, purely because this one
reads the body.

Exposure is bounded by `REGISTRATION_MODE=allowlist`, as with #21: only
admitted accounts can reach these. That bounds it to accounts already
trusted; it is not a mitigation.

## The fix

`delete_projects` authorizes every id in a **first pass**, before deleting
anything. Checking inside the loop would mean a request that stops at id 7
has already destroyed 1 through 6.

The two `deployment_internal` routes use `require_same_project`, so a deploy
key stays bound to its own project and a PAT or session falls back to team
membership.

## Closing the class

The source-level sweep now treats a handler as resource-scoped if it takes
`Path(` **or** `Json(`. Handlers that are genuinely self-scoped — profile
edits, minting a token for the caller, creating a brand new team — are
allow-listed by name with a reason rather than by pattern.

The runtime cross-tenant table now substitutes into request **bodies** as
well as paths, and covers `delete_projects` and `provision_and_authorize`
directly.

Both layers were checked against the bugs they exist to catch: removing any
of the three guards fails the sweep, and two also fail the runtime table.

## Verification

113 lib + 3 cross-tenant + 29 integration against a real Postgres 16.4;
clippy clean.

## Also found, not fixed here — break-glass does not work

`ephemeral_admin_key`'s own docstring says the deployment's stored
`instance_secret` "is the real key the running backend accepts", and that the
mint path is "useful in the v1 demo path where no real backend is running
yet".

Break-glass **always mints**, so it returns a key a real backend will reject.
It fails loudly wrong: reports success, shows a 15-minute countdown, and
writes "access granted" to both audit logs — including the tenant's — for
access that never happened.

Not fixed here because the two goals genuinely conflict: a short TTL needs a
key that can be expired, and the only key the backend accepts is the
permanent one, which cannot be. The options are to return the permanent key
(works, audited, no expiry), to have the orchestrator proxy with its own
auth, or to drop the feature. That is a design decision, not a bug fix.
