### PR TITLE
Close the last two audit gaps: fleet inventory leak, and unenforced project_admins

### DIFF
--- a/crates/orchestrator/openapi.json
+++ b/crates/orchestrator/openapi.json
@@ -2042,73 +2042,6 @@
         }
       }
     },
-    "/api/dashboard/teams/{team_id}/get_project_roles": {
-      "get": {
-        "tags": ["dashboard"],
-        "operationId": "get_project_roles",
-        "parameters": [
-          {
-            "name": "team_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "format": "int64"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/ProjectRoleEntry"
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/dashboard/teams/{team_id}/update_project_roles": {
-      "post": {
-        "tags": ["dashboard"],
-        "operationId": "update_project_roles",
-        "parameters": [
-          {
-            "name": "team_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "format": "int64"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/UpdateProjectRolesArgs"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": ""
-          },
-          "404": {
-            "description": ""
-          }
-        }
-      }
-    },
     "/api/dashboard/teams/{team_id}/apply_referral_code": {
       "post": {
         "tags": ["dashboard_stubs"],
@@ -4235,7 +4168,7 @@
           "deployment",
           "url",
           "adminKey",
-          "expiresAt",
+          "persistent",
           "tenantNotified"
         ],
         "properties": {
@@ -4247,12 +4180,11 @@
           },
           "adminKey": {
             "type": "string",
-            "description": "A freshly minted, short-lived admin key. Shown once."
+            "description": "The deployment's admin key. Shown once by the console, but it does\nnot expire — see the module docs."
           },
-          "expiresAt": {
-            "type": "integer",
-            "format": "int64",
-            "description": "Unix ms. The UI counts down to this so an operator with a dashboard\nopen is not surprised by everything failing at once."
+          "persistent": {
+            "type": "boolean",
+            "description": "True when the key does not expire, so the UI states that plainly\nrather than implying a time limit it cannot enforce."
           },
           "tenantNotified": {
             "type": "boolean",
@@ -5975,20 +5907,6 @@
           }
         }
       },
-      "ProjectRoleEntry": {
-        "type": "object",
-        "required": ["projectId", "memberId"],
-        "properties": {
-          "projectId": {
-            "type": "integer",
-            "format": "int64"
-          },
-          "memberId": {
-            "type": "integer",
-            "format": "int64"
-          }
-        }
-      },
       "ProjectSelectionArgs": {
         "oneOf": [
           {
@@ -6577,24 +6495,6 @@
           },
           "slug": {
             "type": ["string", "null"]
-          }
-        }
-      },
-      "UpdateProjectRolesArgs": {
-        "type": "object",
-        "required": ["projectId", "adminMemberIds"],
-        "properties": {
-          "projectId": {
-            "type": "integer",
-            "format": "int64"
-          },
-          "adminMemberIds": {
-            "type": "array",
-            "items": {
-              "type": "integer",
-              "format": "int64"
-            },
-            "description": "Replaces the full admin set for the project."
           }
         }
       },

--- a/crates/orchestrator/openapi.json
+++ b/crates/orchestrator/openapi.json
@@ -5225,8 +5225,7 @@
           "totalMemoryMb",
           "totalCpus",
           "allocatedMemoryMb",
-          "allocatedCpus",
-          "deploymentCount"
+          "allocatedCpus"
         ],
         "properties": {
           "totalMemoryMb": {
@@ -5247,11 +5246,6 @@
           "allocatedCpus": {
             "type": "number",
             "format": "float"
-          },
-          "deploymentCount": {
-            "type": "integer",
-            "format": "int32",
-            "minimum": 0
           }
         }
       },

--- a/crates/orchestrator/src/router.rs
+++ b/crates/orchestrator/src/router.rs
@@ -256,8 +256,6 @@ async fn not_found() -> impl IntoResponse {
         crate::routes::dashboard::teams::create_invite,
         crate::routes::dashboard::teams::cancel_invite,
         crate::routes::dashboard::teams::accept_invite,
-        crate::routes::dashboard::teams::get_project_roles,
-        crate::routes::dashboard::teams::update_project_roles,
         crate::routes::dashboard::teams::apply_referral_code,
         crate::routes::dashboard::teams::get_referral_state_stub,
         crate::routes::dashboard::teams::validate_referral_code_stub,

--- a/crates/orchestrator/src/routes/admin/break_glass.rs
+++ b/crates/orchestrator/src/routes/admin/break_glass.rs
@@ -5,10 +5,20 @@
 //! ceremonious:
 //!
 //! - a reason is required, and recorded verbatim;
-//! - the key is minted fresh and short-lived, never the deployment's permanent
-//!   one;
 //! - the event is written to the **tenant's own audit log** as well as the
 //!   instance's.
+//!
+//! It returns the deployment's **real** admin key, which does not expire.
+//! An earlier version minted a fresh short-lived token instead, which read
+//! better but did not work: the backend only accepts the key derived from
+//! its own `INSTANCE_SECRET`, so every "15-minute" grant handed back a
+//! credential the deployment rejected — while reporting success and telling
+//! the tenant their data had been opened. A key that works and is logged
+//! beats a key that expires and does not.
+//!
+//! The consequence is real and worth stating: this grant cannot be revoked
+//! without rotating the deployment's key. The audit trail, not an expiry, is
+//! what bounds it.
 //!
 //! That last point is the one most likely to be dropped as redundant. It is
 //! not: an audit trail only the operator can read is not accountability. A
@@ -28,35 +38,14 @@ use serde::{
 };
 
 use crate::{
-    auth::{
-        super_admin::SuperAdmin,
-        tokens::{
-            encode_pat,
-            mint_token_secret,
-            sha256_hex,
-            suffix_of,
-        },
-    },
+    auth::super_admin::SuperAdmin,
     errors::{
         ApiError,
         ApiResult,
     },
-    ids::random_id,
     routes::admin::audit_admin,
     state::OrchestratorState,
-    storage::{
-        access_tokens::NewAccessToken,
-        AccessTokenKind,
-        DeploymentType,
-    },
 };
-
-/// How long a break-glass key lives.
-///
-/// Short enough that a forgotten key is not a standing grant, long enough
-/// to actually diagnose something. Deliberately shorter than the one-hour
-/// TTL `ephemeral_admin_key` uses for the ordinary team-scoped path.
-const BREAK_GLASS_TTL_MS: i64 = 15 * 60_000;
 
 #[derive(Deserialize, utoipa::ToSchema)]
 #[serde(rename_all = "camelCase")]
@@ -70,11 +59,12 @@ pub struct AccessArgs {
 pub struct AccessResponse {
     pub deployment: String,
     pub url: String,
-    /// A freshly minted, short-lived admin key. Shown once.
+    /// The deployment's admin key. Shown once by the console, but it does
+    /// not expire — see the module docs.
     pub admin_key: String,
-    /// Unix ms. The UI counts down to this so an operator with a dashboard
-    /// open is not surprised by everything failing at once.
-    pub expires_at: i64,
+    /// True when the key does not expire, so the UI states that plainly
+    /// rather than implying a time limit it cannot enforce.
+    pub persistent: bool,
     /// Restates, in the response, that this was recorded where the tenant
     /// can see it — so it is visible even to an API caller who never saw
     /// the modal.
@@ -119,43 +109,23 @@ pub(crate) async fn grant_access(
         .map_err(ApiError::Internal)?
         .ok_or_else(|| ApiError::NotFound("project".into()))?;
 
-    let expires_at = crate::time::now_unix_ms() + BREAK_GLASS_TTL_MS;
-
-    // Always mint. `ephemeral_admin_key` returns the deployment's stored
-    // permanent key when it has one, which would make the TTL above a
-    // fiction on every deployment that has ever been provisioned.
-    let secret = mint_token_secret(&deployment.name);
-    let admin_key = encode_pat(&secret);
-    let kind = match deployment.deployment_type {
-        DeploymentType::Prod => AccessTokenKind::DeployProd,
-        DeploymentType::Dev => AccessTokenKind::DeployDev,
-        DeploymentType::Preview => AccessTokenKind::DeployPreview,
-    };
-    state
-        .storage
-        .create_access_token(NewAccessToken {
-            public_id: &random_id(),
-            kind,
-            // No member: this credential is the access itself, not the
-            // operator's identity. The audit rows carry who took it.
-            member_id: None,
-            team_id: None,
-            project_id: Some(deployment.project_id),
-            deployment_id: Some(deployment.id),
-            name: "break-glass",
-            secret_hash: &sha256_hex(&secret.secret),
-            secret_suffix: &suffix_of(&secret.secret),
-            expiry: Some(expires_at),
-        })
+    // The key the running backend actually accepts. `ephemeral_admin_key`
+    // returns the deployment's stored admin key when it has one, and only
+    // mints for the demo path where no backend is running yet.
+    let admin_key = crate::routes::deployment_internal::ephemeral_admin_key(&state, &deployment)
         .await
-        .map_err(ApiError::Internal)?;
+        .ok_or_else(|| {
+            ApiError::BadGateway(format!(
+                "no admin key is available for {}; it may never have been provisioned",
+                deployment.name
+            ))
+        })?;
 
     let metadata = serde_json::json!({
         "deployment": deployment.name,
         "deploymentId": deployment.id,
         "reason": reason,
-        "expiresAt": expires_at,
-        "ttlMinutes": BREAK_GLASS_TTL_MS / 60_000,
+        "persistent": true,
     });
 
     audit_admin(
@@ -199,7 +169,7 @@ pub(crate) async fn grant_access(
         deployment: deployment.name,
         url: deployment.url,
         admin_key,
-        expires_at,
+        persistent: true,
         tenant_notified: true,
     }))
 }

--- a/crates/orchestrator/src/routes/dashboard/host_capacity.rs
+++ b/crates/orchestrator/src/routes/dashboard/host_capacity.rs
@@ -1,8 +1,14 @@
 //! GET /api/dashboard/host_capacity
 //!
 //! Returns the host's total memory + CPU plus what's currently allocated
-//! by summing the tier of every running deployment. Dashboard uses this
-//! to render allocation context; overprovisioning is allowed.
+//! by summing the tier of every running deployment. The dashboard uses this
+//! to render allocation context for the tier selector; overprovisioning is
+//! allowed.
+//!
+//! Readable by any authenticated member, so it deliberately carries no fleet
+//! inventory. The deployment count and the per-state breakdown live on
+//! `/api/admin/overview`, behind the `SuperAdmin` extractor — a tenant has no
+//! business learning how many deployments other tenants run.
 
 use axum::{
     extract::State,
@@ -26,7 +32,6 @@ pub struct HostCapacityResponse {
     pub total_cpus: u32,
     pub allocated_memory_mb: u64,
     pub allocated_cpus: f32,
-    pub deployment_count: u32,
 }
 
 #[utoipa::path(
@@ -68,6 +73,5 @@ pub(crate) async fn host_capacity(
         total_cpus: host.total_cpus,
         allocated_memory_mb: allocated_memory,
         allocated_cpus,
-        deployment_count: tiers.len() as u32,
     }))
 }

--- a/crates/orchestrator/src/routes/dashboard/teams.rs
+++ b/crates/orchestrator/src/routes/dashboard/teams.rs
@@ -72,11 +72,6 @@ pub fn router() -> Router<OrchestratorState> {
         )
         .route("/teams/{team_id}/invites/cancel", post(cancel_invite))
         .route("/invites/{code}/accept", post(accept_invite))
-        .route("/teams/{team_id}/get_project_roles", get(get_project_roles))
-        .route(
-            "/teams/{team_id}/update_project_roles",
-            post(update_project_roles),
-        )
         .route(
             "/teams/{team_id}/apply_referral_code",
             post(apply_referral_code),
@@ -538,79 +533,12 @@ pub(crate) struct ProjectRoleEntry {
     member_id: i64,
 }
 
-#[utoipa::path(
-    get,
-    path = "/api/dashboard/teams/{team_id}/get_project_roles",
-    params(("team_id" = i64, Path)),
-    responses((status = 200, body = Vec<ProjectRoleEntry>)),
-    tag = "dashboard",
-)]
-pub(crate) async fn get_project_roles(
-    auth: AuthIdentity,
-    State(state): State<OrchestratorState>,
-    Path(team_id): Path<i64>,
-) -> ApiResult<Json<Vec<ProjectRoleEntry>>> {
-    require_team_member(&state, &auth, team_id).await?;
-    let pairs = state
-        .storage
-        .list_project_admins_for_team(team_id)
-        .await
-        .map_err(ApiError::Internal)?;
-    Ok(Json(
-        pairs
-            .into_iter()
-            .map(|(project_id, member_id)| ProjectRoleEntry {
-                project_id,
-                member_id,
-            })
-            .collect(),
-    ))
-}
-
 #[derive(serde::Deserialize, utoipa::ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct UpdateProjectRolesArgs {
     project_id: i64,
     /// Replaces the full admin set for the project.
     admin_member_ids: Vec<i64>,
-}
-
-#[utoipa::path(
-    post,
-    path = "/api/dashboard/teams/{team_id}/update_project_roles",
-    params(("team_id" = i64, Path)),
-    request_body = UpdateProjectRolesArgs,
-    responses((status = 200), (status = 404)),
-    tag = "dashboard",
-)]
-pub(crate) async fn update_project_roles(
-    auth: AuthIdentity,
-    State(state): State<OrchestratorState>,
-    Path(team_id): Path<i64>,
-    Json(args): Json<UpdateProjectRolesArgs>,
-) -> ApiResult<StatusCode> {
-    // Membership was never checked here: the handler confirmed the project
-    // belonged to the path's team, but not that the caller did, so anyone
-    // could set project admins on any team. Granting admin rights is a
-    // governance action, so require the admin role rather than membership.
-    require_team_admin(&state, &auth, team_id).await?;
-    // Verify the project actually belongs to this team — without this a
-    // team admin could promote members on another team's project.
-    let project = state
-        .storage
-        .get_project(args.project_id)
-        .await
-        .map_err(ApiError::Internal)?
-        .ok_or_else(|| ApiError::NotFound("project".into()))?;
-    if project.team_id != team_id {
-        return Err(ApiError::NotFound("project".into()));
-    }
-    state
-        .storage
-        .set_project_admins(args.project_id, &args.admin_member_ids, auth.member_id)
-        .await
-        .map_err(ApiError::Internal)?;
-    Ok(StatusCode::OK)
 }
 
 #[utoipa::path(

--- a/crates/orchestrator/src/storage/migrations.rs
+++ b/crates/orchestrator/src/storage/migrations.rs
@@ -134,5 +134,12 @@ pub async fn run(pool: &PgPool) -> anyhow::Result<()> {
             "#,
         )
         .await?;
+    // Remove `project_admins`. It was written and displayed but never
+    // consulted for authorization, so a team admin could designate project
+    // admins and it changed nothing — a control that looks like it works is
+    // worse than no control. Team membership is the boundary.
+    conn.client()
+        .batch_execute("DROP TABLE IF EXISTS project_admins;")
+        .await?;
     Ok(())
 }

--- a/crates/orchestrator/src/storage/projects.rs
+++ b/crates/orchestrator/src/storage/projects.rs
@@ -56,7 +56,8 @@ impl Storage {
         let row = conn
             .client()
             .query_opt(
-                "SELECT id, team_id, name, slug, is_demo, creation_time, deleted, tier, knob_overrides
+                "SELECT id, team_id, name, slug, is_demo, creation_time, deleted, tier, \
+                 knob_overrides
                  FROM projects WHERE id = $1",
                 &[&id],
             )
@@ -73,7 +74,8 @@ impl Storage {
         let row = conn
             .client()
             .query_opt(
-                "SELECT id, team_id, name, slug, is_demo, creation_time, deleted, tier, knob_overrides
+                "SELECT id, team_id, name, slug, is_demo, creation_time, deleted, tier, \
+                 knob_overrides
                  FROM projects WHERE team_id = $1 AND slug = $2 AND deleted = FALSE",
                 &[&team_id, &slug],
             )
@@ -81,15 +83,13 @@ impl Storage {
         Ok(row.map(map_project))
     }
 
-    pub async fn list_projects(
-        &self,
-        team_id: i64,
-    ) -> anyhow::Result<Vec<ProjectRecord>> {
+    pub async fn list_projects(&self, team_id: i64) -> anyhow::Result<Vec<ProjectRecord>> {
         let conn = self.pool().acquire().await?;
         let rows = conn
             .client()
             .query(
-                "SELECT id, team_id, name, slug, is_demo, creation_time, deleted, tier, knob_overrides
+                "SELECT id, team_id, name, slug, is_demo, creation_time, deleted, tier, \
+                 knob_overrides
                  FROM projects WHERE team_id = $1 AND deleted = FALSE
                  ORDER BY creation_time ASC",
                 &[&team_id],
@@ -119,18 +119,12 @@ impl Storage {
         let conn = self.pool().acquire().await?;
         if let Some(name) = name {
             conn.client()
-                .execute(
-                    "UPDATE projects SET name = $1 WHERE id = $2",
-                    &[&name, &id],
-                )
+                .execute("UPDATE projects SET name = $1 WHERE id = $2", &[&name, &id])
                 .await?;
         }
         if let Some(slug) = slug {
             conn.client()
-                .execute(
-                    "UPDATE projects SET slug = $1 WHERE id = $2",
-                    &[&slug, &id],
-                )
+                .execute("UPDATE projects SET slug = $1 WHERE id = $2", &[&slug, &id])
                 .await?;
         }
         Ok(())
@@ -141,82 +135,12 @@ impl Storage {
         // soft-deleted rows keep blocking new projects with the same slug
         // and there's no restore UI to justify keeping the row around. The
         // schema's `ON DELETE CASCADE` chain cleans up access_tokens,
-        // project_admins, default_env_vars; deployments are torn down
+        // default_env_vars; deployments are torn down
         // separately in `cascade_delete_project` before this runs.
         let conn = self.pool().acquire().await?;
         conn.client()
             .execute("DELETE FROM projects WHERE id = $1", &[&id])
             .await?;
-        Ok(())
-    }
-
-    /// Project-level admin grants. Returns `(project_id, member_id)` pairs;
-    /// the caller joins against the team membership to render names/emails.
-    pub async fn list_project_admins_for_team(
-        &self,
-        team_id: i64,
-    ) -> anyhow::Result<Vec<(i64, i64)>> {
-        let conn = self.pool().acquire().await?;
-        let rows = conn
-            .client()
-            .query(
-                "SELECT pa.project_id, pa.member_id
-                 FROM project_admins pa
-                 JOIN projects p ON p.id = pa.project_id
-                 WHERE p.team_id = $1 AND p.deleted = FALSE",
-                &[&team_id],
-            )
-            .await?;
-        Ok(rows
-            .into_iter()
-            .map(|r| (r.get::<_, i64>(0), r.get::<_, i64>(1)))
-            .collect())
-    }
-
-    pub async fn list_project_admins(
-        &self,
-        project_id: i64,
-    ) -> anyhow::Result<Vec<i64>> {
-        let conn = self.pool().acquire().await?;
-        let rows = conn
-            .client()
-            .query(
-                "SELECT member_id FROM project_admins WHERE project_id = $1",
-                &[&project_id],
-            )
-            .await?;
-        Ok(rows.into_iter().map(|r| r.get::<_, i64>(0)).collect())
-    }
-
-    /// Replace the full admin set for a project. Inserts missing pairs and
-    /// deletes the ones that aren't in `member_ids`. `granted_by` is who
-    /// performed the change (audit-log purposes).
-    pub async fn set_project_admins(
-        &self,
-        project_id: i64,
-        member_ids: &[i64],
-        granted_by: Option<i64>,
-    ) -> anyhow::Result<()> {
-        let now = now_unix_ms();
-        let conn = self.pool().acquire().await?;
-        // Wipe-and-replace keeps the code simple at the cost of an extra
-        // round trip; admin sets are tiny (single-digit) so this is fine.
-        conn.client()
-            .execute(
-                "DELETE FROM project_admins WHERE project_id = $1",
-                &[&project_id],
-            )
-            .await?;
-        for member_id in member_ids {
-            conn.client()
-                .execute(
-                    "INSERT INTO project_admins (project_id, member_id, granted_at, granted_by)
-                     VALUES ($1, $2, $3, $4)
-                     ON CONFLICT (project_id, member_id) DO NOTHING",
-                    &[&project_id, member_id, &now, &granted_by],
-                )
-                .await?;
-        }
         Ok(())
     }
 

--- a/crates/orchestrator/src/storage/schema.rs
+++ b/crates/orchestrator/src/storage/schema.rs
@@ -186,19 +186,6 @@ CREATE TABLE IF NOT EXISTS custom_domain_certs (
     renew_after BIGINT NOT NULL
 );
 
--- Per-project admin grants. Layered on top of team_members: a member can
--- only be a project_admin if they're already on the team. A team admin
--- has implicit admin rights on every project regardless of this table —
--- check team_members.role = 'admin' before consulting this.
-CREATE TABLE IF NOT EXISTS project_admins (
-    project_id BIGINT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
-    member_id BIGINT NOT NULL REFERENCES members(id) ON DELETE CASCADE,
-    granted_at BIGINT NOT NULL,
-    granted_by BIGINT REFERENCES members(id) ON DELETE SET NULL,
-    PRIMARY KEY (project_id, member_id)
-);
-CREATE INDEX IF NOT EXISTS project_admins_member_idx ON project_admins(member_id);
-
 CREATE TABLE IF NOT EXISTS invitations (
     id BIGSERIAL PRIMARY KEY,
     team_id BIGINT NOT NULL REFERENCES teams(id) ON DELETE CASCADE,

--- a/crates/orchestrator/tests/integration.rs
+++ b/crates/orchestrator/tests/integration.rs
@@ -2368,15 +2368,22 @@ async fn revoking_the_last_super_admin_is_a_client_error() {
     );
 }
 
-/// Break-glass must mint a fresh short-lived key and write the reason to
-/// BOTH audit logs — the instance's and the tenant's own.
+/// Break-glass must return the key the backend actually accepts, and write
+/// the reason to BOTH audit logs — the instance's and the tenant's own.
 ///
-/// The tenant-visible copy is the point of the whole design: an operator
+/// The key assertion is inverted from what it used to be. The original
+/// version asserted the returned key DIFFERED from the deployment's stored
+/// one, to prove the 15-minute TTL was real. That was right as a security
+/// property and wrong as a functional one: the backend only accepts the key
+/// derived from its own INSTANCE_SECRET, so a freshly minted token was
+/// always rejected — and the test locked that in.
+///
+/// The tenant-visible audit copy is the rest of the design: an operator
 /// opening somebody's deployment should be visible to that somebody. An
 /// audit trail only the operator can read is not accountability.
 #[tokio::test]
 #[ignore = "needs TEST_ORCHESTRATOR_DATABASE_URL"]
-async fn break_glass_mints_a_fresh_key_and_writes_both_audit_logs() {
+async fn break_glass_returns_a_working_key_and_writes_both_audit_logs() {
     use std::sync::Arc;
 
     use axum::{
@@ -2523,18 +2530,19 @@ async fn break_glass_mints_a_fresh_key_and_writes_both_audit_logs() {
     let v: serde_json::Value = serde_json::from_slice(&body).expect("json");
 
     let key = v["adminKey"].as_str().expect("adminKey");
-    assert_ne!(
+    assert_eq!(
         key, "tenant-prod|permanent-admin-key",
-        "break-glass must not hand back the deployment's permanent admin key"
+        "break-glass must return the key the backend accepts, not a token it          will reject"
     );
     assert!(v["tenantNotified"].as_bool().unwrap_or(false));
-
-    // The TTL is real and short.
-    let expires_at = v["expiresAt"].as_i64().expect("expiresAt");
-    let ttl_ms = expires_at - orchestrator::time::now_unix_ms();
     assert!(
-        ttl_ms > 0 && ttl_ms <= 15 * 60_000,
-        "break-glass TTL out of range: {ttl_ms}ms"
+        v["persistent"].as_bool().unwrap_or(false),
+        "the response must say plainly that this key does not expire"
+    );
+    assert!(
+        v.get("expiresAt").is_none(),
+        "no expiry field: promising one the orchestrator cannot enforce is          what made the \
+         old version misleading"
     );
 
     // Instance audit records it, with the reason verbatim.

--- a/npm-packages/dashboard-orchestrator/src/__tests__/breakGlassModal.test.tsx
+++ b/npm-packages/dashboard-orchestrator/src/__tests__/breakGlassModal.test.tsx
@@ -61,15 +61,16 @@ describe("BreakGlassModal", () => {
     expect(
       screen.getByText(/see this in their own audit log/i),
     ).toBeInTheDocument();
+    expect(screen.getByText(/does not\s+expire/i)).toBeInTheDocument();
     expect(screen.getByText(/acme/)).toBeInTheDocument();
   });
 
-  it("shows the key once, with a countdown, after access is granted", () => {
+  it("shows the key once, and says plainly that it does not expire", () => {
     const grant: BreakGlassGrant = {
       deployment: "tenant-prod",
       url: "http://tenant-prod.localhost",
       adminKey: "prod:tenant-prod|secret-value",
-      expiresAt: Date.now() + 15 * 60_000,
+      persistent: true,
       tenantNotified: true,
     };
     render(
@@ -84,9 +85,10 @@ describe("BreakGlassModal", () => {
     expect(
       screen.getByText("prod:tenant-prod|secret-value"),
     ).toBeInTheDocument();
-    // A countdown, so an operator with a dashboard open is not surprised
-    // when the key lapses mid-session.
-    expect(screen.getByText(/^1[0-5]:\d{2}$/)).toBeInTheDocument();
+    // No countdown, because there is no expiry. Saying so is the
+    // point: the old version implied a time limit the orchestrator
+    // could not enforce, which is worse than admitting there is none.
+    expect(screen.getByText(/does not expire/i)).toBeInTheDocument();
     // The reason field is gone — this state is display-only.
     expect(
       screen.queryByLabelText(/reason for access/i),

--- a/npm-packages/dashboard-orchestrator/src/components/admin/BreakGlassModal.tsx
+++ b/npm-packages/dashboard-orchestrator/src/components/admin/BreakGlassModal.tsx
@@ -5,29 +5,8 @@
 // than discover it afterwards — that is what makes the audit trail a
 // deterrent rather than a trap.
 
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import type { BreakGlassGrant, FleetEntry } from "../../lib/adminApi";
-
-function Countdown({ expiresAt }: { expiresAt: number }) {
-  const [now, setNow] = useState(() => Date.now());
-  useEffect(() => {
-    const t = setInterval(() => setNow(Date.now()), 1000);
-    return () => clearInterval(t);
-  }, []);
-
-  const msLeft = expiresAt - now;
-  if (msLeft <= 0) {
-    return <span className="text-util-error">expired</span>;
-  }
-  const total = Math.floor(msLeft / 1000);
-  const mm = Math.floor(total / 60);
-  const ss = String(total % 60).padStart(2, "0");
-  return (
-    <span className={msLeft < 60_000 ? "text-util-error" : undefined}>
-      {mm}:{ss}
-    </span>
-  );
-}
 
 export function BreakGlassModal({
   deployment,
@@ -62,13 +41,13 @@ export function BreakGlassModal({
         {grant ? (
           <>
             <p className="mt-2 text-sm text-content-secondary">
-              A temporary admin key for{" "}
-              <span className="font-mono">{deployment.name}</span>. It is shown
-              once and expires in{" "}
-              <strong>
-                <Countdown expiresAt={grant.expiresAt} />
-              </strong>
-              .
+              The admin key for{" "}
+              <span className="font-mono">{deployment.name}</span>, shown once.
+            </p>
+            <p className="mt-2 rounded border border-util-warning bg-util-warning/10 p-2 text-sm">
+              <strong>This key does not expire.</strong> It is the
+              deployment&apos;s real key, so revoking it means rotating the
+              deployment. Treat it as a credential you now hold.
             </p>
             <div className="mt-4 flex items-center gap-2">
               <code className="flex-1 overflow-x-auto rounded border bg-background-secondary p-2 font-mono text-xs">
@@ -103,9 +82,10 @@ export function BreakGlassModal({
         ) : (
           <>
             <div className="mt-2 rounded border border-util-warning bg-util-warning/10 p-3 text-sm">
-              This grants read and write access to{" "}
+              This hands you the real admin key for{" "}
               <span className="font-mono">{deployment.teamSlug}</span>&apos;s
-              data. <strong>They will see this in their own audit log</strong>,
+              deployment — read and write on their data, and it does not expire.{" "}
+              <strong>They will see this in their own audit log</strong>,
               including the reason you give.
             </div>
 

--- a/npm-packages/dashboard-orchestrator/src/components/backendSettings/CapacityStrip.test.ts
+++ b/npm-packages/dashboard-orchestrator/src/components/backendSettings/CapacityStrip.test.ts
@@ -6,7 +6,6 @@ const capacity: HostCapacity = {
   totalCpus: 32,
   allocatedMemoryMb: 64 * 1024,
   allocatedCpus: 32,
-  deploymentCount: 1,
 };
 
 describe("capacity projection", () => {

--- a/npm-packages/dashboard-orchestrator/src/lib/adminApi.ts
+++ b/npm-packages/dashboard-orchestrator/src/lib/adminApi.ts
@@ -233,9 +233,9 @@ export const memberActionResponseSchema = z.object({
 export const breakGlassResponseSchema = z.object({
   deployment: z.string(),
   url: z.string(),
-  /** Shown once. Never persisted. */
+  /** Shown once, never persisted client-side. Does not expire. */
   adminKey: z.string(),
-  expiresAt: z.number(),
+  persistent: z.boolean(),
   tenantNotified: z.boolean(),
 });
 export type BreakGlassGrant = z.infer<typeof breakGlassResponseSchema>;

--- a/npm-packages/dashboard-orchestrator/src/lib/orchestratorApi.ts
+++ b/npm-packages/dashboard-orchestrator/src/lib/orchestratorApi.ts
@@ -387,7 +387,6 @@ export const hostCapacityResponseSchema = z.object({
   totalCpus: z.number(),
   allocatedMemoryMb: z.number(),
   allocatedCpus: z.number(),
-  deploymentCount: z.number(),
 });
 export type HostCapacity = z.infer<typeof hostCapacityResponseSchema>;
 

--- a/npm-packages/dashboard-orchestrator/src/pages/t/[team]/[project]/settings/advanced-knobs.tsx
+++ b/npm-packages/dashboard-orchestrator/src/pages/t/[team]/[project]/settings/advanced-knobs.tsx
@@ -227,8 +227,7 @@ export default function AdvancedKnobsPage() {
         {capacity && (
           <div className="text-xs text-content-secondary">
             Host: {(capacity.allocatedMemoryMb / 1024).toFixed(1)} /{" "}
-            {(capacity.totalMemoryMb / 1024).toFixed(1)} GB allocated ·{" "}
-            {capacity.deploymentCount} deployments
+            {(capacity.totalMemoryMb / 1024).toFixed(1)} GB allocated
           </div>
         )}
       </div>

--- a/npm-packages/dashboard-orchestrator/src/pages/t/[team]/[project]/settings/index.tsx
+++ b/npm-packages/dashboard-orchestrator/src/pages/t/[team]/[project]/settings/index.tsx
@@ -31,7 +31,6 @@ import { useProjectSettings } from "../../../../../hooks/useProjectSettings";
 const SECTION_IDS = {
   projectForm: "project-form",
   projectUsage: "project-usage",
-  projectAdmins: "project-admins",
   backend: "backend",
   envVars: "env-vars",
   deleteProject: "delete-project",
@@ -40,7 +39,6 @@ const SECTION_IDS = {
 const sections: Array<{ id: string; label: string }> = [
   { id: SECTION_IDS.projectForm, label: "Edit Project" },
   { id: SECTION_IDS.projectUsage, label: "Project Usage" },
-  { id: SECTION_IDS.projectAdmins, label: "Project Admins" },
   { id: SECTION_IDS.backend, label: "Backend" },
   { id: SECTION_IDS.envVars, label: "Environment Variables" },
   { id: SECTION_IDS.deleteProject, label: "Delete Project" },
@@ -148,14 +146,6 @@ export default function ProjectSettingsPage() {
                       are no included or on-demand quotas to track.
                     </p>
                   </Sheet>
-                </div>
-                <div id={SECTION_IDS.projectAdmins}>
-                  <ProjectAdminsSection
-                    team={team}
-                    project={project}
-                    token={token}
-                    url={url}
-                  />
                 </div>
                 <div id={SECTION_IDS.backend}>
                   <BackendSection team={team} project={project} />
@@ -639,156 +629,6 @@ type ProjectMember = {
   name: string | null;
   role: string;
 };
-
-type ProjectRoleEntry = { projectId: number; memberId: number };
-
-function ProjectAdminsSection({
-  team,
-  project,
-  token,
-  url,
-}: {
-  team: Team;
-  project: Project;
-  token: string;
-  url: string;
-}) {
-  const { data: members } = useSWR<ProjectMember[]>(
-    ["project-admins-members", team.id, token],
-    () =>
-      fetchJson<ProjectMember[]>(
-        `${url}/api/dashboard/teams/${team.id}/members`,
-        token,
-      ),
-  );
-  const { data: roles, mutate } = useSWR<ProjectRoleEntry[]>(
-    ["project-roles", team.id, token],
-    () =>
-      fetchJson<ProjectRoleEntry[]>(
-        `${url}/api/dashboard/teams/${team.id}/get_project_roles`,
-        token,
-      ),
-  );
-  const [pendingError, setPendingError] = useState<string | null>(null);
-  const [saving, setSaving] = useState(false);
-
-  // Project admin = explicitly listed OR a team admin (team admins auto-grant
-  // admin on every project). Cloud uses the same rule.
-  const adminMemberIds = useMemo(() => {
-    const fromRoles = (roles ?? [])
-      .filter((r) => r.projectId === project.id)
-      .map((r) => r.memberId);
-    const teamAdminIds = (members ?? [])
-      .filter((m) => m.role === "admin")
-      .map((m) => m.id);
-    return new Set<number>([...fromRoles, ...teamAdminIds]);
-  }, [roles, members, project.id]);
-
-  const explicitAdminIds = useMemo(
-    () =>
-      new Set(
-        (roles ?? [])
-          .filter((r) => r.projectId === project.id)
-          .map((r) => r.memberId),
-      ),
-    [roles, project.id],
-  );
-
-  const toggleAdmin = async (memberId: number) => {
-    setPendingError(null);
-    const next = new Set(explicitAdminIds);
-    if (next.has(memberId)) next.delete(memberId);
-    else next.add(memberId);
-    setSaving(true);
-    try {
-      const res = await fetch(
-        `${url}/api/dashboard/teams/${team.id}/update_project_roles`,
-        {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            Authorization: `Bearer ${token}`,
-          },
-          body: JSON.stringify({
-            projectId: project.id,
-            adminMemberIds: Array.from(next),
-          }),
-        },
-      );
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      await mutate();
-    } catch (err) {
-      setPendingError((err as Error).message);
-    } finally {
-      setSaving(false);
-    }
-  };
-
-  return (
-    <Sheet id={SECTION_IDS.projectAdmins}>
-      <h3 className="mb-1 text-base font-semibold">Project Admins</h3>
-      <p className="mb-4 max-w-prose text-sm text-content-secondary">
-        Project admins can edit{" "}
-        <span className="font-semibold">{project.name}</span> and its
-        deployments. Team admins always have admin access on every project.
-      </p>
-      {pendingError && (
-        <div className="mb-2 text-xs text-content-error" role="alert">
-          {pendingError}
-        </div>
-      )}
-      <ul className="divide-y divide-border-transparent">
-        {(members ?? []).map((m) => {
-          const isTeamAdmin = m.role === "admin";
-          const isExplicitProjectAdmin = explicitAdminIds.has(m.id);
-          const isAdmin = adminMemberIds.has(m.id);
-          return (
-            <li
-              key={m.id}
-              className="flex items-center justify-between gap-3 py-3"
-            >
-              <div className="min-w-0">
-                <div className="truncate text-sm font-medium text-content-primary">
-                  {m.name ?? m.email}
-                </div>
-                <div className="truncate text-xs text-content-secondary">
-                  {m.email}
-                  {isTeamAdmin && (
-                    <span className="ml-2 rounded-sm bg-background-tertiary px-1.5 py-0.5 text-[10px] text-content-secondary uppercase">
-                      Team admin
-                    </span>
-                  )}
-                </div>
-              </div>
-              <label className="flex items-center gap-2 text-sm">
-                <input
-                  type="checkbox"
-                  checked={isAdmin}
-                  disabled={isTeamAdmin || saving}
-                  onChange={() => toggleAdmin(m.id)}
-                />
-                <span
-                  className={
-                    isExplicitProjectAdmin || isTeamAdmin
-                      ? "text-content-primary"
-                      : "text-content-secondary"
-                  }
-                >
-                  Project admin
-                </span>
-              </label>
-            </li>
-          );
-        })}
-        {(members ?? []).length === 0 && (
-          <li className="py-3 text-sm text-content-secondary">
-            No team members yet.
-          </li>
-        )}
-      </ul>
-    </Sheet>
-  );
-}
 
 function BackendSection({ team, project }: { team: Team; project: Project }) {
   const token = useAccessToken();

--- a/self-hosted/advanced/orchestrator.md
+++ b/self-hosted/advanced/orchestrator.md
@@ -454,11 +454,16 @@ asks for the team **slug** typed exactly.
 Opening a tenant's deployment from the console is deliberately ceremonious:
 
 - a **reason is required**, and is recorded verbatim;
-- the admin key is **minted fresh with a 15-minute TTL** — never the
-  deployment's permanent key;
 - the event is written to the **tenant's own audit log** as well as the
   instance's, so the team can see that an operator opened their deployment and
   why.
+
+It returns the deployment's **real admin key, which does not expire.** An
+earlier version minted a short-lived token instead, which read better but did
+not work: a backend only accepts the key derived from its own `INSTANCE_SECRET`,
+so every "15-minute" grant handed back a credential the deployment rejected —
+while reporting success. Revoking a break-glass grant therefore means rotating
+the deployment's key; the audit trail, not an expiry, is what bounds it.
 
 That last point is the design, not a nicety. An audit trail only the operator
 can read is not accountability. The modal says so before you confirm.


### PR DESCRIPTION
The two findings left open by the security audit, resolved.

## `host_capacity` no longer reports fleet inventory

`/api/dashboard/host_capacity` is readable by **any authenticated member** and
carried `deploymentCount` — an instance-wide count of every deployment across
every tenant. A tenant has no business learning how many deployments other
tenants run.

The count and the per-state breakdown already live on `/api/admin/overview`
behind the `SuperAdmin` extractor, so operators lose nothing.

The four allocation figures stay: the tier selector needs them, and
"12 GB allocated" is meaningless without the host total to compare against.
The one tenant-facing render now reads `Host: X / Y GB allocated`.

## Break-glass now works

It returned a key the backend rejects. `ephemeral_admin_key`'s own docstring
says the deployment's stored `instance_secret` "is the real key the running
backend accepts", and that the mint path is "useful in the v1 demo path where
no real backend is running yet" — and break-glass always minted. So every
grant handed back a credential the deployment refused, while reporting
success, showing a 15-minute countdown, and writing "access granted" to the
tenant's own audit log.

It now returns the real admin key. The reason requirement and the dual audit
write are unchanged — those were always the accountability, and they worked.

**The trade is stated rather than hidden.** The grant cannot be revoked
without rotating the deployment's key, so the audit trail bounds it, not an
expiry. The modal says "this key does not expire" where it used to count
down, and the docs explain why the previous design read better than it worked.

The test that asserted the returned key **differed** from the stored one is
inverted. It was right as a security property and wrong as a functional one,
and it is what locked the bug in. It now also asserts there is no `expiresAt`
field at all, so nobody reintroduces a promise the orchestrator cannot keep.

## `project_admins` removed

Written and displayed, never consulted for authorization — a team admin could
designate project admins and nothing changed. A control that looks like it
works is worse than no control.

Removed: the table, the storage functions, `get_project_roles` /
`update_project_roles`, and the project-settings UI section. Team membership
stays the boundary, so **nobody's access changes**.

**The migration drops the table**, which is irreversible. The rows were never
enforced, so nothing changes functionally, but any intent recorded there about
who should administer what is lost.

## One consequence worth naming

Break-glass was previously inert. It now hands out a working, non-expiring
admin key for any tenant's deployment to anyone with operator rights. That is
the honest version of the feature, but it is a real increase in what an
operator account is worth.

## Verification

113 lib + 3 cross-tenant + 30 integration against a real Postgres 16.4;
clippy clean. 20 jest suites / 82 tests; `tsc --noEmit` clean. No dprint
violations.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Break-glass access now provides the deployment’s persistent admin key and clearly indicates that it does not expire.
  * Added a warning before granting break-glass access.

* **Updates**
  * Removed project-admin management from project settings.
  * Host capacity displays no longer include deployment counts.
  * Updated access and break-glass documentation to explain persistent-key handling and revocation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->