### PR TITLE
Restore @heroicons/react and swr to dashboard-self-hosted

### DIFF
--- a/npm-packages/dashboard-self-hosted/package.json
+++ b/npm-packages/dashboard-self-hosted/package.json
@@ -14,19 +14,21 @@
   },
   "dependencies": {
     "@convex-dev/design-system": "workspace:*",
+    "@heroicons/react": "2.2.0",
+    "@monaco-editor/react": "4.7.0",
     "@radix-ui/react-icons": "~1.3.0",
     "convex": "workspace:*",
     "dashboard-common": "workspace:*",
+    "monaco-editor": "0.40.0",
+    "monaco-editor-webpack-plugin": "~7.1.1",
     "next": "^15.5.21",
     "next-themes": "~0.4.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-use": "~17.6.0",
+    "swr": "^2.2.1",
     "system-udfs": "workspace:*",
-    "zod": "^3.24.0",
-    "@monaco-editor/react": "4.7.0",
-    "monaco-editor": "0.40.0",
-    "monaco-editor-webpack-plugin": "~7.1.1"
+    "zod": "^3.24.0"
   },
   "devDependencies": {
     "@jest/types": "^30.0.0",

--- a/npm-packages/pnpm-lock.yaml
+++ b/npm-packages/pnpm-lock.yaml
@@ -1511,6 +1511,9 @@ importers:
       '@convex-dev/design-system':
         specifier: workspace:*
         version: link:../@convex-dev/design-system
+      '@heroicons/react':
+        specifier: 2.2.0
+        version: 2.2.0(react@18.3.1)
       '@monaco-editor/react':
         specifier: 4.7.0
         version: 4.7.0(monaco-editor@0.40.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1544,6 +1547,9 @@ importers:
       react-use:
         specifier: ~17.6.0
         version: 17.6.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      swr:
+        specifier: ^2.2.1
+        version: 2.3.6(react@18.3.1)
       system-udfs:
         specifier: workspace:*
         version: link:../system-udfs
@@ -4364,7 +4370,7 @@ importers:
         version: 56.0.14(expo@56.0.12)(react-native@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.4)(supports-color@10.2.2))(@types/react@19.2.8)(bufferutil@4.0.9)(react@19.2.4)(supports-color@10.2.2))(react@19.2.4)(supports-color@10.2.2)
       expo-router:
         specifier: ^56.2.11
-        version: 56.2.11(45cfa16f5bf1f1efd2b3ab7012829a13)
+        version: 56.2.11(692493b5edbabfcb40c5d0970a82671c)
       expo-splash-screen:
         specifier: ^56.0.10
         version: 56.0.10(expo@56.0.12)(supports-color@10.2.2)(typescript@5.9.3)
@@ -5324,7 +5330,7 @@ importers:
         version: 0.0.94(@auth/core@0.41.3)(convex@convex)(react@19.2.4)
       '@convex-dev/workflow':
         specifier: ^0.3.3
-        version: 0.3.3(@convex-dev/workpool@0.3.0(convex-helpers@0.1.105(@standard-schema/spec@1.1.0)(convex@convex)(hono@4.12.34)(react@19.2.4)(typescript@5.9.3)(zod@4.4.3))(convex@convex))(convex-helpers@0.1.105(@standard-schema/spec@1.1.0)(convex@convex)(hono@4.12.34)(react@19.2.4)(typescript@5.9.3)(zod@4.4.3))(convex@convex)
+        version: 0.3.3(@convex-dev/workpool@0.3.0(convex-helpers@0.1.123(@standard-schema/spec@1.1.0)(convex@convex)(hono@4.12.34)(react@19.2.4)(typescript@5.9.3)(zod@4.4.3))(convex@convex))(convex-helpers@0.1.123(@standard-schema/spec@1.1.0)(convex@convex)(hono@4.12.34)(react@19.2.4)(typescript@5.9.3)(zod@4.4.3))(convex@convex)
       convex:
         specifier: workspace:*
         version: link:../../convex
@@ -31354,17 +31360,12 @@ snapshots:
       handlebars: 4.7.9
       typedoc: 0.24.8(typescript@5.0.4)
 
-  '@convex-dev/workflow@0.3.3(@convex-dev/workpool@0.3.0(convex-helpers@0.1.105(@standard-schema/spec@1.1.0)(convex@convex)(hono@4.12.34)(react@19.2.4)(typescript@5.9.3)(zod@4.4.3))(convex@convex))(convex-helpers@0.1.105(@standard-schema/spec@1.1.0)(convex@convex)(hono@4.12.34)(react@19.2.4)(typescript@5.9.3)(zod@4.4.3))(convex@convex)':
+  '@convex-dev/workflow@0.3.3(@convex-dev/workpool@0.3.0(convex-helpers@0.1.123(@standard-schema/spec@1.1.0)(convex@convex)(hono@4.12.34)(react@19.2.4)(typescript@5.9.3)(zod@4.4.3))(convex@convex))(convex-helpers@0.1.123(@standard-schema/spec@1.1.0)(convex@convex)(hono@4.12.34)(react@19.2.4)(typescript@5.9.3)(zod@4.4.3))(convex@convex)':
     dependencies:
-      '@convex-dev/workpool': 0.3.0(convex-helpers@0.1.105(@standard-schema/spec@1.1.0)(convex@convex)(hono@4.12.34)(react@19.2.4)(typescript@5.9.3)(zod@4.4.3))(convex@convex)
+      '@convex-dev/workpool': 0.3.0(convex-helpers@0.1.123(@standard-schema/spec@1.1.0)(convex@convex)(hono@4.12.34)(react@19.2.4)(typescript@5.9.3)(zod@4.4.3))(convex@convex)
       async-channel: 0.2.0
       convex: link:convex
-      convex-helpers: 0.1.105(@standard-schema/spec@1.1.0)(convex@convex)(hono@4.12.34)(react@19.2.4)(typescript@5.9.3)(zod@4.4.3)
-
-  '@convex-dev/workpool@0.3.0(convex-helpers@0.1.105(@standard-schema/spec@1.1.0)(convex@convex)(hono@4.12.34)(react@19.2.4)(typescript@5.9.3)(zod@4.4.3))(convex@convex)':
-    dependencies:
-      convex: link:convex
-      convex-helpers: 0.1.105(@standard-schema/spec@1.1.0)(convex@convex)(hono@4.12.34)(react@19.2.4)(typescript@5.9.3)(zod@4.4.3)
+      convex-helpers: 0.1.123(@standard-schema/spec@1.1.0)(convex@convex)(hono@4.12.34)(react@19.2.4)(typescript@5.9.3)(zod@4.4.3)
 
   '@convex-dev/workpool@0.3.0(convex-helpers@0.1.123(@standard-schema/spec@1.1.0)(convex@convex)(hono@4.12.34)(react@19.2.4)(typescript@5.9.3)(zod@4.4.3))(convex@convex)':
     dependencies:
@@ -33306,7 +33307,7 @@ snapshots:
       ws: 8.21.0(bufferutil@4.0.9)
       zod: 3.25.76
     optionalDependencies:
-      expo-router: 56.2.11(45cfa16f5bf1f1efd2b3ab7012829a13)
+      expo-router: 56.2.11(692493b5edbabfcb40c5d0970a82671c)
       react-native: 0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.4)(supports-color@10.2.2))(@types/react@19.2.8)(bufferutil@4.0.9)(react@19.2.4)(supports-color@10.2.2)
     transitivePeerDependencies:
       - '@expo/dom-webview'
@@ -33558,6 +33559,15 @@ snapshots:
       stacktrace-parser: 0.1.11
     optional: true
 
+  '@expo/log-box@56.0.14(@expo/dom-webview@56.0.6)(expo@56.0.12)(react-native@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.4)(supports-color@10.2.2))(@types/react@19.2.8)(bufferutil@4.0.9)(react@19.2.4)(supports-color@10.2.2))(react@19.2.4)':
+    dependencies:
+      '@expo/dom-webview': 56.0.6(expo@56.0.12)(react-native@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.4)(supports-color@10.2.2))(@types/react@19.2.8)(bufferutil@4.0.9)(react@19.2.4)(supports-color@10.2.2))(react@19.2.4)
+      anser: 1.4.10
+      expo: 56.0.12(@babel/core@7.29.7(supports-color@10.2.2))(@expo/dom-webview@56.0.6)(@expo/metro-runtime@56.0.19)(bufferutil@4.0.9)(expo-router@56.2.11)(react-dom@19.2.4(react@19.2.4))(react-native-web@0.21.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-native@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.4)(supports-color@10.2.2))(@types/react@19.2.8)(bufferutil@4.0.9)(react@19.2.4)(supports-color@10.2.2))(react@19.2.4)(supports-color@10.2.2)(typescript@5.9.3)
+      react: 19.2.4
+      react-native: 0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.4)(supports-color@10.2.2))(@types/react@19.2.8)(bufferutil@4.0.9)(react@19.2.4)(supports-color@10.2.2)
+      stacktrace-parser: 0.1.11
+
   '@expo/metro-config@56.0.14(bufferutil@4.0.9)(expo@56.0.12)(supports-color@10.2.2)(typescript@5.9.3)':
     dependencies:
       '@babel/code-frame': 7.29.7
@@ -33602,19 +33612,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@expo/metro-runtime@56.0.19(@expo/log-box@56.0.13)(expo@56.0.12)(react-dom@19.2.4(react@19.2.4))(react-native@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.4)(supports-color@10.2.2))(@types/react@19.2.8)(bufferutil@4.0.9)(react@19.2.4)(supports-color@10.2.2))(react@19.2.4)':
-    dependencies:
-      '@expo/log-box': 56.0.13(@expo/dom-webview@56.0.6)(expo@56.0.12)(react-native@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.4)(supports-color@10.2.2))(@types/react@19.2.8)(bufferutil@4.0.9)(react@19.2.4)(supports-color@10.2.2))(react@19.2.4)
-      anser: 1.4.10
-      expo: 56.0.12(@babel/core@7.29.7(supports-color@10.2.2))(@expo/dom-webview@56.0.6)(@expo/metro-runtime@56.0.19)(bufferutil@4.0.9)(expo-router@56.2.11)(react-dom@19.2.4(react@19.2.4))(react-native-web@0.21.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-native@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.4)(supports-color@10.2.2))(@types/react@19.2.8)(bufferutil@4.0.9)(react@19.2.4)(supports-color@10.2.2))(react@19.2.4)(supports-color@10.2.2)(typescript@5.9.3)
-      pretty-format: 29.7.0
-      react: 19.2.4
-      react-native: 0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.4)(supports-color@10.2.2))(@types/react@19.2.8)(bufferutil@4.0.9)(react@19.2.4)(supports-color@10.2.2)
-      stacktrace-parser: 0.1.11
-      whatwg-fetch: 3.6.20
-    optionalDependencies:
-      react-dom: 19.2.4(react@19.2.4)
-
   '@expo/metro-runtime@56.0.19(@expo/log-box@56.0.14)(expo@56.0.12)(react-dom@19.2.4(react@19.2.4))(react-native@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.4)(supports-color@10.2.2))(@react-native/metro-config@0.85.2(@babel/core@7.29.7(supports-color@10.2.2))(bufferutil@4.0.9)(supports-color@10.2.2))(@types/react@19.2.8)(bufferutil@4.0.9)(react@19.2.4)(supports-color@10.2.2))(react@19.2.4)':
     dependencies:
       '@expo/log-box': 56.0.14(@expo/dom-webview@56.0.6)(expo@56.0.12)(react-native@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.4)(supports-color@10.2.2))(@react-native/metro-config@0.85.2(@babel/core@7.29.7(supports-color@10.2.2))(bufferutil@4.0.9)(supports-color@10.2.2))(@types/react@19.2.8)(bufferutil@4.0.9)(react@19.2.4)(supports-color@10.2.2))(react@19.2.4)
@@ -33628,6 +33625,19 @@ snapshots:
     optionalDependencies:
       react-dom: 19.2.4(react@19.2.4)
     optional: true
+
+  '@expo/metro-runtime@56.0.19(@expo/log-box@56.0.14)(expo@56.0.12)(react-dom@19.2.4(react@19.2.4))(react-native@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.4)(supports-color@10.2.2))(@types/react@19.2.8)(bufferutil@4.0.9)(react@19.2.4)(supports-color@10.2.2))(react@19.2.4)':
+    dependencies:
+      '@expo/log-box': 56.0.14(@expo/dom-webview@56.0.6)(expo@56.0.12)(react-native@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.4)(supports-color@10.2.2))(@types/react@19.2.8)(bufferutil@4.0.9)(react@19.2.4)(supports-color@10.2.2))(react@19.2.4)
+      anser: 1.4.10
+      expo: 56.0.12(@babel/core@7.29.7(supports-color@10.2.2))(@expo/dom-webview@56.0.6)(@expo/metro-runtime@56.0.19)(bufferutil@4.0.9)(expo-router@56.2.11)(react-dom@19.2.4(react@19.2.4))(react-native-web@0.21.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-native@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.4)(supports-color@10.2.2))(@types/react@19.2.8)(bufferutil@4.0.9)(react@19.2.4)(supports-color@10.2.2))(react@19.2.4)(supports-color@10.2.2)(typescript@5.9.3)
+      pretty-format: 29.7.0
+      react: 19.2.4
+      react-native: 0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.4)(supports-color@10.2.2))(@types/react@19.2.8)(bufferutil@4.0.9)(react@19.2.4)(supports-color@10.2.2)
+      stacktrace-parser: 0.1.11
+      whatwg-fetch: 3.6.20
+    optionalDependencies:
+      react-dom: 19.2.4(react@19.2.4)
 
   '@expo/metro@56.0.0(bufferutil@4.0.9)(supports-color@10.2.2)':
     dependencies:
@@ -33719,8 +33729,8 @@ snapshots:
       expo-server: 56.0.5
       react: 19.2.4
     optionalDependencies:
-      '@expo/metro-runtime': 56.0.19(@expo/log-box@56.0.13)(expo@56.0.12)(react-dom@19.2.4(react@19.2.4))(react-native@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.4)(supports-color@10.2.2))(@types/react@19.2.8)(bufferutil@4.0.9)(react@19.2.4)(supports-color@10.2.2))(react@19.2.4)
-      expo-router: 56.2.11(45cfa16f5bf1f1efd2b3ab7012829a13)
+      '@expo/metro-runtime': 56.0.19(@expo/log-box@56.0.14)(expo@56.0.12)(react-dom@19.2.4(react@19.2.4))(react-native@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.4)(supports-color@10.2.2))(@types/react@19.2.8)(bufferutil@4.0.9)(react@19.2.4)(supports-color@10.2.2))(react@19.2.4)
+      expo-router: 56.2.11(692493b5edbabfcb40c5d0970a82671c)
       react-dom: 19.2.4(react@19.2.4)
     transitivePeerDependencies:
       - supports-color
@@ -35676,17 +35686,17 @@ snapshots:
 
   '@peculiar/asn1-cms@2.7.0':
     dependencies:
-      '@peculiar/asn1-schema': 2.7.0
+      '@peculiar/asn1-schema': 2.9.0
       '@peculiar/asn1-x509': 2.7.0
       '@peculiar/asn1-x509-attr': 2.7.0
-      asn1js: 3.0.6
+      asn1js: 3.0.10
       tslib: 2.8.1
 
   '@peculiar/asn1-csr@2.7.0':
     dependencies:
-      '@peculiar/asn1-schema': 2.7.0
+      '@peculiar/asn1-schema': 2.9.0
       '@peculiar/asn1-x509': 2.7.0
-      asn1js: 3.0.6
+      asn1js: 3.0.10
       tslib: 2.8.1
 
   '@peculiar/asn1-ecc@2.7.0':
@@ -35701,15 +35711,15 @@ snapshots:
       '@peculiar/asn1-cms': 2.7.0
       '@peculiar/asn1-pkcs8': 2.7.0
       '@peculiar/asn1-rsa': 2.7.0
-      '@peculiar/asn1-schema': 2.7.0
-      asn1js: 3.0.6
+      '@peculiar/asn1-schema': 2.9.0
+      asn1js: 3.0.10
       tslib: 2.8.1
 
   '@peculiar/asn1-pkcs8@2.7.0':
     dependencies:
-      '@peculiar/asn1-schema': 2.7.0
+      '@peculiar/asn1-schema': 2.9.0
       '@peculiar/asn1-x509': 2.7.0
-      asn1js: 3.0.6
+      asn1js: 3.0.10
       tslib: 2.8.1
 
   '@peculiar/asn1-pkcs9@2.7.0':
@@ -35717,10 +35727,10 @@ snapshots:
       '@peculiar/asn1-cms': 2.7.0
       '@peculiar/asn1-pfx': 2.7.0
       '@peculiar/asn1-pkcs8': 2.7.0
-      '@peculiar/asn1-schema': 2.7.0
+      '@peculiar/asn1-schema': 2.9.0
       '@peculiar/asn1-x509': 2.7.0
       '@peculiar/asn1-x509-attr': 2.7.0
-      asn1js: 3.0.6
+      asn1js: 3.0.10
       tslib: 2.8.1
 
   '@peculiar/asn1-rsa@2.7.0':
@@ -35750,9 +35760,9 @@ snapshots:
 
   '@peculiar/asn1-x509-attr@2.7.0':
     dependencies:
-      '@peculiar/asn1-schema': 2.7.0
+      '@peculiar/asn1-schema': 2.9.0
       '@peculiar/asn1-x509': 2.7.0
-      asn1js: 3.0.6
+      asn1js: 3.0.10
       tslib: 2.8.1
 
   '@peculiar/asn1-x509@2.7.0':
@@ -35785,7 +35795,7 @@ snapshots:
       '@peculiar/asn1-ecc': 2.7.0
       '@peculiar/asn1-pkcs9': 2.7.0
       '@peculiar/asn1-rsa': 2.7.0
-      '@peculiar/asn1-schema': 2.7.0
+      '@peculiar/asn1-schema': 2.9.0
       '@peculiar/asn1-x509': 2.7.0
       pvtsutils: 1.3.6
       reflect-metadata: 0.2.2
@@ -44398,16 +44408,6 @@ snapshots:
       typescript: 5.0.4
       zod: 4.4.3
 
-  convex-helpers@0.1.105(@standard-schema/spec@1.1.0)(convex@convex)(hono@4.12.34)(react@19.2.4)(typescript@5.9.3)(zod@4.4.3):
-    dependencies:
-      convex: link:convex
-    optionalDependencies:
-      '@standard-schema/spec': 1.1.0
-      hono: 4.12.34
-      react: 19.2.4
-      typescript: 5.9.3
-      zod: 4.4.3
-
   convex-helpers@0.1.123(@standard-schema/spec@1.1.0)(convex@convex)(hono@4.12.34)(react@19.2.4)(typescript@5.9.3)(zod@4.4.3):
     dependencies:
       convex: link:convex
@@ -46914,10 +46914,10 @@ snapshots:
     dependencies:
       react-native: 0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.4)(supports-color@10.2.2))(@types/react@19.2.8)(bufferutil@4.0.9)(react@19.2.4)(supports-color@10.2.2)
 
-  expo-router@56.2.11(45cfa16f5bf1f1efd2b3ab7012829a13):
+  expo-router@56.2.11(692493b5edbabfcb40c5d0970a82671c):
     dependencies:
-      '@expo/log-box': 56.0.13(@expo/dom-webview@56.0.6)(expo@56.0.12)(react-native@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.4)(supports-color@10.2.2))(@types/react@19.2.8)(bufferutil@4.0.9)(react@19.2.4)(supports-color@10.2.2))(react@19.2.4)
-      '@expo/metro-runtime': 56.0.19(@expo/log-box@56.0.13)(expo@56.0.12)(react-dom@19.2.4(react@19.2.4))(react-native@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.4)(supports-color@10.2.2))(@types/react@19.2.8)(bufferutil@4.0.9)(react@19.2.4)(supports-color@10.2.2))(react@19.2.4)
+      '@expo/log-box': 56.0.14(@expo/dom-webview@56.0.6)(expo@56.0.12)(react-native@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.4)(supports-color@10.2.2))(@types/react@19.2.8)(bufferutil@4.0.9)(react@19.2.4)(supports-color@10.2.2))(react@19.2.4)
+      '@expo/metro-runtime': 56.0.19(@expo/log-box@56.0.14)(expo@56.0.12)(react-dom@19.2.4(react@19.2.4))(react-native@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.4)(supports-color@10.2.2))(@types/react@19.2.8)(bufferutil@4.0.9)(react@19.2.4)(supports-color@10.2.2))(react@19.2.4)
       '@expo/schema-utils': 56.0.1
       '@expo/ui': 56.0.18(@babel/core@7.29.7(supports-color@10.2.2))(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(expo@56.0.12)(react-dom@19.2.4(react@19.2.4))(react-native-reanimated@4.5.0(react-native@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.4)(supports-color@10.2.2))(@types/react@19.2.8)(bufferutil@4.0.9)(react@19.2.4)(supports-color@10.2.2))(react@19.2.4))(react-native@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.4)(supports-color@10.2.2))(@types/react@19.2.8)(bufferutil@4.0.9)(react@19.2.4)(supports-color@10.2.2))(react@19.2.4)
       '@radix-ui/react-slot': 1.3.1(@types/react@19.2.8)(react@19.2.4)
@@ -47146,7 +47146,7 @@ snapshots:
       whatwg-url-minimum: 0.1.2
     optionalDependencies:
       '@expo/dom-webview': 56.0.6(expo@56.0.12)(react-native@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.4)(supports-color@10.2.2))(@types/react@19.2.8)(bufferutil@4.0.9)(react@19.2.4)(supports-color@10.2.2))(react@19.2.4)
-      '@expo/metro-runtime': 56.0.19(@expo/log-box@56.0.13)(expo@56.0.12)(react-dom@19.2.4(react@19.2.4))(react-native@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.4)(supports-color@10.2.2))(@types/react@19.2.8)(bufferutil@4.0.9)(react@19.2.4)(supports-color@10.2.2))(react@19.2.4)
+      '@expo/metro-runtime': 56.0.19(@expo/log-box@56.0.14)(expo@56.0.12)(react-dom@19.2.4(react@19.2.4))(react-native@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.4)(supports-color@10.2.2))(@types/react@19.2.8)(bufferutil@4.0.9)(react@19.2.4)(supports-color@10.2.2))(react@19.2.4)
       react-dom: 19.2.4(react@19.2.4)
       react-native-web: 0.21.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
     transitivePeerDependencies:
@@ -53696,7 +53696,7 @@ snapshots:
   pkijs@3.4.0:
     dependencies:
       '@noble/hashes': 1.4.0
-      asn1js: 3.0.6
+      asn1js: 3.0.10
       bytestreamjs: 2.0.1
       pvtsutils: 1.3.6
       pvutils: 1.1.5


### PR DESCRIPTION
Fixes the dashboard image build, which I broke resolving the upstream sync in #20 / #19.

## What happened

Resolving that sync's `dashboard-self-hosted/package.json` conflict, I took upstream's file as the base and reasoned only about **devDependencies** — the jest cluster upstream dropped when it moved linting to `../lint`. Upstream's **`dependencies`** block differs too, and taking it wholesale silently removed four fork runtime deps. Two are used:

| Dependency | Used by |
| --- | --- |
| `@heroicons/react` | `src/components/SelfHostedDeploymentSummary.tsx` |
| `swr` | `src/hooks/useAdminKeys.ts` and its test |

The build failed with `Cannot find module '@heroicons/react/24/outline'`.

`id-encoding` and `lodash` were dropped too and are genuinely unused anywhere in the package — upstream removed those correctly, so they stay dropped. This also normalises the `monaco-*` entries into the block's existing alphabetical order.

## Why every local gate passed anyway

This is the part worth keeping. `tsc --noEmit` and `jest` both resolve against **the node_modules already on disk**, which still had `@heroicons/react` and `swr` linked from an earlier install. A clean `pnpm install --frozen-lockfile` — what Docker does — does not.

So the whole local suite passed against a tree that could not be reproduced from the lockfile I had just regenerated. Reporting "tsc clean" was true and useless: it proved the working copy was consistent, not that the committed manifest was.

## What I verified instead

Resolving every bare import in the package against **declared dependencies**, ignoring node_modules entirely — aliases from tsconfig `paths` and `baseUrl` excluded. That reports `MISSING=2` before this change and `MISSING=0` after, and it is immune to whatever happens to be installed.

Then the actual failing step, `next build`, which now gets through "Linting and checking validity of types" and reaches "Compiled successfully".

## Unrelated noise in the same build log

`⨯ ESLint: Cannot find module .../@convex-dev/eslint-plugin/dist/esm/index.js`.

That package is a dependency of `npm-packages/lint`, not of `dashboard-self-hosted`, so `turbo run build --filter=dashboard-self-hosted...` never builds its `dist`. **Confirmed non-fatal** by hiding the dist locally and rebuilding: Next logs the error and still reaches "Compiled successfully". Left alone rather than guessed at.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added runtime support for Heroicons and SWR.
  * Reorganized editor-related dependencies without changing existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->